### PR TITLE
Quiet terminal output by default (opt-in verbose logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Quiet terminal output by default: the Electron main process no longer echoes its verbose per-event log (startup info, focus/blur, memory stats) or Chromium's GPU/init messages to the terminal. A full log is still written to `jsmol.log` in the user-data directory. Enable terminal logging with `npm run start-verbose`, `--verbose`/`--debug`, or `JLMOL_DEBUG=1`.
+
 ### Added
 
 - Atom selection by clicking in the 3D structure: clicking an atom in the viewer now selects/deselects it (toggle), with the selection mirrored in the XYZ viewer rows and vice versa (two-way sync). A shared selection state highlights selected atoms with halos in 3D and a highlight in the XYZ viewer, shows a selection count, and offers a "Clear Selection" button. The selected atoms can be inserted as a 1-based index list (e.g. `[1, 3, 5]`) into the ElemCo.jl input editor with one click ("Insert Selected Atoms"), e.g. to define dummy atoms or active regions. Selection is cleared automatically when a new structure is loaded, and clicking is disabled while the model-kit editor is active.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ npm install
 npm start
 ```
 
+The terminal output is kept quiet by default. A full log is always written to `jsmol.log` in the app's user-data directory. To echo the detailed log to the terminal, run with verbose logging:
+
+```bash
+npm run start-verbose
+# or: npm start -- --verbose
+# or set JLMOL_DEBUG=1 in the environment
+```
+
 ### Building
 
 To build the application:

--- a/main.js
+++ b/main.js
@@ -3,6 +3,21 @@ const path = require('path')
 const fs = require('fs')
 const { version } = require('./package.json')
 
+// Console verbosity. A full log file (jsmol.log in userData) is ALWAYS kept for
+// troubleshooting; this flag only controls how much is echoed to the terminal.
+// Quiet by default; enable with `--verbose` / `--debug` or JLMOL_DEBUG=1
+// (e.g. `npm run start-verbose`).
+const VERBOSE_LOGGING = process.argv.includes('--verbose')
+    || process.argv.includes('--debug')
+    || process.env.JLMOL_DEBUG === '1'
+    || process.env.JLMOL_VERBOSE === '1';
+
+// Silence Chromium's own noisy GPU/init messages on the terminal unless logging
+// was explicitly requested (the start-debug script passes --enable-logging).
+if (!VERBOSE_LOGGING && !process.argv.includes('--enable-logging')) {
+    app.commandLine.appendSwitch('log-level', '3'); // 3 = fatal only
+}
+
 // Add command line switches for stability on Windows 11
 app.commandLine.appendSwitch('disable-gpu-sandbox');
 app.commandLine.appendSwitch('disable-software-rasterizer');
@@ -31,8 +46,14 @@ function log(message) {
     const timestamp = new Date().toISOString();
     const memUsage = process.memoryUsage();
     const logEntry = `${timestamp}: ${message} [Memory: RSS=${Math.round(memUsage.rss/1024/1024)}MB, Heap=${Math.round(memUsage.heapUsed/1024/1024)}MB]\n`;
-    fs.appendFileSync(logFile, logEntry);
-    console.log(logEntry.trim());
+    try {
+        fs.appendFileSync(logFile, logEntry);
+    } catch (e) {
+        // Ignore log-file write errors so logging never breaks the app.
+    }
+    if (VERBOSE_LOGGING) {
+        console.log(logEntry.trim());
+    }
 }
 
 // Clear log file

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
+    "start-verbose": "electron . --verbose",
     "start:win": "node_modules/electron/dist/electron.exe .",
     "start-safe": "electron . --disable-hardware-acceleration",
     "start-debug": "electron . --enable-logging --log-level=0",


### PR DESCRIPTION
## Problem

`npm start` floods the terminal with the main process's per-event log (startup info, focus/blur, memory stats) and Chromium's GPU/init `ERROR` lines, e.g.:

```
2026-05-31T15:12:01.387Z: Application starting [Memory: RSS=49MB, Heap=4MB]
...
[34792:...:ERROR:components\viz\service\main\viz_main_impl.cc:189] Exiting GPU process due to errors during initialization
2026-05-31T15:12:02.067Z: Window gained focus [Memory: RSS=90MB, Heap=5MB]
```

## Fix

- `log()` now only echoes to the terminal when verbose logging is enabled. The full `jsmol.log` file (in the app's user-data directory) is **always** written, so troubleshooting info is preserved.
- Chromium's own console output is quieted (`--log-level=3`, fatal only) unless verbose/`--enable-logging` is set — this removes the GPU init `ERROR` noise.
- Verbose logging is opt-in via `--verbose`/`--debug`, `JLMOL_DEBUG=1`, or the new `npm run start-verbose` script.
- The log-file write is wrapped in try/catch so logging can never break the app.

Note: this is gated by a CLI flag / env var rather than the in-app Settings, because the main-process logging runs at startup before the renderer (where preferences live in `localStorage`) is available.

## Testing

- `node --check main.js` and `package.json` JSON both validate.
- `npm start` should now be quiet; `npm run start-verbose` restores the detailed terminal log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)