### PR TITLE
Auto-scroll orbital list to keep the selected orbital visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -2728,6 +2728,7 @@
             
             // Create orbital entries in groups of 10 for better performance
             const fragment = document.createDocumentFragment();
+            let selectedDiv = null;
             for (let i = 1; i <= numOrbitals; i++) {
                 const div = document.createElement('div');
                 // Find orbital energy from the stored orbitals array
@@ -2749,10 +2750,24 @@
                 div.onclick = () => showOrbital(i);
                 if (i === currentOrbitalIndex) {
                     div.className = 'selected';
+                    selectedDiv = div;
                 }
                 fragment.appendChild(div);
             }
             list.appendChild(fragment);
+
+            // Keep the selected orbital visible: scroll the list (only the list,
+            // not the page) so the highlighted entry stays in view when navigating
+            // with the arrow keys or HOMO/LUMO buttons.
+            if (selectedDiv) {
+                const itemRect = selectedDiv.getBoundingClientRect();
+                const listRect = list.getBoundingClientRect();
+                if (itemRect.top < listRect.top) {
+                    list.scrollTop -= (listRect.top - itemRect.top);
+                } else if (itemRect.bottom > listRect.bottom) {
+                    list.scrollTop += (itemRect.bottom - listRect.bottom);
+                }
+            }
         }
         
         function showHOMO() {


### PR DESCRIPTION
## Problem

In the orbital list, pressing ↑/↓ (or using the HOMO/LUMO buttons) moved the selection, but the list did not scroll to follow it. The highlighted orbital could move off-screen, so you couldn't see which orbital was selected.

## Fix

After `updateOrbitalList()` rebuilds the list and tags the current orbital with `.selected`, scroll the `#orbitalList` container so the selected entry stays in view. Uses `getBoundingClientRect` deltas to adjust only `list.scrollTop` — it never scrolls the page or the surrounding panel, and only scrolls when the entry is actually outside the visible area (so it doesn't jump around unnecessarily).

## Testing

- Inline `<script>` blocks pass a JS syntax check.
- Manual check in the desktop app (`npm start`): load a structure with orbital data, open the orbital panel, and hold ↑/↓ — the list should now track the selection in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)