### PR TITLE
Refactor (4/N): re-indent js/ files (whitespace only)

### DIFF
--- a/js/app-init.js
+++ b/js/app-init.js
@@ -1,69 +1,69 @@
-        // Initialize ElemCo panel elements
-        function initElemCoPanel() {
-            // Clean up any existing elements first
-            const dfLabel = document.querySelector('.df-toggle-label');
-            if (dfLabel) {
-                // Remove existing content to prevent memory leaks
-                dfLabel.innerHTML = '';
-                dfLabel.innerHTML = `
+// Initialize ElemCo panel elements
+function initElemCoPanel() {
+    // Clean up any existing elements first
+    const dfLabel = document.querySelector('.df-toggle-label');
+    if (dfLabel) {
+        // Remove existing content to prevent memory leaks
+        dfLabel.innerHTML = '';
+        dfLabel.innerHTML = `
                     <input type="checkbox" id="elemco-df" onchange="updateMethodOptions()">
                     <span>Use DF</span>
                 `;
-            }
+    }
 
-            // Initialize method options
-            updateMethodOptions();
+    // Initialize method options
+    updateMethodOptions();
 
-            // Update input text
-            updateElemCoInput();
-        }
+    // Update input text
+    updateElemCoInput();
+}
 
-        // Add initialization to both window.onload and document.ready
-        if (typeof window !== 'undefined') {
-            window.addEventListener('load', function() {
-                // Use a proper initialization sequence with dependency checking
-                initializeApplication();
-            });
-        }
+// Add initialization to both window.onload and document.ready
+if (typeof window !== 'undefined') {
+    window.addEventListener('load', function() {
+        // Use a proper initialization sequence with dependency checking
+        initializeApplication();
+    });
+}
+
+// Proper initialization function with dependency checking
+function initializeApplication() {
+    let initAttempts = 0;
+    const maxAttempts = 20; // Allow up to 2 seconds (20 * 100ms)
+    
+    function attemptInit() {
+        initAttempts++;
         
-        // Proper initialization function with dependency checking
-        function initializeApplication() {
-            let initAttempts = 0;
-            const maxAttempts = 20; // Allow up to 2 seconds (20 * 100ms)
-            
-            function attemptInit() {
-                initAttempts++;
-                
-                // Check if required DOM elements exist
-                const elemcoPanel = document.getElementById('elemcoPanel');
-                const searchInput = document.getElementById('pubchemInput');
-                
-                if (elemcoPanel && searchInput) {
-                    // All required elements are available, proceed with initialization
-                    try {
-                        initElemCoPanel();
-                        updateInputPlaceholder();
-                        setupDatabaseInputHandlers();
-                        initPreferences();
-                        console.log('Application initialized successfully');
-                    } catch (error) {
-                        console.warn('Error during initialization:', error);
-                        // Retry if we haven't exceeded max attempts
-                        if (initAttempts < maxAttempts) {
-                            setTimeout(attemptInit, 100);
-                        }
-                    }
-                } else {
-                    // Required elements not ready yet, retry if we haven't exceeded max attempts
-                    if (initAttempts < maxAttempts) {
-                        setTimeout(attemptInit, 100);
-                    } else {
-                        console.warn('Application initialization failed: required DOM elements not found after', maxAttempts, 'attempts');
-                    }
+        // Check if required DOM elements exist
+        const elemcoPanel = document.getElementById('elemcoPanel');
+        const searchInput = document.getElementById('pubchemInput');
+        
+        if (elemcoPanel && searchInput) {
+            // All required elements are available, proceed with initialization
+            try {
+                initElemCoPanel();
+                updateInputPlaceholder();
+                setupDatabaseInputHandlers();
+                initPreferences();
+                console.log('Application initialized successfully');
+            } catch (error) {
+                console.warn('Error during initialization:', error);
+                // Retry if we haven't exceeded max attempts
+                if (initAttempts < maxAttempts) {
+                    setTimeout(attemptInit, 100);
                 }
             }
-            
-            // Start initialization
-            attemptInit();
+        } else {
+            // Required elements not ready yet, retry if we haven't exceeded max attempts
+            if (initAttempts < maxAttempts) {
+                setTimeout(attemptInit, 100);
+            } else {
+                console.warn('Application initialization failed: required DOM elements not found after', maxAttempts, 'attempts');
+            }
         }
-        
+    }
+    
+    // Start initialization
+    attemptInit();
+}
+

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -1,485 +1,485 @@
-        function showElemCoPanel() {
-            debugLog('ElemCo', 'Opening panel');
-            const panel = document.getElementById('elemcoPanel');
-            if (panel) {
-                panel.style.display = 'block';
-                
-                // Reinitialize panel elements to ensure they're set up properly
-                debugLog('ElemCo', 'Initializing panel elements');
-                initElemCoPanel();
-                
-                // Force refresh molecular data detection with multiple attempts
-                debugLog('ElemCo', 'Starting molecular data refresh sequence');
-                
-                // Immediate attempt
-                updateElemCoInput();
-                
-                // Delayed attempt 1 - sometimes JSmol needs time to update
-                setTimeout(() => {
-                    debugLog('ElemCo', 'First delayed attempt');
-                    updateElemCoInput();
-                }, 100);
-                
-                // Delayed attempt 2 - final fallback with force refresh
-                setTimeout(() => {
-                    console.log('showElemCoPanel: Second delayed attempt with force refresh');
-                    
-                    // Check if we still have the error message
-                    const inputArea = document.getElementById('elemco-input');
-                    if (inputArea && inputArea.value.includes('Please load a molecule first')) {
-                        console.warn('showElemCoPanel: Still showing "Please load a molecule first", trying force refresh');
-                        
-                        const refreshSuccess = forceRefreshMolecularData();
-                        
-                        if (!refreshSuccess) {
-                            // Try to diagnose the issue
-                            try {
-                                const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
-                                console.log('showElemCoPanel: Diagnostic - JSmol atom count:', atomCount);
-                                
-                                if (atomCount > 0) {
-                                    console.log('showElemCoPanel: Atoms exist but data retrieval failed. This suggests a JSmol communication issue.');
-                                    inputArea.value = '# Molecular data detected but could not be retrieved.\n# Try closing and reopening the ElemCo panel, or reload the molecule.';
-                                } else {
-                                    console.log('showElemCoPanel: No atoms detected in JSmol');
-                                    inputArea.value = '# No molecular structure detected.\n# Please load a molecule first.';
-                                }
-                            } catch (e) {
-                                console.error('showElemCoPanel: Diagnostic failed:', e);
-                                inputArea.value = '# Error communicating with molecular viewer.\n# Please reload the page and try again.';
-                            }
-                        }
-                    } else {
-                        console.log('showElemCoPanel: ElemCo input appears to be working correctly');
-                    }
-                }, 300);
-            } else {
-                console.error('showElemCoPanel: Could not find elemcoPanel element');
-            }
-        }
-
-        function hideElemCoPanel() {
-            document.getElementById('elemcoPanel').style.display = 'none';
-        }
-
-        function generateElemCoInput() {
+function showElemCoPanel() {
+    debugLog('ElemCo', 'Opening panel');
+    const panel = document.getElementById('elemcoPanel');
+    if (panel) {
+        panel.style.display = 'block';
+        
+        // Reinitialize panel elements to ensure they're set up properly
+        debugLog('ElemCo', 'Initializing panel elements');
+        initElemCoPanel();
+        
+        // Force refresh molecular data detection with multiple attempts
+        debugLog('ElemCo', 'Starting molecular data refresh sequence');
+        
+        // Immediate attempt
+        updateElemCoInput();
+        
+        // Delayed attempt 1 - sometimes JSmol needs time to update
+        setTimeout(() => {
+            debugLog('ElemCo', 'First delayed attempt');
             updateElemCoInput();
-            document.getElementById('status').innerHTML = 'ElemCo.jl input reset to default';
-        }
-
-        // Insert the list of currently selected atoms (sorted, 1-based indices) at the
-        // cursor position in the ElemCo input editor, e.g. for dummy atoms or active
-        // regions. Falls back to appending at the end if no cursor position is known.
-        function insertSelectedAtomsIntoElemCo() {
-            const nums = getSelectedAtomNumbers();
-            if (nums.length === 0) {
-                document.getElementById('status').innerHTML =
-                    'No atoms selected — click atoms in the structure or XYZ viewer first';
-                return;
-            }
-            const textarea = document.getElementById('elemco-input');
-            const listText = '[' + nums.join(', ') + ']';
-            const hasCursor = typeof textarea.selectionStart === 'number';
-            const start = hasCursor ? textarea.selectionStart : textarea.value.length;
-            const end = hasCursor ? textarea.selectionEnd : textarea.value.length;
-            textarea.value = textarea.value.slice(0, start) + listText + textarea.value.slice(end);
-            const pos = start + listText.length;
-            textarea.selectionStart = textarea.selectionEnd = pos;
-            textarea.focus();
-            document.getElementById('status').innerHTML =
-                `Inserted ${nums.length} selected atom${nums.length === 1 ? '' : 's'}: ${listText}`;
-        }
-
-        function copyElemCoInput() {
-            const input = document.getElementById('elemco-input');
-            const text = input.value;
-            
-            // Use modern Clipboard API with fallback for older browsers
-            if (navigator.clipboard && navigator.clipboard.writeText) {
-                navigator.clipboard.writeText(text).then(() => {
-                    document.getElementById('status').innerHTML = 'Input copied to clipboard';
-                }).catch(err => {
-                    console.error('Clipboard API failed:', err);
-                    fallbackCopyToClipboard(input);
-                });
-            } else {
-                fallbackCopyToClipboard(input);
-            }
-        }
+        }, 100);
         
-        // Fallback for browsers without Clipboard API
-        function fallbackCopyToClipboard(textArea) {
-            textArea.select();
-            try {
-                document.execCommand('copy');
-                document.getElementById('status').innerHTML = 'Input copied to clipboard';
-            } catch (err) {
-                console.error('Fallback copy failed:', err);
-                document.getElementById('status').innerHTML = 'Copy failed - please copy manually';
-            }
-        }
-
-        // Remove previous event listeners and add new ones
-        function initializeElemCoListeners() {
-            const method = document.getElementById('elemco-method');
-            const aoBasis = document.getElementById('elemco-basis');
-            const jkfitBasis = document.getElementById('elemco-jkfit');
-            const mpfitBasis = document.getElementById('elemco-mpfit');
-            const charge = document.getElementById('elemco-charge');
-            const multiplicity = document.getElementById('elemco-multiplicity');
-            const moldenCheckbox = document.getElementById('elemco-molden');
-            const moldenFile = document.getElementById('elemco-molden-file');
-
-            // Store references to listeners for proper cleanup
-            const elements = [
-                { element: method, event: 'change', handler: updateElemCoInput },
-                { element: aoBasis, event: 'change', handler: updateElemCoInput },
-                { element: jkfitBasis, event: 'change', handler: updateElemCoInput },
-                { element: mpfitBasis, event: 'change', handler: updateElemCoInput },
-                { element: charge, event: 'input', handler: updateElemCoInput },
-                { element: multiplicity, event: 'input', handler: updateElemCoInput },
-                { element: moldenCheckbox, event: 'change', handler: updateElemCoInput },
-                { element: moldenFile, event: 'input', handler: updateElemCoInput }
-            ];
-
-            // Remove old listeners if they exist
-            elements.forEach(({ element, event, handler }) => {
-                if (element && element._elemcoHandler) {
-                    element.removeEventListener(event, element._elemcoHandler);
-                }
-            });
-
-            // Add new listeners and store references
-            elements.forEach(({ element, event, handler }) => {
-                if (element) {
-                    element._elemcoHandler = handler;
-                    element.addEventListener(event, handler);
-                }
-            });
-        }
-
-        // Function to update method options based on DF toggle
-        function updateMethodOptions() {
-            const dfEnabled = document.getElementById('elemco-df').checked;
-            const methodSelect = document.getElementById('elemco-method');
-            const selectedMethod = methodSelect.value;
+        // Delayed attempt 2 - final fallback with force refresh
+        setTimeout(() => {
+            console.log('showElemCoPanel: Second delayed attempt with force refresh');
             
-            // Store all available methods
-            const allMethods = {
-                standard: ['HF', 'MP2', 'DCSD', 'CCSD(T)', 'CCSDT', 'DC-CCSDT', 'SVD-DC-CCSDT'],
-                df: ['HF', 'MP2', 'SVD-DCSD']
-            };
-
-            // Clear existing options
-            methodSelect.innerHTML = '';
-
-            // Add appropriate methods based on DF toggle
-            const methods = dfEnabled ? allMethods.df : allMethods.standard;
-            methods.forEach(method => {
-                const option = document.createElement('option');
-                option.value = method;
-                option.text = method;
-                methodSelect.appendChild(option);
-            });
-
-            // Try to maintain selected method if it's still available
-            if (methods.includes(selectedMethod)) {
-                methodSelect.value = selectedMethod;
-            }
-
-            // Update the input text
-            updateElemCoInput();
-        }
-        
-        // Function to generate meaningful comment line for XYZ files
-        function generateXYZCommentLine() {
-            // Check if we have database metadata
-            if (window.databaseMetadata && window.databaseMetadata.source === 'PubChem') {
-                const metadata = window.databaseMetadata;
-                let commentParts = [];
+            // Check if we still have the error message
+            const inputArea = document.getElementById('elemco-input');
+            if (inputArea && inputArea.value.includes('Please load a molecule first')) {
+                console.warn('showElemCoPanel: Still showing "Please load a molecule first", trying force refresh');
                 
-                // Add PubChem source
-                commentParts.push('PubChem');
+                const refreshSuccess = forceRefreshMolecularData();
                 
-                // Add CID if available
-                if (metadata.cid) {
-                    commentParts.push(`CID:${metadata.cid}`);
-                }
-                
-                // Add compound name if available
-                if (metadata.name) {
-                    commentParts.push(`Name:"${metadata.name}"`);
-                }
-                
-                // Add SMILES if available (truncate if too long)
-                if (metadata.smiles) {
-                    const smiles = metadata.smiles.length > 50 ? 
-                        metadata.smiles.substring(0, 47) + '...' : 
-                        metadata.smiles;
-                    commentParts.push(`SMILES:${smiles}`);
-                }
-                
-                // Add query info if different from what's already shown
-                if (metadata.originalQuery && metadata.queryType) {
-                    if (metadata.queryType === 'CID' && metadata.originalQuery !== metadata.cid) {
-                        commentParts.push(`Query:${metadata.originalQuery}`);
-                    } else if (metadata.queryType === 'Name' && metadata.originalQuery !== metadata.name) {
-                        commentParts.push(`Query:"${metadata.originalQuery}"`);
-                    } else if (metadata.queryType === 'SMILES' && metadata.originalQuery !== metadata.smiles) {
-                        commentParts.push(`Query:${metadata.originalQuery}`);
-                    } else if (metadata.queryType === 'Formula') {
-                        commentParts.push(`Formula:${metadata.originalQuery}`);
-                    }
-                }
-                
-                return commentParts.join(', ');
-            }
-            
-            // Fallback to original comment if no database metadata
-            return 'Structure with numbered atoms';
-        }
-        
-        // Function to generate XYZ content with numbered atoms if available
-        function getXYZDataWithNumberedAtoms() {
-            debugLog('XYZ', 'Starting data retrieval');
-            debugLog('XYZ', `shouldUseNumberedAtoms flag: ${shouldUseNumberedAtoms}`);
-            
-            try {
-                // First check if there are any atoms at all
-                const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
-                debugLog('XYZ', `Atom count from JSmol: ${atomCount}`);
-                
-                if (!atomCount || atomCount === 0) {
-                    console.warn('No atoms found in JSmol');
-                    return null;
-                }
-                
-                // Strategy 1: Try to use preserved numbered atom names
-                if (window.originalAtomNames && window.originalAtomNames.length > 0) {
-                    console.log('getXYZDataWithNumberedAtoms: Found preserved atom names, count:', window.originalAtomNames.length);
+                if (!refreshSuccess) {
+                    // Try to diagnose the issue
                     try {
-                        if (atomCount === window.originalAtomNames.length) {
-                            let xyzContent = atomCount + '\n' + generateXYZCommentLine() + '\n';
-                            
-                            for (let i = 0; i < atomCount; i++) {
-                                // Get atom coordinates from JSmol
-                                const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`);
-                                const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`);
-                                const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`);
-                                
-                                // Validate coordinates
-                                if (isNaN(x) || isNaN(y) || isNaN(z)) {
-                                    console.warn('Invalid coordinates for atom', i, 'falling back');
-                                    break;
-                                }
-                                
-                                // Use the preserved numbered atom name
-                                const atomName = window.originalAtomNames[i];
-                                xyzContent += `${atomName} ${x.toFixed(6)} ${y.toFixed(6)} ${z.toFixed(6)}\n`;
-                            }
-                            
-                            // Validate the generated content
-                            const lines = xyzContent.trim().split('\n');
-                            if (lines.length >= atomCount + 2) {
-                                console.log('getXYZDataWithNumberedAtoms: Successfully generated numbered XYZ data');
-                                return xyzContent;
-                            }
+                        const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+                        console.log('showElemCoPanel: Diagnostic - JSmol atom count:', atomCount);
+                        
+                        if (atomCount > 0) {
+                            console.log('showElemCoPanel: Atoms exist but data retrieval failed. This suggests a JSmol communication issue.');
+                            inputArea.value = '# Molecular data detected but could not be retrieved.\n# Try closing and reopening the ElemCo panel, or reload the molecule.';
                         } else {
-                            console.warn('Atom count mismatch: JSmol has', atomCount, 'but preserved names has', window.originalAtomNames.length);
+                            console.log('showElemCoPanel: No atoms detected in JSmol');
+                            inputArea.value = '# No molecular structure detected.\n# Please load a molecule first.';
                         }
-                    } catch (error) {
-                        console.error('Error generating numbered XYZ data:', error);
-                        // Continue to next strategy
+                    } catch (e) {
+                        console.error('showElemCoPanel: Diagnostic failed:', e);
+                        inputArea.value = '# Error communicating with molecular viewer.\n# Please reload the page and try again.';
                     }
                 }
-                
-                // Strategy 2: Try to get current atom names from JSmol and build XYZ
-                console.log('getXYZDataWithNumberedAtoms: Trying to get current atom names from JSmol');
-                try {
+            } else {
+                console.log('showElemCoPanel: ElemCo input appears to be working correctly');
+            }
+        }, 300);
+    } else {
+        console.error('showElemCoPanel: Could not find elemcoPanel element');
+    }
+}
+
+function hideElemCoPanel() {
+    document.getElementById('elemcoPanel').style.display = 'none';
+}
+
+function generateElemCoInput() {
+    updateElemCoInput();
+    document.getElementById('status').innerHTML = 'ElemCo.jl input reset to default';
+}
+
+// Insert the list of currently selected atoms (sorted, 1-based indices) at the
+// cursor position in the ElemCo input editor, e.g. for dummy atoms or active
+// regions. Falls back to appending at the end if no cursor position is known.
+function insertSelectedAtomsIntoElemCo() {
+    const nums = getSelectedAtomNumbers();
+    if (nums.length === 0) {
+        document.getElementById('status').innerHTML =
+            'No atoms selected — click atoms in the structure or XYZ viewer first';
+        return;
+    }
+    const textarea = document.getElementById('elemco-input');
+    const listText = '[' + nums.join(', ') + ']';
+    const hasCursor = typeof textarea.selectionStart === 'number';
+    const start = hasCursor ? textarea.selectionStart : textarea.value.length;
+    const end = hasCursor ? textarea.selectionEnd : textarea.value.length;
+    textarea.value = textarea.value.slice(0, start) + listText + textarea.value.slice(end);
+    const pos = start + listText.length;
+    textarea.selectionStart = textarea.selectionEnd = pos;
+    textarea.focus();
+    document.getElementById('status').innerHTML =
+        `Inserted ${nums.length} selected atom${nums.length === 1 ? '' : 's'}: ${listText}`;
+}
+
+function copyElemCoInput() {
+    const input = document.getElementById('elemco-input');
+    const text = input.value;
+    
+    // Use modern Clipboard API with fallback for older browsers
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(() => {
+            document.getElementById('status').innerHTML = 'Input copied to clipboard';
+        }).catch(err => {
+            console.error('Clipboard API failed:', err);
+            fallbackCopyToClipboard(input);
+        });
+    } else {
+        fallbackCopyToClipboard(input);
+    }
+}
+
+// Fallback for browsers without Clipboard API
+function fallbackCopyToClipboard(textArea) {
+    textArea.select();
+    try {
+        document.execCommand('copy');
+        document.getElementById('status').innerHTML = 'Input copied to clipboard';
+    } catch (err) {
+        console.error('Fallback copy failed:', err);
+        document.getElementById('status').innerHTML = 'Copy failed - please copy manually';
+    }
+}
+
+// Remove previous event listeners and add new ones
+function initializeElemCoListeners() {
+    const method = document.getElementById('elemco-method');
+    const aoBasis = document.getElementById('elemco-basis');
+    const jkfitBasis = document.getElementById('elemco-jkfit');
+    const mpfitBasis = document.getElementById('elemco-mpfit');
+    const charge = document.getElementById('elemco-charge');
+    const multiplicity = document.getElementById('elemco-multiplicity');
+    const moldenCheckbox = document.getElementById('elemco-molden');
+    const moldenFile = document.getElementById('elemco-molden-file');
+
+    // Store references to listeners for proper cleanup
+    const elements = [
+        { element: method, event: 'change', handler: updateElemCoInput },
+        { element: aoBasis, event: 'change', handler: updateElemCoInput },
+        { element: jkfitBasis, event: 'change', handler: updateElemCoInput },
+        { element: mpfitBasis, event: 'change', handler: updateElemCoInput },
+        { element: charge, event: 'input', handler: updateElemCoInput },
+        { element: multiplicity, event: 'input', handler: updateElemCoInput },
+        { element: moldenCheckbox, event: 'change', handler: updateElemCoInput },
+        { element: moldenFile, event: 'input', handler: updateElemCoInput }
+    ];
+
+    // Remove old listeners if they exist
+    elements.forEach(({ element, event, handler }) => {
+        if (element && element._elemcoHandler) {
+            element.removeEventListener(event, element._elemcoHandler);
+        }
+    });
+
+    // Add new listeners and store references
+    elements.forEach(({ element, event, handler }) => {
+        if (element) {
+            element._elemcoHandler = handler;
+            element.addEventListener(event, handler);
+        }
+    });
+}
+
+// Function to update method options based on DF toggle
+function updateMethodOptions() {
+    const dfEnabled = document.getElementById('elemco-df').checked;
+    const methodSelect = document.getElementById('elemco-method');
+    const selectedMethod = methodSelect.value;
+    
+    // Store all available methods
+    const allMethods = {
+        standard: ['HF', 'MP2', 'DCSD', 'CCSD(T)', 'CCSDT', 'DC-CCSDT', 'SVD-DC-CCSDT'],
+        df: ['HF', 'MP2', 'SVD-DCSD']
+    };
+
+    // Clear existing options
+    methodSelect.innerHTML = '';
+
+    // Add appropriate methods based on DF toggle
+    const methods = dfEnabled ? allMethods.df : allMethods.standard;
+    methods.forEach(method => {
+        const option = document.createElement('option');
+        option.value = method;
+        option.text = method;
+        methodSelect.appendChild(option);
+    });
+
+    // Try to maintain selected method if it's still available
+    if (methods.includes(selectedMethod)) {
+        methodSelect.value = selectedMethod;
+    }
+
+    // Update the input text
+    updateElemCoInput();
+}
+
+// Function to generate meaningful comment line for XYZ files
+function generateXYZCommentLine() {
+    // Check if we have database metadata
+    if (window.databaseMetadata && window.databaseMetadata.source === 'PubChem') {
+        const metadata = window.databaseMetadata;
+        let commentParts = [];
+        
+        // Add PubChem source
+        commentParts.push('PubChem');
+        
+        // Add CID if available
+        if (metadata.cid) {
+            commentParts.push(`CID:${metadata.cid}`);
+        }
+        
+        // Add compound name if available
+        if (metadata.name) {
+            commentParts.push(`Name:"${metadata.name}"`);
+        }
+        
+        // Add SMILES if available (truncate if too long)
+        if (metadata.smiles) {
+            const smiles = metadata.smiles.length > 50 ? 
+                metadata.smiles.substring(0, 47) + '...' : 
+                metadata.smiles;
+            commentParts.push(`SMILES:${smiles}`);
+        }
+        
+        // Add query info if different from what's already shown
+        if (metadata.originalQuery && metadata.queryType) {
+            if (metadata.queryType === 'CID' && metadata.originalQuery !== metadata.cid) {
+                commentParts.push(`Query:${metadata.originalQuery}`);
+            } else if (metadata.queryType === 'Name' && metadata.originalQuery !== metadata.name) {
+                commentParts.push(`Query:"${metadata.originalQuery}"`);
+            } else if (metadata.queryType === 'SMILES' && metadata.originalQuery !== metadata.smiles) {
+                commentParts.push(`Query:${metadata.originalQuery}`);
+            } else if (metadata.queryType === 'Formula') {
+                commentParts.push(`Formula:${metadata.originalQuery}`);
+            }
+        }
+        
+        return commentParts.join(', ');
+    }
+    
+    // Fallback to original comment if no database metadata
+    return 'Structure with numbered atoms';
+}
+
+// Function to generate XYZ content with numbered atoms if available
+function getXYZDataWithNumberedAtoms() {
+    debugLog('XYZ', 'Starting data retrieval');
+    debugLog('XYZ', `shouldUseNumberedAtoms flag: ${shouldUseNumberedAtoms}`);
+    
+    try {
+        // First check if there are any atoms at all
+        const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+        debugLog('XYZ', `Atom count from JSmol: ${atomCount}`);
+        
+        if (!atomCount || atomCount === 0) {
+            console.warn('No atoms found in JSmol');
+            return null;
+        }
+        
+        // Strategy 1: Try to use preserved numbered atom names
+        if (window.originalAtomNames && window.originalAtomNames.length > 0) {
+            console.log('getXYZDataWithNumberedAtoms: Found preserved atom names, count:', window.originalAtomNames.length);
+            try {
+                if (atomCount === window.originalAtomNames.length) {
                     let xyzContent = atomCount + '\n' + generateXYZCommentLine() + '\n';
-                    let validData = true;
                     
-                    for (let i = 0; i < atomCount && validData; i++) {
-                        try {
-                            // Try to get current atom name from JSmol
-                            let atomName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
-                            if (!atomName || atomName === 'null' || atomName === '') {
-                                // Fallback based on whether we should use numbered atoms
-                                const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
-                                atomName = shouldUseNumberedAtoms ? `${element}${i + 1}` : element;
-                                console.log(`getXYZDataWithNumberedAtoms: Strategy 2 - Generated atom name for atom ${i}: ${atomName} (shouldUseNumberedAtoms: ${shouldUseNumberedAtoms})`);
-                            }
-                            
-                            const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`);
-                            const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`);
-                            const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`);
-                            
-                            // Validate coordinates
-                            if (isNaN(x) || isNaN(y) || isNaN(z)) {
-                                console.warn('Invalid coordinates for atom', i);
-                                validData = false;
-                                break;
-                            }
-                            
-                            xyzContent += `${atomName} ${x.toFixed(6)} ${y.toFixed(6)} ${z.toFixed(6)}\n`;
-                        } catch (atomError) {
-                            console.warn('Error getting data for atom', i, ':', atomError);
-                            validData = false;
+                    for (let i = 0; i < atomCount; i++) {
+                        // Get atom coordinates from JSmol
+                        const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`);
+                        const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`);
+                        const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`);
+                        
+                        // Validate coordinates
+                        if (isNaN(x) || isNaN(y) || isNaN(z)) {
+                            console.warn('Invalid coordinates for atom', i, 'falling back');
                             break;
                         }
+                        
+                        // Use the preserved numbered atom name
+                        const atomName = window.originalAtomNames[i];
+                        xyzContent += `${atomName} ${x.toFixed(6)} ${y.toFixed(6)} ${z.toFixed(6)}\n`;
                     }
                     
-                    if (validData) {
-                        console.log('getXYZDataWithNumberedAtoms: Successfully generated XYZ from current JSmol state');
+                    // Validate the generated content
+                    const lines = xyzContent.trim().split('\n');
+                    if (lines.length >= atomCount + 2) {
+                        console.log('getXYZDataWithNumberedAtoms: Successfully generated numbered XYZ data');
                         return xyzContent;
                     }
-                } catch (error) {
-                    console.error('Error building XYZ from current JSmol state:', error);
+                } else {
+                    console.warn('Atom count mismatch: JSmol has', atomCount, 'but preserved names has', window.originalAtomNames.length);
                 }
-                
-                // Strategy 3: Try JSmol's built-in write function
-                console.log('getXYZDataWithNumberedAtoms: Trying JSmol write function');
-                try {
-                    const xyzData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")');
-                    if (xyzData && xyzData.trim().length > 0) {
-                        const lines = xyzData.trim().split('\n');
-                        if (lines.length >= 3 && !isNaN(parseInt(lines[0]))) {
-                            console.log('getXYZDataWithNumberedAtoms: Successfully got XYZ from JSmol write function');
-                            return xyzData;
-                        }
-                    }
-                } catch (error) {
-                    console.error('JSmol write function failed:', error);
-                }
-                
-                // Strategy 4: Manual XYZ building with element symbols (numbered only if appropriate)
-                console.log('getXYZDataWithNumberedAtoms: Building manual XYZ with element symbols');
-                try {
-                    let manualXYZ = atomCount + '\n' + generateXYZCommentLine() + '\n';
-                    let validManualData = true;
-                    
-                    for (let i = 0; i < atomCount && validManualData; i++) {
-                        try {
-                            const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
-                            const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`) || 0;
-                            const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`) || 0;
-                            const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`) || 0;
-                            
-                            // Use numbered atoms only if this came from an XYZ file
-                            const atomName = shouldUseNumberedAtoms ? `${element}${i+1}` : element;
-                            console.log(`getXYZDataWithNumberedAtoms: Strategy 4 - Generated atom name for atom ${i}: ${atomName} (shouldUseNumberedAtoms: ${shouldUseNumberedAtoms})`);
-                            manualXYZ += `${atomName} ${parseFloat(x).toFixed(6)} ${parseFloat(y).toFixed(6)} ${parseFloat(z).toFixed(6)}\n`;
-                        } catch (atomError) {
-                            console.warn('Error in manual XYZ generation for atom', i, ':', atomError);
-                            validManualData = false;
-                            break;
-                        }
-                    }
-                    
-                    if (validManualData) {
-                        console.log('getXYZDataWithNumberedAtoms: Successfully generated manual XYZ');
-                        return manualXYZ;
-                    }
-                } catch (error) {
-                    console.error('Manual XYZ generation failed:', error);
-                }
-                
-                console.error('All XYZ generation strategies failed');
-                return null;
-                
             } catch (error) {
-                console.error('Error in getXYZDataWithNumberedAtoms:', error);
-                
-                // Last resort: try to get any molecular data
-                try {
-                    console.log('getXYZDataWithNumberedAtoms: Last resort fallback attempt');
-                    const fallbackData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")');
-                    if (fallbackData && fallbackData.trim().length > 0) {
-                        console.log('getXYZDataWithNumberedAtoms: Fallback successful');
-                        return fallbackData;
-                    }
-                } catch (fallbackError) {
-                    console.error('Fallback XYZ generation also failed:', fallbackError);
-                }
-                
-                console.error('All molecular data retrieval attempts failed');
-                return null;
+                console.error('Error generating numbered XYZ data:', error);
+                // Continue to next strategy
             }
         }
-
-        function updateElemCoInput() {
-            debugLog('ElemCo', 'Starting input generation');
+        
+        // Strategy 2: Try to get current atom names from JSmol and build XYZ
+        console.log('getXYZDataWithNumberedAtoms: Trying to get current atom names from JSmol');
+        try {
+            let xyzContent = atomCount + '\n' + generateXYZCommentLine() + '\n';
+            let validData = true;
             
-            const dfEnabled = document.getElementById('elemco-df').checked;
-            const method = document.getElementById('elemco-method').value;
-            const aoBasis = document.getElementById('elemco-basis').value;
-            const jkfitBasis = document.getElementById('elemco-jkfit').value;
-            const mpfitBasis = document.getElementById('elemco-mpfit').value;
-            const charge = parseInt(document.getElementById('elemco-charge').value) || 0;
-            const multiplicity = parseInt(document.getElementById('elemco-multiplicity').value) || 0;
-            const moldenEnabled = document.getElementById('elemco-molden').checked;
-            const moldenFile = document.getElementById('elemco-molden-file').value.trim() || 'orbitals.molden';
-
-            // Get current molecular structure from JSmol (with numbered atoms if available)
-            debugLog('ElemCo', 'Calling getXYZDataWithNumberedAtoms');
-            const xyzData = getXYZDataWithNumberedAtoms();
-            
-            if (!xyzData || xyzData.trim().length === 0) {
-                debugLog('ElemCo', 'No XYZ data received', 'warning');
-                document.getElementById('elemco-input').value = '# Please load a molecule first';
-                return;
-            }
-            
-            debugLog('ElemCo', `Received XYZ data, length: ${xyzData.length}`);
-            
-            // Double-check that we have valid XYZ data
-            const lines = xyzData.trim().split('\n');
-            if (lines.length < 3) {
-                console.warn('updateElemCoInput: XYZ data has insufficient lines:', lines.length);
-                document.getElementById('elemco-input').value = '# Invalid molecular structure - please reload molecule';
-                return;
-            }
-            
-            // Check if first line contains atom count
-            const atomCount = parseInt(lines[0]);
-            if (isNaN(atomCount) || atomCount <= 0) {
-                console.warn('updateElemCoInput: Invalid atom count in first line:', lines[0]);
-                document.getElementById('elemco-input').value = '# Invalid molecular structure - please reload molecule';
-                return;
-            }
-            
-            // Verify we have enough data lines for all atoms
-            const dataLines = lines.slice(2); // Skip atom count and comment lines
-            if (dataLines.length < atomCount) {
-                console.warn('updateElemCoInput: Insufficient atom data lines. Expected:', atomCount, 'Found:', dataLines.length);
-                document.getElementById('elemco-input').value = '# Incomplete molecular structure - please reload molecule';
-                return;
-            }
-            
-            // Validate that atom data lines have proper format
-            let validAtomLines = 0;
-            for (let i = 0; i < Math.min(dataLines.length, atomCount); i++) {
-                const parts = dataLines[i].trim().split(/\s+/);
-                if (parts.length >= 4) {
-                    const x = parseFloat(parts[1]);
-                    const y = parseFloat(parts[2]);
-                    const z = parseFloat(parts[3]);
-                    if (!isNaN(x) && !isNaN(y) && !isNaN(z)) {
-                        validAtomLines++;
+            for (let i = 0; i < atomCount && validData; i++) {
+                try {
+                    // Try to get current atom name from JSmol
+                    let atomName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
+                    if (!atomName || atomName === 'null' || atomName === '') {
+                        // Fallback based on whether we should use numbered atoms
+                        const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
+                        atomName = shouldUseNumberedAtoms ? `${element}${i + 1}` : element;
+                        console.log(`getXYZDataWithNumberedAtoms: Strategy 2 - Generated atom name for atom ${i}: ${atomName} (shouldUseNumberedAtoms: ${shouldUseNumberedAtoms})`);
                     }
+                    
+                    const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`);
+                    const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`);
+                    const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`);
+                    
+                    // Validate coordinates
+                    if (isNaN(x) || isNaN(y) || isNaN(z)) {
+                        console.warn('Invalid coordinates for atom', i);
+                        validData = false;
+                        break;
+                    }
+                    
+                    xyzContent += `${atomName} ${x.toFixed(6)} ${y.toFixed(6)} ${z.toFixed(6)}\n`;
+                } catch (atomError) {
+                    console.warn('Error getting data for atom', i, ':', atomError);
+                    validData = false;
+                    break;
                 }
             }
             
-            if (validAtomLines < atomCount) {
-                console.warn('updateElemCoInput: Not all atom lines are valid. Valid:', validAtomLines, 'Expected:', atomCount);
-                document.getElementById('elemco-input').value = '# Malformed molecular structure - please reload molecule';
-                return;
+            if (validData) {
+                console.log('getXYZDataWithNumberedAtoms: Successfully generated XYZ from current JSmol state');
+                return xyzContent;
+            }
+        } catch (error) {
+            console.error('Error building XYZ from current JSmol state:', error);
+        }
+        
+        // Strategy 3: Try JSmol's built-in write function
+        console.log('getXYZDataWithNumberedAtoms: Trying JSmol write function');
+        try {
+            const xyzData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")');
+            if (xyzData && xyzData.trim().length > 0) {
+                const lines = xyzData.trim().split('\n');
+                if (lines.length >= 3 && !isNaN(parseInt(lines[0]))) {
+                    console.log('getXYZDataWithNumberedAtoms: Successfully got XYZ from JSmol write function');
+                    return xyzData;
+                }
+            }
+        } catch (error) {
+            console.error('JSmol write function failed:', error);
+        }
+        
+        // Strategy 4: Manual XYZ building with element symbols (numbered only if appropriate)
+        console.log('getXYZDataWithNumberedAtoms: Building manual XYZ with element symbols');
+        try {
+            let manualXYZ = atomCount + '\n' + generateXYZCommentLine() + '\n';
+            let validManualData = true;
+            
+            for (let i = 0; i < atomCount && validManualData; i++) {
+                try {
+                    const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
+                    const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`) || 0;
+                    const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`) || 0;
+                    const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`) || 0;
+                    
+                    // Use numbered atoms only if this came from an XYZ file
+                    const atomName = shouldUseNumberedAtoms ? `${element}${i+1}` : element;
+                    console.log(`getXYZDataWithNumberedAtoms: Strategy 4 - Generated atom name for atom ${i}: ${atomName} (shouldUseNumberedAtoms: ${shouldUseNumberedAtoms})`);
+                    manualXYZ += `${atomName} ${parseFloat(x).toFixed(6)} ${parseFloat(y).toFixed(6)} ${parseFloat(z).toFixed(6)}\n`;
+                } catch (atomError) {
+                    console.warn('Error in manual XYZ generation for atom', i, ':', atomError);
+                    validManualData = false;
+                    break;
+                }
             }
             
-            debugLog('ElemCo', `XYZ data validation passed. Atoms: ${atomCount}, Valid lines: ${validAtomLines}`);
+            if (validManualData) {
+                console.log('getXYZDataWithNumberedAtoms: Successfully generated manual XYZ');
+                return manualXYZ;
+            }
+        } catch (error) {
+            console.error('Manual XYZ generation failed:', error);
+        }
         
-            // Format ElemCo.jl input with complete XYZ specification
-            let elemcoInput = `using ElemCo
+        console.error('All XYZ generation strategies failed');
+        return null;
+        
+    } catch (error) {
+        console.error('Error in getXYZDataWithNumberedAtoms:', error);
+        
+        // Last resort: try to get any molecular data
+        try {
+            console.log('getXYZDataWithNumberedAtoms: Last resort fallback attempt');
+            const fallbackData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")');
+            if (fallbackData && fallbackData.trim().length > 0) {
+                console.log('getXYZDataWithNumberedAtoms: Fallback successful');
+                return fallbackData;
+            }
+        } catch (fallbackError) {
+            console.error('Fallback XYZ generation also failed:', fallbackError);
+        }
+        
+        console.error('All molecular data retrieval attempts failed');
+        return null;
+    }
+}
+
+function updateElemCoInput() {
+    debugLog('ElemCo', 'Starting input generation');
+    
+    const dfEnabled = document.getElementById('elemco-df').checked;
+    const method = document.getElementById('elemco-method').value;
+    const aoBasis = document.getElementById('elemco-basis').value;
+    const jkfitBasis = document.getElementById('elemco-jkfit').value;
+    const mpfitBasis = document.getElementById('elemco-mpfit').value;
+    const charge = parseInt(document.getElementById('elemco-charge').value) || 0;
+    const multiplicity = parseInt(document.getElementById('elemco-multiplicity').value) || 0;
+    const moldenEnabled = document.getElementById('elemco-molden').checked;
+    const moldenFile = document.getElementById('elemco-molden-file').value.trim() || 'orbitals.molden';
+
+    // Get current molecular structure from JSmol (with numbered atoms if available)
+    debugLog('ElemCo', 'Calling getXYZDataWithNumberedAtoms');
+    const xyzData = getXYZDataWithNumberedAtoms();
+    
+    if (!xyzData || xyzData.trim().length === 0) {
+        debugLog('ElemCo', 'No XYZ data received', 'warning');
+        document.getElementById('elemco-input').value = '# Please load a molecule first';
+        return;
+    }
+    
+    debugLog('ElemCo', `Received XYZ data, length: ${xyzData.length}`);
+    
+    // Double-check that we have valid XYZ data
+    const lines = xyzData.trim().split('\n');
+    if (lines.length < 3) {
+        console.warn('updateElemCoInput: XYZ data has insufficient lines:', lines.length);
+        document.getElementById('elemco-input').value = '# Invalid molecular structure - please reload molecule';
+        return;
+    }
+    
+    // Check if first line contains atom count
+    const atomCount = parseInt(lines[0]);
+    if (isNaN(atomCount) || atomCount <= 0) {
+        console.warn('updateElemCoInput: Invalid atom count in first line:', lines[0]);
+        document.getElementById('elemco-input').value = '# Invalid molecular structure - please reload molecule';
+        return;
+    }
+    
+    // Verify we have enough data lines for all atoms
+    const dataLines = lines.slice(2); // Skip atom count and comment lines
+    if (dataLines.length < atomCount) {
+        console.warn('updateElemCoInput: Insufficient atom data lines. Expected:', atomCount, 'Found:', dataLines.length);
+        document.getElementById('elemco-input').value = '# Incomplete molecular structure - please reload molecule';
+        return;
+    }
+    
+    // Validate that atom data lines have proper format
+    let validAtomLines = 0;
+    for (let i = 0; i < Math.min(dataLines.length, atomCount); i++) {
+        const parts = dataLines[i].trim().split(/\s+/);
+        if (parts.length >= 4) {
+            const x = parseFloat(parts[1]);
+            const y = parseFloat(parts[2]);
+            const z = parseFloat(parts[3]);
+            if (!isNaN(x) && !isNaN(y) && !isNaN(z)) {
+                validAtomLines++;
+            }
+        }
+    }
+    
+    if (validAtomLines < atomCount) {
+        console.warn('updateElemCoInput: Not all atom lines are valid. Valid:', validAtomLines, 'Expected:', atomCount);
+        document.getElementById('elemco-input').value = '# Malformed molecular structure - please reload molecule';
+        return;
+    }
+    
+    debugLog('ElemCo', `XYZ data validation passed. Atoms: ${atomCount}, Valid lines: ${validAtomLines}`);
+
+    // Format ElemCo.jl input with complete XYZ specification
+    let elemcoInput = `using ElemCo
 
 function main()        
 # Molecule specification
@@ -488,327 +488,327 @@ ${xyzData.trim()}
 """
         
 # Set basis set`;
-        
-            // Handle basis set configuration based on selected options
-            if (jkfitBasis === 'auto' && mpfitBasis === 'auto') {
-                // Use simple basis set specification if no auxiliary basis sets are selected
-                elemcoInput += `\nbasis = "${aoBasis}"\n`;
-            } else {
-                // Build the basis dictionary with selected auxiliary basis sets
-                elemcoInput += `\nbasis = Dict(\n    "ao" => "${aoBasis}"`;
 
-                if (jkfitBasis !== 'auto') {
-                    elemcoInput += `,\n    "jkfit" => "${jkfitBasis}"`;
-                }
+    // Handle basis set configuration based on selected options
+    if (jkfitBasis === 'auto' && mpfitBasis === 'auto') {
+        // Use simple basis set specification if no auxiliary basis sets are selected
+        elemcoInput += `\nbasis = "${aoBasis}"\n`;
+    } else {
+        // Build the basis dictionary with selected auxiliary basis sets
+        elemcoInput += `\nbasis = Dict(\n    "ao" => "${aoBasis}"`;
 
-                if (mpfitBasis !== 'auto') {
-                    elemcoInput += `,\n    "mpfit" => "${mpfitBasis}"`;
-                }
-
-                elemcoInput += "\n)\n";
-            }
-        
-            // Add charge and multiplicity settings only if they are non-zero
-            if (charge !== 0 || multiplicity !== 0) {
-                elemcoInput += `\n# Set charge and multiplicity\n@set wf charge=${charge} ms2=${multiplicity}\n`;
-            }
-        
-            // Add calculation commands
-            elemcoInput += `\n# Run HF calculation first\n${dfEnabled ? '@dfhf' : '@dfhf'}\n`;
-        
-            // Add coupled cluster calculation if method is not HF
-            if (method !== 'HF') {
-                const ccCommand = dfEnabled ? '@dfcc' : '@cc';
-                elemcoInput += `\n# Run ${method} calculation\n${ccCommand} ${method.toLowerCase()}\n`;
-            }
-
-            // Add molden export if enabled
-            if (moldenEnabled) {
-                elemcoInput += `\n# Export orbitals to Molden file\n@export_molden "${moldenFile}"\n`;
-            }
-
-            elemcoInput += `\nend\nmain()\n`;
-        
-            // Set the input text
-            const inputArea = document.getElementById('elemco-input');
-            if (inputArea) {
-                inputArea.value = elemcoInput;
-                debugLog('ElemCo', 'Successfully generated input');
-            } else {
-                console.error('updateElemCoInput: Could not find elemco-input textarea');
-            }
+        if (jkfitBasis !== 'auto') {
+            elemcoInput += `,\n    "jkfit" => "${jkfitBasis}"`;
         }
 
-        // Function to run Julia calculation
-        async function runJuliaCalculation() {
-            const inputTextarea = document.getElementById('elemco-input');
-            const outputTextarea = document.getElementById('julia-output');
-            const outputSection = document.getElementById('julia-output-section');
-            
-            if (!inputTextarea || !outputTextarea || !outputSection) {
-                document.getElementById('status').innerHTML = 'Error: Could not find required elements';
-                return;
-            }
-            
-            const juliaCode = inputTextarea.value.trim();
-            if (!juliaCode || juliaCode === '# Please load a molecule first') {
-                document.getElementById('status').innerHTML = 'Please generate valid input first';
-                return;
-            }
-            
-            // Show the output section
-            outputSection.style.display = 'block';
-            outputTextarea.value = 'Initializing Julia calculation...\n';
-            document.getElementById('status').innerHTML = 'Preparing Julia calculation...';
-            
-            try {
-                // Check if we're in Electron environment
-                if (typeof require !== 'undefined') {
-                    // Electron environment - use child_process to run Julia
-                    await runJuliaInElectron(juliaCode);
-                } else {
-                    // Browser environment - show instructions for manual execution
-                    showJuliaInstructions(juliaCode);
-                }
-            } catch (error) {
-                console.error('Error running Julia calculation:', error);
-                outputTextarea.value = `Error: ${error.message}\n\nTroubleshooting:\n- Ensure Julia is installed and accessible\n- Verify ElemCo.jl package is installed\n- Check file permissions\n- Try running Julia from command line first`;
-                document.getElementById('status').innerHTML = 'Julia calculation failed - see output for details';
-            }
+        if (mpfitBasis !== 'auto') {
+            elemcoInput += `,\n    "mpfit" => "${mpfitBasis}"`;
         }
-        
-        // Function to run Julia in Electron environment
-        async function runJuliaInElectron(juliaCode) {
-            const { spawn } = require('child_process');
-            const fs = require('fs');
-            const path = require('path');
-            const os = require('os');
-            
-            const outputTextarea = document.getElementById('julia-output');
-            
-            // Get the configured Julia command from user preferences
-            const prefs = getPreferences();
-            const juliaCommand = prefs.juliaCommand || 'julia';
-            
-            let tempFile = null;
-            
-            // Cleanup function to be called in all exit scenarios
-            function cleanupTempFile() {
-                if (tempFile) {
-                    try {
-                        fs.unlinkSync(tempFile);
-                        console.log('Temporary file cleaned up:', tempFile);
-                    } catch (e) {
-                        console.warn('Could not delete temporary file:', tempFile, e);
-                    }
-                    tempFile = null;
-                }
-            }
-            
-            // Ensure cleanup happens even if process is terminated
-            process.on('exit', cleanupTempFile);
-            process.on('SIGINT', cleanupTempFile);
-            process.on('SIGTERM', cleanupTempFile);
-            
+
+        elemcoInput += "\n)\n";
+    }
+
+    // Add charge and multiplicity settings only if they are non-zero
+    if (charge !== 0 || multiplicity !== 0) {
+        elemcoInput += `\n# Set charge and multiplicity\n@set wf charge=${charge} ms2=${multiplicity}\n`;
+    }
+
+    // Add calculation commands
+    elemcoInput += `\n# Run HF calculation first\n${dfEnabled ? '@dfhf' : '@dfhf'}\n`;
+
+    // Add coupled cluster calculation if method is not HF
+    if (method !== 'HF') {
+        const ccCommand = dfEnabled ? '@dfcc' : '@cc';
+        elemcoInput += `\n# Run ${method} calculation\n${ccCommand} ${method.toLowerCase()}\n`;
+    }
+
+    // Add molden export if enabled
+    if (moldenEnabled) {
+        elemcoInput += `\n# Export orbitals to Molden file\n@export_molden "${moldenFile}"\n`;
+    }
+
+    elemcoInput += `\nend\nmain()\n`;
+
+    // Set the input text
+    const inputArea = document.getElementById('elemco-input');
+    if (inputArea) {
+        inputArea.value = elemcoInput;
+        debugLog('ElemCo', 'Successfully generated input');
+    } else {
+        console.error('updateElemCoInput: Could not find elemco-input textarea');
+    }
+}
+
+// Function to run Julia calculation
+async function runJuliaCalculation() {
+    const inputTextarea = document.getElementById('elemco-input');
+    const outputTextarea = document.getElementById('julia-output');
+    const outputSection = document.getElementById('julia-output-section');
+    
+    if (!inputTextarea || !outputTextarea || !outputSection) {
+        document.getElementById('status').innerHTML = 'Error: Could not find required elements';
+        return;
+    }
+    
+    const juliaCode = inputTextarea.value.trim();
+    if (!juliaCode || juliaCode === '# Please load a molecule first') {
+        document.getElementById('status').innerHTML = 'Please generate valid input first';
+        return;
+    }
+    
+    // Show the output section
+    outputSection.style.display = 'block';
+    outputTextarea.value = 'Initializing Julia calculation...\n';
+    document.getElementById('status').innerHTML = 'Preparing Julia calculation...';
+    
+    try {
+        // Check if we're in Electron environment
+        if (typeof require !== 'undefined') {
+            // Electron environment - use child_process to run Julia
+            await runJuliaInElectron(juliaCode);
+        } else {
+            // Browser environment - show instructions for manual execution
+            showJuliaInstructions(juliaCode);
+        }
+    } catch (error) {
+        console.error('Error running Julia calculation:', error);
+        outputTextarea.value = `Error: ${error.message}\n\nTroubleshooting:\n- Ensure Julia is installed and accessible\n- Verify ElemCo.jl package is installed\n- Check file permissions\n- Try running Julia from command line first`;
+        document.getElementById('status').innerHTML = 'Julia calculation failed - see output for details';
+    }
+}
+
+// Function to run Julia in Electron environment
+async function runJuliaInElectron(juliaCode) {
+    const { spawn } = require('child_process');
+    const fs = require('fs');
+    const path = require('path');
+    const os = require('os');
+    
+    const outputTextarea = document.getElementById('julia-output');
+    
+    // Get the configured Julia command from user preferences
+    const prefs = getPreferences();
+    const juliaCommand = prefs.juliaCommand || 'julia';
+    
+    let tempFile = null;
+    
+    // Cleanup function to be called in all exit scenarios
+    function cleanupTempFile() {
+        if (tempFile) {
             try {
-                // Parse Julia command to handle WSL and other complex commands with proper quote handling
-                function parseCommand(cmd) {
-                    const parts = [];
-                    let current = '';
-                    let inQuotes = false;
-                    let quoteChar = '';
-                    
-                    for (let i = 0; i < cmd.length; i++) {
-                        const char = cmd[i];
-                        
-                        if ((char === '"' || char === "'") && !inQuotes) {
-                            inQuotes = true;
-                            quoteChar = char;
-                        } else if (char === quoteChar && inQuotes) {
-                            inQuotes = false;
-                            quoteChar = '';
-                        } else if (char === ' ' && !inQuotes) {
-                            if (current.trim()) {
-                                parts.push(current.trim());
-                                current = '';
-                            }
-                        } else {
-                            current += char;
-                        }
-                    }
-                    
+                fs.unlinkSync(tempFile);
+                console.log('Temporary file cleaned up:', tempFile);
+            } catch (e) {
+                console.warn('Could not delete temporary file:', tempFile, e);
+            }
+            tempFile = null;
+        }
+    }
+    
+    // Ensure cleanup happens even if process is terminated
+    process.on('exit', cleanupTempFile);
+    process.on('SIGINT', cleanupTempFile);
+    process.on('SIGTERM', cleanupTempFile);
+    
+    try {
+        // Parse Julia command to handle WSL and other complex commands with proper quote handling
+        function parseCommand(cmd) {
+            const parts = [];
+            let current = '';
+            let inQuotes = false;
+            let quoteChar = '';
+            
+            for (let i = 0; i < cmd.length; i++) {
+                const char = cmd[i];
+                
+                if ((char === '"' || char === "'") && !inQuotes) {
+                    inQuotes = true;
+                    quoteChar = char;
+                } else if (char === quoteChar && inQuotes) {
+                    inQuotes = false;
+                    quoteChar = '';
+                } else if (char === ' ' && !inQuotes) {
                     if (current.trim()) {
                         parts.push(current.trim());
+                        current = '';
                     }
-                    
-                    return parts;
-                }
-                
-                const commandParts = parseCommand(juliaCommand.trim());
-                const isWSL = commandParts[0].toLowerCase() === 'wsl';
-                
-                // Create temporary file for Julia code
-                const tempDir = os.tmpdir();
-                tempFile = path.join(tempDir, `jlmol_calculation_${Date.now()}.jl`);
-                fs.writeFileSync(tempFile, juliaCode);
-                
-                // For WSL, convert Windows path to WSL path
-                let filePathForCommand = tempFile;
-                if (isWSL) {
-                    // Convert Windows path to WSL path format
-                    // Handle both uppercase and lowercase drive letters
-                    // e.g., C:\Users\... or c:\Users\... -> /mnt/c/Users/...
-                    if (/^[A-Za-z]:/.test(tempFile)) {
-                        const driveLetter = tempFile.charAt(0).toLowerCase();
-                        filePathForCommand = tempFile.replace(/^[A-Za-z]:/, `/mnt/${driveLetter}`).replace(/\\/g, '/');
-                    } else {
-                        // If path doesn't start with drive letter, assume it's already Unix-style
-                        filePathForCommand = tempFile.replace(/\\/g, '/');
-                    }
-                }
-                
-                outputTextarea.value = `=== JLMol Julia Calculation ===\nTimestamp: ${new Date().toISOString()}\nJulia command: ${juliaCommand}\nTemporary file: ${tempFile}\n${isWSL ? `WSL path: ${filePathForCommand}\n` : ''}Full command: ${juliaCommand} "${filePathForCommand}"\n\n--- Starting calculation ---\n`;
-                document.getElementById('status').innerHTML = 'Starting Julia process...';
-                
-                // Prepare command and arguments for version check
-                let baseCommand, versionCheckArgs;
-                if (isWSL) {
-                    baseCommand = 'wsl';
-                    // The command is something like "wsl -d <distro> julia" or "wsl /path/to/julia"
-                    // commandParts[0] is "wsl", the rest are arguments for wsl.
-                    versionCheckArgs = [...commandParts.slice(1), '--version'];
-                } else if (commandParts.length > 1) {
-                    baseCommand = commandParts[0];
-                    versionCheckArgs = [...commandParts.slice(1), '--version'];
                 } else {
-                    baseCommand = juliaCommand;
-                    versionCheckArgs = ['--version'];
+                    current += char;
                 }
-                
-                // Check if Julia is available first
-                const juliaCheck = spawn(baseCommand, versionCheckArgs, { 
-                    stdio: ['pipe', 'pipe', 'pipe'],
-                    shell: isWSL ? false : true
-                });
-                
-                juliaCheck.on('error', (error) => {
-                    throw new Error(`Julia not found at "${juliaCommand}": ${error.message}\n\nPlease check your Julia command in Settings or install Julia and ensure it's accessible from command line.`);
-                });
-                
-                juliaCheck.on('close', (code) => {
-                    if (code !== 0) {
-                        throw new Error(`Julia version check failed with code ${code} for command "${juliaCommand}"`);
-                    }
-                    
-                    // Julia is available, proceed with calculation
-                    document.getElementById('status').innerHTML = 'Julia found, executing calculation...';
-                    
-                    // Prepare arguments for actual execution
-                    let execArgs;
-                    if (isWSL) {
-                        // The command is something like "wsl -d <distro> julia" or "wsl julia"
-                        // commandParts[0] is "wsl", the rest are arguments for wsl.
-                        execArgs = [...commandParts.slice(1), filePathForCommand];
-                    } else if (commandParts.length > 1) {
-                        execArgs = [...commandParts.slice(1), tempFile];
-                    } else {
-                        execArgs = [tempFile];
-                    }
-                    
-                    const juliaProcess = spawn(baseCommand, execArgs, {
-                        cwd: process.cwd(),
-                        stdio: ['pipe', 'pipe', 'pipe'],
-                        timeout: 300000, // 5 minute timeout
-                        shell: isWSL ? false : true
-                    });
-                    
-                    let output = '';
-                    let errorOutput = '';
-                    let startTime = Date.now();
-                    let outputBuffer = '';
-                    let lastUpdateTime = Date.now();
-                    
-                    // Function to update UI with buffered output (throttled)
-                    function updateOutput() {
-                        if (outputBuffer.length > 0) {
-                            outputTextarea.value += outputBuffer;
-                            outputBuffer = '';
-                            outputTextarea.scrollTop = outputTextarea.scrollHeight;
-                        }
-                    }
-                    
-                    juliaProcess.stdout.on('data', (data) => {
-                        const text = data.toString();
-                        output += text;
-                        outputBuffer += text;
-                        
-                        // Update UI every 100ms to prevent freezing
-                        const now = Date.now();
-                        if (now - lastUpdateTime > 100) {
-                            updateOutput();
-                            lastUpdateTime = now;
-                            
-                            // Update status with progress indication
-                            const elapsed = ((now - startTime) / 1000).toFixed(1);
-                            document.getElementById('status').innerHTML = `Calculation running... (${elapsed}s)`;
-                        }
-                    });
-                    
-                    juliaProcess.stderr.on('data', (data) => {
-                        const text = data.toString();
-                        errorOutput += text;
-                        
-                        // Only show actual errors in STDERR, not just warnings
-                        if (text.toLowerCase().includes('error') || text.toLowerCase().includes('exception')) {
-                            outputTextarea.value += `\n[ERROR] ${text}`;
-                        } else {
-                            outputTextarea.value += `[INFO] ${text}`;
-                        }
-                        outputTextarea.scrollTop = outputTextarea.scrollHeight;
-                    });
-                    
-                    juliaProcess.on('close', (code) => {
-                        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-                        
-                        // Clean up temporary file
-                        cleanupTempFile();
-                        outputTextarea.value += `\n--- Cleanup: Temporary file deleted ---\n`;
-                        
-                        if (code === 0) {
-                            outputTextarea.value += `\n=== CALCULATION COMPLETED SUCCESSFULLY ===\nElapsed time: ${elapsed} seconds\nExit code: ${code}`;
-                            document.getElementById('status').innerHTML = `Julia calculation completed successfully (${elapsed}s)`;
-                        } else {
-                            outputTextarea.value += `\n=== CALCULATION FAILED ===\nElapsed time: ${elapsed} seconds\nExit code: ${code}\n\nCheck the output above for error details.`;
-                            document.getElementById('status').innerHTML = `Julia calculation failed with exit code ${code}`;
-                        }
-                        outputTextarea.scrollTop = outputTextarea.scrollHeight;
-                    });
-                    
-                    juliaProcess.on('error', (error) => {
-                        // Clean up temporary file on error
-                        cleanupTempFile();
-                        
-                        const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-                        outputTextarea.value += `\n=== PROCESS ERROR ===\nElapsed time: ${elapsed} seconds\nError: ${error.message}\n\nTroubleshooting:\n- Check if Julia is properly installed\n- Verify the Julia command path in Settings\n- Ensure Julia has necessary permissions`;
-                        document.getElementById('status').innerHTML = `Julia process error: ${error.message}`;
-                        outputTextarea.scrollTop = outputTextarea.scrollHeight;
-                    });
-                });
-                
-            } catch (error) {
-                const isWSL = prefs.juliaCommand && prefs.juliaCommand.trim().toLowerCase().startsWith('wsl');
-                const wslTroubleshooting = isWSL ? `\n\nWSL-specific troubleshooting:\n- Ensure WSL is installed and configured\n- Verify Julia is installed in your WSL distribution\n- Try running 'wsl julia --version' in Command Prompt/PowerShell\n- Make sure the WSL distribution has access to the temp directory\n- Consider using the full path to Julia in WSL (e.g., 'wsl /usr/local/bin/julia')` : '';
-                
-                outputTextarea.value = `=== EXECUTION ERROR ===\n${error.message}\n\nTroubleshooting:\n1. Install Julia from https://julialang.org/downloads/\n2. Add Julia to your system PATH or configure the correct path in Settings\n3. Current Julia command: "${prefs.juliaCommand}"\n4. Install ElemCo.jl package:\n   ${prefs.juliaCommand}> import Pkg; Pkg.add("ElemCo")\n5. Verify installation by running '${prefs.juliaCommand} --version' in terminal\n6. Ensure you have write permissions to temp directory${wslTroubleshooting}\n\nFor more help, see: https://docs.julialang.org/en/v1/manual/getting-started/`;
-                document.getElementById('status').innerHTML = 'Julia execution failed - see output for troubleshooting';
+            }
+            
+            if (current.trim()) {
+                parts.push(current.trim());
+            }
+            
+            return parts;
+        }
+        
+        const commandParts = parseCommand(juliaCommand.trim());
+        const isWSL = commandParts[0].toLowerCase() === 'wsl';
+        
+        // Create temporary file for Julia code
+        const tempDir = os.tmpdir();
+        tempFile = path.join(tempDir, `jlmol_calculation_${Date.now()}.jl`);
+        fs.writeFileSync(tempFile, juliaCode);
+        
+        // For WSL, convert Windows path to WSL path
+        let filePathForCommand = tempFile;
+        if (isWSL) {
+            // Convert Windows path to WSL path format
+            // Handle both uppercase and lowercase drive letters
+            // e.g., C:\Users\... or c:\Users\... -> /mnt/c/Users/...
+            if (/^[A-Za-z]:/.test(tempFile)) {
+                const driveLetter = tempFile.charAt(0).toLowerCase();
+                filePathForCommand = tempFile.replace(/^[A-Za-z]:/, `/mnt/${driveLetter}`).replace(/\\/g, '/');
+            } else {
+                // If path doesn't start with drive letter, assume it's already Unix-style
+                filePathForCommand = tempFile.replace(/\\/g, '/');
             }
         }
         
-        // Function to show instructions for browser environment
-        function showJuliaInstructions(juliaCode) {
-            const outputTextarea = document.getElementById('julia-output');
+        outputTextarea.value = `=== JLMol Julia Calculation ===\nTimestamp: ${new Date().toISOString()}\nJulia command: ${juliaCommand}\nTemporary file: ${tempFile}\n${isWSL ? `WSL path: ${filePathForCommand}\n` : ''}Full command: ${juliaCommand} "${filePathForCommand}"\n\n--- Starting calculation ---\n`;
+        document.getElementById('status').innerHTML = 'Starting Julia process...';
+        
+        // Prepare command and arguments for version check
+        let baseCommand, versionCheckArgs;
+        if (isWSL) {
+            baseCommand = 'wsl';
+            // The command is something like "wsl -d <distro> julia" or "wsl /path/to/julia"
+            // commandParts[0] is "wsl", the rest are arguments for wsl.
+            versionCheckArgs = [...commandParts.slice(1), '--version'];
+        } else if (commandParts.length > 1) {
+            baseCommand = commandParts[0];
+            versionCheckArgs = [...commandParts.slice(1), '--version'];
+        } else {
+            baseCommand = juliaCommand;
+            versionCheckArgs = ['--version'];
+        }
+        
+        // Check if Julia is available first
+        const juliaCheck = spawn(baseCommand, versionCheckArgs, { 
+            stdio: ['pipe', 'pipe', 'pipe'],
+            shell: isWSL ? false : true
+        });
+        
+        juliaCheck.on('error', (error) => {
+            throw new Error(`Julia not found at "${juliaCommand}": ${error.message}\n\nPlease check your Julia command in Settings or install Julia and ensure it's accessible from command line.`);
+        });
+        
+        juliaCheck.on('close', (code) => {
+            if (code !== 0) {
+                throw new Error(`Julia version check failed with code ${code} for command "${juliaCommand}"`);
+            }
             
-            outputTextarea.value = `=== JLMol Browser Mode ===
+            // Julia is available, proceed with calculation
+            document.getElementById('status').innerHTML = 'Julia found, executing calculation...';
+            
+            // Prepare arguments for actual execution
+            let execArgs;
+            if (isWSL) {
+                // The command is something like "wsl -d <distro> julia" or "wsl julia"
+                // commandParts[0] is "wsl", the rest are arguments for wsl.
+                execArgs = [...commandParts.slice(1), filePathForCommand];
+            } else if (commandParts.length > 1) {
+                execArgs = [...commandParts.slice(1), tempFile];
+            } else {
+                execArgs = [tempFile];
+            }
+            
+            const juliaProcess = spawn(baseCommand, execArgs, {
+                cwd: process.cwd(),
+                stdio: ['pipe', 'pipe', 'pipe'],
+                timeout: 300000, // 5 minute timeout
+                shell: isWSL ? false : true
+            });
+            
+            let output = '';
+            let errorOutput = '';
+            let startTime = Date.now();
+            let outputBuffer = '';
+            let lastUpdateTime = Date.now();
+            
+            // Function to update UI with buffered output (throttled)
+            function updateOutput() {
+                if (outputBuffer.length > 0) {
+                    outputTextarea.value += outputBuffer;
+                    outputBuffer = '';
+                    outputTextarea.scrollTop = outputTextarea.scrollHeight;
+                }
+            }
+            
+            juliaProcess.stdout.on('data', (data) => {
+                const text = data.toString();
+                output += text;
+                outputBuffer += text;
+                
+                // Update UI every 100ms to prevent freezing
+                const now = Date.now();
+                if (now - lastUpdateTime > 100) {
+                    updateOutput();
+                    lastUpdateTime = now;
+                    
+                    // Update status with progress indication
+                    const elapsed = ((now - startTime) / 1000).toFixed(1);
+                    document.getElementById('status').innerHTML = `Calculation running... (${elapsed}s)`;
+                }
+            });
+            
+            juliaProcess.stderr.on('data', (data) => {
+                const text = data.toString();
+                errorOutput += text;
+                
+                // Only show actual errors in STDERR, not just warnings
+                if (text.toLowerCase().includes('error') || text.toLowerCase().includes('exception')) {
+                    outputTextarea.value += `\n[ERROR] ${text}`;
+                } else {
+                    outputTextarea.value += `[INFO] ${text}`;
+                }
+                outputTextarea.scrollTop = outputTextarea.scrollHeight;
+            });
+            
+            juliaProcess.on('close', (code) => {
+                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+                
+                // Clean up temporary file
+                cleanupTempFile();
+                outputTextarea.value += `\n--- Cleanup: Temporary file deleted ---\n`;
+                
+                if (code === 0) {
+                    outputTextarea.value += `\n=== CALCULATION COMPLETED SUCCESSFULLY ===\nElapsed time: ${elapsed} seconds\nExit code: ${code}`;
+                    document.getElementById('status').innerHTML = `Julia calculation completed successfully (${elapsed}s)`;
+                } else {
+                    outputTextarea.value += `\n=== CALCULATION FAILED ===\nElapsed time: ${elapsed} seconds\nExit code: ${code}\n\nCheck the output above for error details.`;
+                    document.getElementById('status').innerHTML = `Julia calculation failed with exit code ${code}`;
+                }
+                outputTextarea.scrollTop = outputTextarea.scrollHeight;
+            });
+            
+            juliaProcess.on('error', (error) => {
+                // Clean up temporary file on error
+                cleanupTempFile();
+                
+                const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+                outputTextarea.value += `\n=== PROCESS ERROR ===\nElapsed time: ${elapsed} seconds\nError: ${error.message}\n\nTroubleshooting:\n- Check if Julia is properly installed\n- Verify the Julia command path in Settings\n- Ensure Julia has necessary permissions`;
+                document.getElementById('status').innerHTML = `Julia process error: ${error.message}`;
+                outputTextarea.scrollTop = outputTextarea.scrollHeight;
+            });
+        });
+        
+    } catch (error) {
+        const isWSL = prefs.juliaCommand && prefs.juliaCommand.trim().toLowerCase().startsWith('wsl');
+        const wslTroubleshooting = isWSL ? `\n\nWSL-specific troubleshooting:\n- Ensure WSL is installed and configured\n- Verify Julia is installed in your WSL distribution\n- Try running 'wsl julia --version' in Command Prompt/PowerShell\n- Make sure the WSL distribution has access to the temp directory\n- Consider using the full path to Julia in WSL (e.g., 'wsl /usr/local/bin/julia')` : '';
+        
+        outputTextarea.value = `=== EXECUTION ERROR ===\n${error.message}\n\nTroubleshooting:\n1. Install Julia from https://julialang.org/downloads/\n2. Add Julia to your system PATH or configure the correct path in Settings\n3. Current Julia command: "${prefs.juliaCommand}"\n4. Install ElemCo.jl package:\n   ${prefs.juliaCommand}> import Pkg; Pkg.add("ElemCo")\n5. Verify installation by running '${prefs.juliaCommand} --version' in terminal\n6. Ensure you have write permissions to temp directory${wslTroubleshooting}\n\nFor more help, see: https://docs.julialang.org/en/v1/manual/getting-started/`;
+        document.getElementById('status').innerHTML = 'Julia execution failed - see output for troubleshooting';
+    }
+}
+
+// Function to show instructions for browser environment
+function showJuliaInstructions(juliaCode) {
+    const outputTextarea = document.getElementById('julia-output');
+    
+    outputTextarea.value = `=== JLMol Browser Mode ===
 Running calculations directly from the browser is not supported for security reasons.
 
 OPTION 1: Use the Desktop Version
@@ -841,20 +841,20 @@ For detailed documentation, visit: https://elem.co.il
 Note: The desktop version of JLMol provides seamless Julia integration
 and eliminates the need for manual steps.`;
 
-            document.getElementById('status').innerHTML = 'Manual execution instructions provided';
-        }
+    document.getElementById('status').innerHTML = 'Manual execution instructions provided';
+}
 
-        // Function to clear calculation output
-        function clearJuliaOutput() {
-            const outputTextarea = document.getElementById('julia-output');
-            const outputSection = document.getElementById('julia-output-section');
-            
-            if (outputTextarea) {
-                outputTextarea.value = '';
-            }
-            if (outputSection) {
-                outputSection.style.display = 'none';
-            }
-            document.getElementById('status').innerHTML = 'Calculation output cleared';
-        }
+// Function to clear calculation output
+function clearJuliaOutput() {
+    const outputTextarea = document.getElementById('julia-output');
+    const outputSection = document.getElementById('julia-output-section');
+    
+    if (outputTextarea) {
+        outputTextarea.value = '';
+    }
+    if (outputSection) {
+        outputSection.style.display = 'none';
+    }
+    document.getElementById('status').innerHTML = 'Calculation output cleared';
+}
 

--- a/js/image-export.js
+++ b/js/image-export.js
@@ -1,104 +1,104 @@
-        // Function to export the current view as an image
-        function exportImage() {
-            try {
-                // Get user preferences for export format and transparency
-                const prefs = getPreferences();
-                const exportFormat = prefs.exportFormat || 'png';
-                const useTransparentBackground = prefs.exportTransparentBackground !== false;
-                
-                // Handle background setting for exports that need white background
-                const needsWhiteBackground = exportFormat === 'jpg' || (exportFormat === 'png' && !useTransparentBackground);
-                let currentBg = null;
-                
-                if (needsWhiteBackground) {
-                    currentBg = Jmol.evaluateVar(jmolApplet0, "background");
-                    Jmol.script(jmolApplet0, "background white");
-                }
-                
-                // Get the image data from JSmol
-                // Note: JSmol.getPropertyAsString with "image" returns JPEG data
-                var imageData = Jmol.getPropertyAsString(jmolApplet0, "image");
-                
-                // Restore original background if it was changed
-                if (currentBg !== null) {
-                    Jmol.script(jmolApplet0, `background ${currentBg}`);
-                }
-                
-                // Convert to proper data URL if needed
-                if (!imageData.startsWith('data:')) {
-                    imageData = 'data:image/jpeg;base64,' + imageData;
-                }
-                
-                // Handle format conversion
-                if (exportFormat === 'png') {
-                    // Convert JPEG to PNG for proper format and transparency support
-                    convertAndDownload(imageData, 'png', useTransparentBackground);
-                } else {
-                    // Direct JPEG download
-                    downloadImage(imageData, 'molecule.jpg', 'jpg', false);
-                }
-                
-            } catch (err) {
-                document.getElementById('status').innerHTML = 'Error exporting image: ' + err.message;
-                console.error('Export error:', err);
-            }
+// Function to export the current view as an image
+function exportImage() {
+    try {
+        // Get user preferences for export format and transparency
+        const prefs = getPreferences();
+        const exportFormat = prefs.exportFormat || 'png';
+        const useTransparentBackground = prefs.exportTransparentBackground !== false;
+        
+        // Handle background setting for exports that need white background
+        const needsWhiteBackground = exportFormat === 'jpg' || (exportFormat === 'png' && !useTransparentBackground);
+        let currentBg = null;
+        
+        if (needsWhiteBackground) {
+            currentBg = Jmol.evaluateVar(jmolApplet0, "background");
+            Jmol.script(jmolApplet0, "background white");
         }
         
-        // Convert image format and handle transparency
-        function convertAndDownload(jpegDataUrl, targetFormat, useTransparent) {
-            const canvas = document.createElement('canvas');
-            const ctx = canvas.getContext('2d');
-            const img = new Image();
-            
-            img.onload = function() {
-                canvas.width = img.width;
-                canvas.height = img.height;
-                
-                // For PNG with white background, fill canvas with white first
-                if (targetFormat === 'png' && !useTransparent) {
-                    ctx.fillStyle = 'white';
-                    ctx.fillRect(0, 0, canvas.width, canvas.height);
-                }
-                // For transparent PNG, we leave canvas transparent (default)
-                
-                // Draw the image
-                ctx.drawImage(img, 0, 0);
-                
-                // Convert to target format
-                let outputData;
-                if (targetFormat === 'png') {
-                    outputData = canvas.toDataURL('image/png');
-                } else {
-                    outputData = canvas.toDataURL('image/jpeg', 0.9);
-                }
-                
-                const filename = `molecule.${targetFormat}`;
-                downloadImage(outputData, filename, targetFormat, useTransparent);
-            };
-            
-            img.src = jpegDataUrl;
+        // Get the image data from JSmol
+        // Note: JSmol.getPropertyAsString with "image" returns JPEG data
+        var imageData = Jmol.getPropertyAsString(jmolApplet0, "image");
+        
+        // Restore original background if it was changed
+        if (currentBg !== null) {
+            Jmol.script(jmolApplet0, `background ${currentBg}`);
         }
         
-        // Helper function to handle the actual download
-        function downloadImage(imageData, filename, format, transparent) {
-            // Create a temporary link element
-            var link = document.createElement('a');
-            link.href = imageData;
-            link.download = filename;
-            
-            // This is required for Firefox
-            link.target = '_blank';
-            
-            // Append to body, click, and remove
-            document.body.appendChild(link);
-            link.click();
-            
-            // Small delay before removing the link to ensure the download starts
-            setTimeout(() => {
-                document.body.removeChild(link);
-            }, 100);
-            
-            const transparencyNote = (format === 'png' && transparent) ? ' with transparent background' : '';
-            document.getElementById('status').innerHTML = `${format.toUpperCase()} image exported successfully${transparencyNote}`;
+        // Convert to proper data URL if needed
+        if (!imageData.startsWith('data:')) {
+            imageData = 'data:image/jpeg;base64,' + imageData;
         }
+        
+        // Handle format conversion
+        if (exportFormat === 'png') {
+            // Convert JPEG to PNG for proper format and transparency support
+            convertAndDownload(imageData, 'png', useTransparentBackground);
+        } else {
+            // Direct JPEG download
+            downloadImage(imageData, 'molecule.jpg', 'jpg', false);
+        }
+        
+    } catch (err) {
+        document.getElementById('status').innerHTML = 'Error exporting image: ' + err.message;
+        console.error('Export error:', err);
+    }
+}
+
+// Convert image format and handle transparency
+function convertAndDownload(jpegDataUrl, targetFormat, useTransparent) {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    
+    img.onload = function() {
+        canvas.width = img.width;
+        canvas.height = img.height;
+        
+        // For PNG with white background, fill canvas with white first
+        if (targetFormat === 'png' && !useTransparent) {
+            ctx.fillStyle = 'white';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+        }
+        // For transparent PNG, we leave canvas transparent (default)
+        
+        // Draw the image
+        ctx.drawImage(img, 0, 0);
+        
+        // Convert to target format
+        let outputData;
+        if (targetFormat === 'png') {
+            outputData = canvas.toDataURL('image/png');
+        } else {
+            outputData = canvas.toDataURL('image/jpeg', 0.9);
+        }
+        
+        const filename = `molecule.${targetFormat}`;
+        downloadImage(outputData, filename, targetFormat, useTransparent);
+    };
+    
+    img.src = jpegDataUrl;
+}
+
+// Helper function to handle the actual download
+function downloadImage(imageData, filename, format, transparent) {
+    // Create a temporary link element
+    var link = document.createElement('a');
+    link.href = imageData;
+    link.download = filename;
+    
+    // This is required for Firefox
+    link.target = '_blank';
+    
+    // Append to body, click, and remove
+    document.body.appendChild(link);
+    link.click();
+    
+    // Small delay before removing the link to ensure the download starts
+    setTimeout(() => {
+        document.body.removeChild(link);
+    }, 100);
+    
+    const transparencyNote = (format === 'png' && transparent) ? ' with transparent background' : '';
+    document.getElementById('status').innerHTML = `${format.toUpperCase()} image exported successfully${transparencyNote}`;
+}
 

--- a/js/jsme-2d.js
+++ b/js/jsme-2d.js
@@ -1,284 +1,284 @@
-        var jsmeApplet;
-        var is3D = true;
-        var lastMolFile = null;
+var jsmeApplet;
+var is3D = true;
+var lastMolFile = null;
 
-        // JSME initialization and conversion functions
-        function convertJsmolToJSME(callback) {
-            try {
-                debugLog('Starting JSmol to JSME conversion');
-                
-                // Ensure we're working with the latest structure data
-                Jmol.script(jmolApplet0, 'select all; set atomNameFormat user');
-                
-                // First try to get a 2D MOL file
-                let molData = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                
-                debugLog('Initial MOL data length:', molData ? molData.length : 0);
-                
-                // If we got valid MOL data, try to clean it up
-                if (molData && molData.includes('V2000')) {
-                    // Ensure proper line endings
-                    molData = molData.replace(/\r?\n/g, '\n');
-                    
-                    // Add implicit hydrogens and clean up structure
-                    Jmol.script(jmolApplet0, 'select all; set addHydrogens true');
-                    let cleanMolData = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                    
-                    // Use the cleaned version if it's valid
-                    if (cleanMolData && cleanMolData.includes('V2000')) {
-                        molData = cleanMolData;
-                        debugLog('Using cleaned MOL data, length:', molData.length);
-                    }
-                    
-                    callback(molData);
-                } else {
-                    console.error('Failed to get valid MOL data from JSmol');
-                    document.getElementById('status').innerHTML = 'Error: Could not convert 3D structure to 2D';
-                    debugLog('Conversion failed - no valid MOL data');
-                }
-            } catch (e) {
-                console.error('Error converting JSmol to JSME:', e);
-                document.getElementById('status').innerHTML = 'Error converting structure';
-                debugLog('Conversion error:', e.message);
+// JSME initialization and conversion functions
+function convertJsmolToJSME(callback) {
+    try {
+        debugLog('Starting JSmol to JSME conversion');
+        
+        // Ensure we're working with the latest structure data
+        Jmol.script(jmolApplet0, 'select all; set atomNameFormat user');
+        
+        // First try to get a 2D MOL file
+        let molData = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+        
+        debugLog('Initial MOL data length:', molData ? molData.length : 0);
+        
+        // If we got valid MOL data, try to clean it up
+        if (molData && molData.includes('V2000')) {
+            // Ensure proper line endings
+            molData = molData.replace(/\r?\n/g, '\n');
+            
+            // Add implicit hydrogens and clean up structure
+            Jmol.script(jmolApplet0, 'select all; set addHydrogens true');
+            let cleanMolData = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+            
+            // Use the cleaned version if it's valid
+            if (cleanMolData && cleanMolData.includes('V2000')) {
+                molData = cleanMolData;
+                debugLog('Using cleaned MOL data, length:', molData.length);
+            }
+            
+            callback(molData);
+        } else {
+            console.error('Failed to get valid MOL data from JSmol');
+            document.getElementById('status').innerHTML = 'Error: Could not convert 3D structure to 2D';
+            debugLog('Conversion failed - no valid MOL data');
+        }
+    } catch (e) {
+        console.error('Error converting JSmol to JSME:', e);
+        document.getElementById('status').innerHTML = 'Error converting structure';
+        debugLog('Conversion error:', e.message);
+    }
+}
+
+function initJSME(container, width, height, molFile = null) {
+    // Create new JSME instance with explicit size
+    const jsmeInstance = new JSApplet.JSME(container, width + "px", height + "px", {
+        "options": "oldlook,star"
+    });
+
+    // Define structure change handler
+    const handleStructureChange = function() {
+        if (jsmeInstance && typeof jsmeInstance.molFile === 'function' && !is3D) {
+            const currentMol = jsmeInstance.molFile();
+            if (currentMol && currentMol.includes('V2000')) {
+                lastMolFile = currentMol;
+                // Directly load into JSmol in background
+                Jmol.script(jmolApplet0, `set echo top left; echo "2D structure modified"`);
+                Jmol.script(jmolApplet0, `load inline "${currentMol}" background`);
             }
         }
+    };
 
-        function initJSME(container, width, height, molFile = null) {
-            // Create new JSME instance with explicit size
-            const jsmeInstance = new JSApplet.JSME(container, width + "px", height + "px", {
-                "options": "oldlook,star"
-            });
+    // Add direct event listener for structure changes
+    jsmeInstance.options.onChange = handleStructureChange;
+    
+    // Store handler for cleanup
+    jsmeInstance._changeHandler = handleStructureChange;
 
-            // Define structure change handler
-            const handleStructureChange = function() {
-                if (jsmeInstance && typeof jsmeInstance.molFile === 'function' && !is3D) {
-                    const currentMol = jsmeInstance.molFile();
-                    if (currentMol && currentMol.includes('V2000')) {
-                        lastMolFile = currentMol;
-                        // Directly load into JSmol in background
-                        Jmol.script(jmolApplet0, `set echo top left; echo "2D structure modified"`);
-                        Jmol.script(jmolApplet0, `load inline "${currentMol}" background`);
-                    }
-                }
-            };
+    // Load initial molecule if provided
+    if (molFile && typeof jsmeInstance.readMolFile === 'function') {
+        setTimeout(() => {
+            jsmeInstance.readMolFile(molFile);
+            // Store initial state
+            lastMolFile = jsmeInstance.molFile();
+        }, 100);
+    }
 
-            // Add direct event listener for structure changes
-            jsmeInstance.options.onChange = handleStructureChange;
-            
-            // Store handler for cleanup
-            jsmeInstance._changeHandler = handleStructureChange;
+    return jsmeInstance;
+}
 
-            // Load initial molecule if provided
-            if (molFile && typeof jsmeInstance.readMolFile === 'function') {
+// Cleanup function for JSME with better resource management
+function cleanupJSME() {
+    if (jsmeApplet) {
+        try {
+            if (jsmeApplet.options) {
+                jsmeApplet.options.onChange = null;
+            }
+            if (jsmeApplet._changeHandler) {
+                delete jsmeApplet._changeHandler;
+            }
+            // More thorough cleanup
+            if (typeof jsmeApplet.destroy === 'function') {
+                jsmeApplet.destroy();
+            }
+        } catch (e) {
+            console.error('Error cleaning up JSME:', e);
+        }
+        
+        // Clear the container
+        const container = document.getElementById('jsmeContainer');
+        if (container) {
+            container.innerHTML = '';
+        }
+        jsmeApplet = null;
+    }
+}
+
+// Utility function to refresh JSME editor with current JSmol structure
+function refreshJSMEFromJSmol() {
+    if (!is3D && jsmeApplet) {
+        debugLog('Refreshing JSME editor with current JSmol structure');
+        convertJsmolToJSME(molFile => {
+            if (molFile && jsmeApplet && typeof jsmeApplet.readMolFile === 'function') {
+                jsmeApplet.readMolFile(molFile);
+                lastMolFile = molFile;
+                debugLog('JSME editor refreshed with new structure data');
+            }
+        });
+    }
+}
+
+// Update toggle2D3D function
+function toggle2D3D() {
+    // Check if there's a molecule loaded by getting XYZ data
+    const xyzData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")');
+    const atomCount = xyzData ? parseInt(xyzData.split('\n')[0]) : 0;
+
+    // If we're in 3D mode and there's no structure, just switch to 2D with empty editor
+    if (is3D && atomCount === 0) {
+        is3D = false;
+        const viewer = document.getElementById('viewer');
+        const jsmeContainer = document.getElementById('jsmeContainer');
+        const button = document.getElementById('toggle2D3DButton');
+        
+        cleanupJSME();
+        jsmeContainer.style.display = 'block';
+        viewer.style.display = 'none';
+        button.textContent = '3D Viewer';
+        
+        const width = jsmeContainer.offsetWidth;
+        const height = jsmeContainer.offsetHeight;
+        if (width > 0 && height > 0) {
+            jsmeApplet = initJSME("jsmeContainer", width, height);
+        }
+        return;
+    }
+
+    is3D = !is3D;
+    const viewer = document.getElementById('viewer');
+    const jsmeContainer = document.getElementById('jsmeContainer');
+    const button = document.getElementById('toggle2D3DButton');
+
+    if (is3D) {
+        // Switch to 3D (JSmol)
+        if (jsmeApplet && typeof jsmeApplet.molFile === 'function') {
+            let molFile = jsmeApplet.molFile();
+            if (molFile) {
+                cleanupJSME(); // Cleanup old JSME instance
+                jsmeContainer.style.display = 'none';
+                viewer.style.display = 'block';
+                
+                // Get dimensions before switching
+                const width = viewer.offsetWidth;
+                const height = viewer.offsetHeight;
+                
                 setTimeout(() => {
-                    jsmeInstance.readMolFile(molFile);
-                    // Store initial state
-                    lastMolFile = jsmeInstance.molFile();
+                    // Set canvas dimensions
+                    const canvas = document.querySelector('#viewer-inner canvas');
+                    if (canvas) {
+                        canvas.style.width = width + 'px';
+                        canvas.style.height = height + 'px';
+                        canvas.width = width;
+                        canvas.height = height;
+                    }
+                    
+                    // Load the structure and optimize
+                    lastMolFile = molFile;
+                    Jmol.script(jmolApplet0, `load inline "${molFile}"; select all; minimize`);
+                    
+                    // Restore the last used display mode
+                    setTimeout(() => {
+                        setDisplayMode(displayMode || 'default');
+                        
+                        // Apply all JSmol preferences after 2D to 3D conversion
+                        if (typeof applyJSmolPreferences === 'function') {
+                            applyJSmolPreferences();
+                            console.log('toggle2D3D: Applied JSmol preferences after 2D to 3D conversion');
+                        }
+                        
+                        if (width > 0 && height > 0) {
+                            Jmol.resizeApplet(jmolApplet0, [width, height]);
+                        }
+                        document.getElementById('status').innerHTML = '3D structure generated successfully';
+                    }, 100);
                 }, 100);
             }
-
-            return jsmeInstance;
         }
-
-        // Cleanup function for JSME with better resource management
-        function cleanupJSME() {
-            if (jsmeApplet) {
-                try {
-                    if (jsmeApplet.options) {
-                        jsmeApplet.options.onChange = null;
-                    }
-                    if (jsmeApplet._changeHandler) {
-                        delete jsmeApplet._changeHandler;
-                    }
-                    // More thorough cleanup
-                    if (typeof jsmeApplet.destroy === 'function') {
-                        jsmeApplet.destroy();
-                    }
-                } catch (e) {
-                    console.error('Error cleaning up JSME:', e);
-                }
+    } else {
+        // Switch to 2D (JSME) - only try to convert if there's a structure
+        if (atomCount > 0) {
+            // Force refresh of JSmol structure to get latest data
+            Jmol.script(jmolApplet0, 'select all; refresh');
+            
+            // Always perform fresh conversion from current JSmol state
+            convertJsmolToJSME(molFile => {
+                debugLog('Converting to 2D with fresh MOL data length:', molFile ? molFile.length : 0);
                 
-                // Clear the container
-                const container = document.getElementById('jsmeContainer');
-                if (container) {
-                    container.innerHTML = '';
-                }
-                jsmeApplet = null;
-            }
-        }
-
-        // Utility function to refresh JSME editor with current JSmol structure
-        function refreshJSMEFromJSmol() {
-            if (!is3D && jsmeApplet) {
-                debugLog('Refreshing JSME editor with current JSmol structure');
-                convertJsmolToJSME(molFile => {
-                    if (molFile && jsmeApplet && typeof jsmeApplet.readMolFile === 'function') {
-                        jsmeApplet.readMolFile(molFile);
-                        lastMolFile = molFile;
-                        debugLog('JSME editor refreshed with new structure data');
-                    }
-                });
-            }
-        }
-
-        // Update toggle2D3D function
-        function toggle2D3D() {
-            // Check if there's a molecule loaded by getting XYZ data
-            const xyzData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")');
-            const atomCount = xyzData ? parseInt(xyzData.split('\n')[0]) : 0;
-
-            // If we're in 3D mode and there's no structure, just switch to 2D with empty editor
-            if (is3D && atomCount === 0) {
-                is3D = false;
-                const viewer = document.getElementById('viewer');
-                const jsmeContainer = document.getElementById('jsmeContainer');
-                const button = document.getElementById('toggle2D3DButton');
-                
-                cleanupJSME();
-                jsmeContainer.style.display = 'block';
                 viewer.style.display = 'none';
-                button.textContent = '3D Viewer';
+                jsmeContainer.style.display = 'block';
+                jsmeContainer.innerHTML = ''; // Clear old instance
                 
-                const width = jsmeContainer.offsetWidth;
-                const height = jsmeContainer.offsetHeight;
-                if (width > 0 && height > 0) {
-                    jsmeApplet = initJSME("jsmeContainer", width, height);
-                }
-                return;
-            }
-
-            is3D = !is3D;
-            const viewer = document.getElementById('viewer');
-            const jsmeContainer = document.getElementById('jsmeContainer');
-            const button = document.getElementById('toggle2D3DButton');
-
-            if (is3D) {
-                // Switch to 3D (JSmol)
-                if (jsmeApplet && typeof jsmeApplet.molFile === 'function') {
-                    let molFile = jsmeApplet.molFile();
-                    if (molFile) {
-                        cleanupJSME(); // Cleanup old JSME instance
-                        jsmeContainer.style.display = 'none';
-                        viewer.style.display = 'block';
-                        
-                        // Get dimensions before switching
-                        const width = viewer.offsetWidth;
-                        const height = viewer.offsetHeight;
-                        
-                        setTimeout(() => {
-                            // Set canvas dimensions
-                            const canvas = document.querySelector('#viewer-inner canvas');
-                            if (canvas) {
-                                canvas.style.width = width + 'px';
-                                canvas.style.height = height + 'px';
-                                canvas.width = width;
-                                canvas.height = height;
-                            }
-                            
-                            // Load the structure and optimize
-                            lastMolFile = molFile;
-                            Jmol.script(jmolApplet0, `load inline "${molFile}"; select all; minimize`);
-                            
-                            // Restore the last used display mode
-                            setTimeout(() => {
-                                setDisplayMode(displayMode || 'default');
-                                
-                                // Apply all JSmol preferences after 2D to 3D conversion
-                                if (typeof applyJSmolPreferences === 'function') {
-                                    applyJSmolPreferences();
-                                    console.log('toggle2D3D: Applied JSmol preferences after 2D to 3D conversion');
-                                }
-                                
-                                if (width > 0 && height > 0) {
-                                    Jmol.resizeApplet(jmolApplet0, [width, height]);
-                                }
-                                document.getElementById('status').innerHTML = '3D structure generated successfully';
-                            }, 100);
-                        }, 100);
-                    }
-                }
-            } else {
-                // Switch to 2D (JSME) - only try to convert if there's a structure
-                if (atomCount > 0) {
-                    // Force refresh of JSmol structure to get latest data
-                    Jmol.script(jmolApplet0, 'select all; refresh');
-                    
-                    // Always perform fresh conversion from current JSmol state
-                    convertJsmolToJSME(molFile => {
-                        debugLog('Converting to 2D with fresh MOL data length:', molFile ? molFile.length : 0);
-                        
-                        viewer.style.display = 'none';
-                        jsmeContainer.style.display = 'block';
-                        jsmeContainer.innerHTML = ''; // Clear old instance
-                        
-                        setTimeout(() => {
-                            const width = jsmeContainer.offsetWidth;
-                            const height = jsmeContainer.offsetHeight;
-                            
-                            if (width > 0 && height > 0) {
-                                lastMolFile = molFile;
-                                jsmeApplet = initJSME("jsmeContainer", width, height, molFile);
-                                debugLog('JSME editor initialized with structure data');
-                            }
-                        }, 150);
-                    });
-                } else {
-                    // No structure in JSmol, just show empty 2D editor
-                    viewer.style.display = 'none';
-                    jsmeContainer.style.display = 'block';
-                    jsmeContainer.innerHTML = ''; // Clear old instance
-                    
+                setTimeout(() => {
                     const width = jsmeContainer.offsetWidth;
                     const height = jsmeContainer.offsetHeight;
+                    
                     if (width > 0 && height > 0) {
-                        jsmeApplet = initJSME("jsmeContainer", width, height);
+                        lastMolFile = molFile;
+                        jsmeApplet = initJSME("jsmeContainer", width, height, molFile);
+                        debugLog('JSME editor initialized with structure data');
                     }
-                }
-            }
+                }, 150);
+            });
+        } else {
+            // No structure in JSmol, just show empty 2D editor
+            viewer.style.display = 'none';
+            jsmeContainer.style.display = 'block';
+            jsmeContainer.innerHTML = ''; // Clear old instance
             
-            button.textContent = is3D ? '2D Editor' : '3D Viewer';
+            const width = jsmeContainer.offsetWidth;
+            const height = jsmeContainer.offsetHeight;
+            if (width > 0 && height > 0) {
+                jsmeApplet = initJSME("jsmeContainer", width, height);
+            }
         }
+    }
+    
+    button.textContent = is3D ? '2D Editor' : '3D Viewer';
+}
 
-        // Update window.jsmeOnLoad to use the new initJSME function
-        window.jsmeOnLoad = function() {
-            // Add delay and multiple retries for Electron with proper dependency checking
-            let attempts = 0;
-            const maxAttempts = 10;
-            
-            function tryInitJSME() {
-                attempts++;
-                const container = document.getElementById('jsmeContainer');
-                
-                if (!container) {
-                    if (attempts < maxAttempts) {
-                        setTimeout(tryInitJSME, 250);
-                    }
-                    return;
-                }
-                
-                const width = container.offsetWidth;
-                const height = container.offsetHeight;
-                
-                if (width > 0 && height > 0 && typeof JSApplet !== 'undefined' && JSApplet.JSME) {
-                    try {
-                        jsmeApplet = initJSME("jsmeContainer", width, height);
-                        console.log("JSME initialized successfully");
-                    } catch (e) {
-                        console.error("JSME init error:", e);
-                        if (attempts < maxAttempts) {
-                            setTimeout(tryInitJSME, 250);
-                        }
-                    }
-                } else {
-                    if (attempts < maxAttempts) {
-                        setTimeout(tryInitJSME, 250);
-                    } else {
-                        console.warn('JSME initialization failed: container not ready or JSApplet not loaded after', maxAttempts, 'attempts');
-                    }
+// Update window.jsmeOnLoad to use the new initJSME function
+window.jsmeOnLoad = function() {
+    // Add delay and multiple retries for Electron with proper dependency checking
+    let attempts = 0;
+    const maxAttempts = 10;
+    
+    function tryInitJSME() {
+        attempts++;
+        const container = document.getElementById('jsmeContainer');
+        
+        if (!container) {
+            if (attempts < maxAttempts) {
+                setTimeout(tryInitJSME, 250);
+            }
+            return;
+        }
+        
+        const width = container.offsetWidth;
+        const height = container.offsetHeight;
+        
+        if (width > 0 && height > 0 && typeof JSApplet !== 'undefined' && JSApplet.JSME) {
+            try {
+                jsmeApplet = initJSME("jsmeContainer", width, height);
+                console.log("JSME initialized successfully");
+            } catch (e) {
+                console.error("JSME init error:", e);
+                if (attempts < maxAttempts) {
+                    setTimeout(tryInitJSME, 250);
                 }
             }
+        } else {
+            if (attempts < maxAttempts) {
+                setTimeout(tryInitJSME, 250);
+            } else {
+                console.warn('JSME initialization failed: container not ready or JSApplet not loaded after', maxAttempts, 'attempts');
+            }
+        }
+    }
 
-            // Initial delay for Electron to ensure DOM is ready
-            tryInitJSME();
-        };
+    // Initial delay for Electron to ensure DOM is ready
+    tryInitJSME();
+};
 

--- a/js/jsmol-setup.js
+++ b/js/jsmol-setup.js
@@ -1,106 +1,106 @@
-        var jmolApplet0;
-        var isSpinning = false;
-        var displayMode = 'default'; // Track current display mode
-        var currentZoom = 100;
-        var isDragMinimize = false; // Track drag-minimize state
-        var Info = {
-            width: "100%",
-            height: "100%",
-            debug: false,
-            color: "0xFFFFFF",
-            use: "HTML5",
-            j2sPath: "jsmol/j2s",
-            addSelectionOptions: true,
-            serverURL: "https://jlmol.com/php/jsmol.php",
-            disableJ2SLoadMonitor: true,
-            disableInitialConsole: true,
-            allowJavaScript: true,
-            readyFunction: function(applet) {
-                jmolApplet0._ready = true;
-                console.log('JSmol initialization complete');
-                
-                // Set initial display mode after JSmol is ready
-                setTimeout(() => {
-                    if (displayMode === undefined || displayMode === null) {
-                        displayMode = 'default';
-                    }
-                    console.log('JSmol ready: Setting initial display mode to', displayMode);
-                    setDisplayMode(displayMode);
-                    
-                    // Apply JSmol preferences when ready
-                    if (typeof applyJSmolPreferences === 'function') {
-                        applyJSmolPreferences();
-                    }
-                    
-                    // Initialize MOL file data if there's already a structure loaded
-                    try {
-                        const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
-                        if (atomCount && atomCount > 0) {
-                            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                            debugLog('Init', 'Initialized lastMolFile on JSmol ready, length:', lastMolFile ? lastMolFile.length : 0);
-                        }
-                    } catch (initMolError) {
-                        console.error('Error initializing MOL file data on JSmol ready:', initMolError);
-                    }
-                }, 500);
-            },
-            script: "set debugScript off; set antialiasDisplay; set zoomLarge false; set picking ON; set pickCallback 'onJmolAtomPicked'; set loadStructCallback 'onJmolStructureLoaded'"
-        };
+var jmolApplet0;
+var isSpinning = false;
+var displayMode = 'default'; // Track current display mode
+var currentZoom = 100;
+var isDragMinimize = false; // Track drag-minimize state
+var Info = {
+    width: "100%",
+    height: "100%",
+    debug: false,
+    color: "0xFFFFFF",
+    use: "HTML5",
+    j2sPath: "jsmol/j2s",
+    addSelectionOptions: true,
+    serverURL: "https://jlmol.com/php/jsmol.php",
+    disableJ2SLoadMonitor: true,
+    disableInitialConsole: true,
+    allowJavaScript: true,
+    readyFunction: function(applet) {
+        jmolApplet0._ready = true;
+        console.log('JSmol initialization complete');
+        
+        // Set initial display mode after JSmol is ready
+        setTimeout(() => {
+            if (displayMode === undefined || displayMode === null) {
+                displayMode = 'default';
+            }
+            console.log('JSmol ready: Setting initial display mode to', displayMode);
+            setDisplayMode(displayMode);
+            
+            // Apply JSmol preferences when ready
+            if (typeof applyJSmolPreferences === 'function') {
+                applyJSmolPreferences();
+            }
+            
+            // Initialize MOL file data if there's already a structure loaded
+            try {
+                const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+                if (atomCount && atomCount > 0) {
+                    lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                    debugLog('Init', 'Initialized lastMolFile on JSmol ready, length:', lastMolFile ? lastMolFile.length : 0);
+                }
+            } catch (initMolError) {
+                console.error('Error initializing MOL file data on JSmol ready:', initMolError);
+            }
+        }, 500);
+    },
+    script: "set debugScript off; set antialiasDisplay; set zoomLarge false; set picking ON; set pickCallback 'onJmolAtomPicked'; set loadStructCallback 'onJmolStructureLoaded'"
+};
 
-        /*
-         * FIXES FOR ELEMCO.JL INTEGRATION WITH NUMBERED ATOMS
-         * 
-         * Problem: After using the XYZ editor with numbered atoms (N1, C2, C3, etc.), 
-         * the ElemCo integration button shows "# Please load a molecule first" instead 
-         * of generating proper Julia input code.
-         * 
-         * Root Cause: The getXYZDataWithNumberedAtoms() function was not properly 
-         * handling the case where numbered atom names were used after XYZ editor operations.
-         * 
-         * Implemented Fixes:
-         * 
-         * 1. Enhanced getXYZDataWithNumberedAtoms() function:
-         *    - Added comprehensive error handling and detailed logging
-         *    - Implemented multiple fallback strategies (4 different approaches)
-         *    - Added validation of coordinates and atom data at each step
-         *    - Proper handling of window.originalAtomNames variable
-         * 
-         * 2. Improved updateElemCoInput() function:
-         *    - Added detailed validation checks for XYZ data completeness
-         *    - Enhanced error messages for different failure scenarios
-         *    - Better logging for debugging molecular data issues
-         *    - Validation of atom count vs actual data lines
-         * 
-         * 3. Updated showElemCoPanel() function:
-         *    - Added multiple delayed molecular data refresh attempts
-         *    - Integrated forceRefreshMolecularData() for comprehensive refresh
-         *    - Enhanced diagnostic capabilities for troubleshooting
-         *    - Better error reporting for different failure modes
-         * 
-         * 4. Added refreshAtomNames() function:
-         *    - Maintains numbered atom names across operations
-         *    - Detects and preserves numbered atom patterns
-         *    - Reapplies atom names when needed
-         * 
-         * 5. Added forceRefreshMolecularData() function:
-         *    - Comprehensive molecular data refresh capability
-         *    - Combines atom name refresh with XYZ data retrieval
-         *    - Enhanced debugging and diagnostic information
-         * 
-         * 6. Fixed variable scope issues:
-         *    - Ensured originalAtomNames is accessible as window.originalAtomNames
-         *    - Maintained consistency between local and global variables
-         * 
-         * 7. Enhanced XYZ editor integration:
-         *    - updateStructure() now calls refreshAtomNames() after changes
-         *    - loadXYZWithNumberedAtoms() maintains atom names properly
-         *    - showXYZEditor() refreshes atom names before display
-         * 
-         * Test Workflow:
-         * 1. Load a molecule with numbered atoms (e.g., caffeine with N1, C2, C3, etc.)
-         * 2. Use the XYZ editor to modify coordinates
-         * 3. Apply changes in the XYZ editor
-         * 4. Open the ElemCo.jl integration panel
-         * 5. Verify that proper Julia code is generated with numbered atom names
-         */
+/*
+ * FIXES FOR ELEMCO.JL INTEGRATION WITH NUMBERED ATOMS
+ * 
+ * Problem: After using the XYZ editor with numbered atoms (N1, C2, C3, etc.), 
+ * the ElemCo integration button shows "# Please load a molecule first" instead 
+ * of generating proper Julia input code.
+ * 
+ * Root Cause: The getXYZDataWithNumberedAtoms() function was not properly 
+ * handling the case where numbered atom names were used after XYZ editor operations.
+ * 
+ * Implemented Fixes:
+ * 
+ * 1. Enhanced getXYZDataWithNumberedAtoms() function:
+ *    - Added comprehensive error handling and detailed logging
+ *    - Implemented multiple fallback strategies (4 different approaches)
+ *    - Added validation of coordinates and atom data at each step
+ *    - Proper handling of window.originalAtomNames variable
+ * 
+ * 2. Improved updateElemCoInput() function:
+ *    - Added detailed validation checks for XYZ data completeness
+ *    - Enhanced error messages for different failure scenarios
+ *    - Better logging for debugging molecular data issues
+ *    - Validation of atom count vs actual data lines
+ * 
+ * 3. Updated showElemCoPanel() function:
+ *    - Added multiple delayed molecular data refresh attempts
+ *    - Integrated forceRefreshMolecularData() for comprehensive refresh
+ *    - Enhanced diagnostic capabilities for troubleshooting
+ *    - Better error reporting for different failure modes
+ * 
+ * 4. Added refreshAtomNames() function:
+ *    - Maintains numbered atom names across operations
+ *    - Detects and preserves numbered atom patterns
+ *    - Reapplies atom names when needed
+ * 
+ * 5. Added forceRefreshMolecularData() function:
+ *    - Comprehensive molecular data refresh capability
+ *    - Combines atom name refresh with XYZ data retrieval
+ *    - Enhanced debugging and diagnostic information
+ * 
+ * 6. Fixed variable scope issues:
+ *    - Ensured originalAtomNames is accessible as window.originalAtomNames
+ *    - Maintained consistency between local and global variables
+ * 
+ * 7. Enhanced XYZ editor integration:
+ *    - updateStructure() now calls refreshAtomNames() after changes
+ *    - loadXYZWithNumberedAtoms() maintains atom names properly
+ *    - showXYZEditor() refreshes atom names before display
+ * 
+ * Test Workflow:
+ * 1. Load a molecule with numbered atoms (e.g., caffeine with N1, C2, C3, etc.)
+ * 2. Use the XYZ editor to modify coordinates
+ * 3. Apply changes in the XYZ editor
+ * 4. Open the ElemCo.jl integration panel
+ * 5. Verify that proper Julia code is generated with numbered atom names
+ */
 

--- a/js/molecule-data.js
+++ b/js/molecule-data.js
@@ -1,422 +1,422 @@
-        // Add variable to store XYZ data
-        var lastXYZData = null;
-        var originalAtomNames = null; // Store original numbered atom names
-        var originalXYZContent = null; // Store original XYZ file content
-        var shouldUseNumberedAtoms = false; // Flag to track if numbered atoms should be used (only for XYZ files)
-        
-        // Debug function to test MOL file export quality - call from console with: window.testMolExport()
-        window.testMolExport = function() {
-            console.log('=== MOL Export Test ===');
-            if (jmolApplet0 && jmolApplet0._ready) {
-                try {
-                    const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
-                    console.log('Atom count:', atomCount);
-                    
-                    if (atomCount > 0) {
-                        console.log('Testing MOL export before refreshAtomNames...');
-                        const molBefore = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                        console.log('MOL before - length:', molBefore ? molBefore.length : 'null');
-                        console.log('MOL before - valid:', !!(molBefore && molBefore.includes('V2000')));
-                        
-                        console.log('Calling refreshAtomNames...');
-                        refreshAtomNames();
-                        
-                        console.log('Testing MOL export after refreshAtomNames...');
-                        const molAfter = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                        console.log('MOL after - length:', molAfter ? molAfter.length : 'null');
-                        console.log('MOL after - valid:', !!(molAfter && molAfter.includes('V2000')));
-                        
-                        console.log('MOL data changed:', molBefore !== molAfter);
-                        
-                        if (molBefore !== molAfter) {
-                            console.log('=== MOL DATA CHANGED! ===');
-                            console.log('Before preview:', molBefore ? molBefore.substring(0, 200) : 'null');
-                            console.log('After preview:', molAfter ? molAfter.substring(0, 200) : 'null');
-                        }
-                    }
-                } catch (e) {
-                    console.error('Error in MOL export test:', e);
-                }
-            } else {
-                console.log('JSmol not ready');
-            }
-            console.log('=== End MOL Export Test ===');
-        };
-        
-        // Utility function to manage atom names consistently
-        function setOriginalAtomNames(names) {
-            originalAtomNames = names;
-            window.originalAtomNames = names; // Make sure it's accessible globally
-        }
-        
-        function clearOriginalAtomNames() {
-            originalAtomNames = null;
-            window.originalAtomNames = null;
-        }
-        
-        // Debug utility function
-        function debugLog(category, message, data = null) {
-            if (window.jlmolDebug) {
-                const timestamp = new Date().toISOString().substr(14, 9);
-                console.log(`[${timestamp}] ${category}: ${message}`, data ? data : '');
-            }
-        }
-        
-        // Add frame rate limiting to prevent excessive GPU usage
-        var lastFrameTime = 0;
-        var frameRateLimit = 60; // Max 60 FPS
-        var minFrameInterval = 1000 / frameRateLimit;
-        
-        function throttledRepaint(callback) {
-            var now = Date.now();
-            if (now - lastFrameTime >= minFrameInterval) {
-                lastFrameTime = now;
-                if (typeof callback === 'function') {
-                    callback();
-                }
-            }
-        }
+// Add variable to store XYZ data
+var lastXYZData = null;
+var originalAtomNames = null; // Store original numbered atom names
+var originalXYZContent = null; // Store original XYZ file content
+var shouldUseNumberedAtoms = false; // Flag to track if numbered atoms should be used (only for XYZ files)
 
-        // Custom XYZ loader that preserves numbered atom names
-        function loadXYZWithNumberedAtoms(xyzContent) {
-            try {
-                // Parse the XYZ content to extract atom names
-                const lines = xyzContent.trim().split('\n');
-                if (lines.length < 3) {
-                    throw new Error('Invalid XYZ format');
+// Debug function to test MOL file export quality - call from console with: window.testMolExport()
+window.testMolExport = function() {
+    console.log('=== MOL Export Test ===');
+    if (jmolApplet0 && jmolApplet0._ready) {
+        try {
+            const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+            console.log('Atom count:', atomCount);
+            
+            if (atomCount > 0) {
+                console.log('Testing MOL export before refreshAtomNames...');
+                const molBefore = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                console.log('MOL before - length:', molBefore ? molBefore.length : 'null');
+                console.log('MOL before - valid:', !!(molBefore && molBefore.includes('V2000')));
+                
+                console.log('Calling refreshAtomNames...');
+                refreshAtomNames();
+                
+                console.log('Testing MOL export after refreshAtomNames...');
+                const molAfter = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                console.log('MOL after - length:', molAfter ? molAfter.length : 'null');
+                console.log('MOL after - valid:', !!(molAfter && molAfter.includes('V2000')));
+                
+                console.log('MOL data changed:', molBefore !== molAfter);
+                
+                if (molBefore !== molAfter) {
+                    console.log('=== MOL DATA CHANGED! ===');
+                    console.log('Before preview:', molBefore ? molBefore.substring(0, 200) : 'null');
+                    console.log('After preview:', molAfter ? molAfter.substring(0, 200) : 'null');
+                }
+            }
+        } catch (e) {
+            console.error('Error in MOL export test:', e);
+        }
+    } else {
+        console.log('JSmol not ready');
+    }
+    console.log('=== End MOL Export Test ===');
+};
+
+// Utility function to manage atom names consistently
+function setOriginalAtomNames(names) {
+    originalAtomNames = names;
+    window.originalAtomNames = names; // Make sure it's accessible globally
+}
+
+function clearOriginalAtomNames() {
+    originalAtomNames = null;
+    window.originalAtomNames = null;
+}
+
+// Debug utility function
+function debugLog(category, message, data = null) {
+    if (window.jlmolDebug) {
+        const timestamp = new Date().toISOString().substr(14, 9);
+        console.log(`[${timestamp}] ${category}: ${message}`, data ? data : '');
+    }
+}
+
+// Add frame rate limiting to prevent excessive GPU usage
+var lastFrameTime = 0;
+var frameRateLimit = 60; // Max 60 FPS
+var minFrameInterval = 1000 / frameRateLimit;
+
+function throttledRepaint(callback) {
+    var now = Date.now();
+    if (now - lastFrameTime >= minFrameInterval) {
+        lastFrameTime = now;
+        if (typeof callback === 'function') {
+            callback();
+        }
+    }
+}
+
+// Custom XYZ loader that preserves numbered atom names
+function loadXYZWithNumberedAtoms(xyzContent) {
+    try {
+        // Parse the XYZ content to extract atom names
+        const lines = xyzContent.trim().split('\n');
+        if (lines.length < 3) {
+            throw new Error('Invalid XYZ format');
+        }
+        
+        const atomCount = parseInt(lines[0]);
+        if (isNaN(atomCount) || atomCount <= 0) {
+            throw new Error('Invalid atom count');
+        }
+        
+        // Extract original atom names and prepare modified content
+        const extractedNames = [];
+        let modifiedXYZ = lines[0] + '\n' + lines[1] + '\n';
+        let hasNumberedAtoms = false;
+        
+        for (let i = 2; i < atomCount + 2 && i < lines.length; i++) {
+            const parts = lines[i].trim().split(/\s+/);
+            if (parts.length >= 4) {
+                const originalName = parts[0];
+                let elementSymbol = originalName.replace(/\d+/g, ''); // Remove numbers for JSmol
+                
+                // Check if this atom name contains numbers (indicating numbered atoms)
+                if (originalName !== elementSymbol && /\d/.test(originalName)) {
+                    hasNumberedAtoms = true;
                 }
                 
-                const atomCount = parseInt(lines[0]);
-                if (isNaN(atomCount) || atomCount <= 0) {
-                    throw new Error('Invalid atom count');
+                // Capitalize the first letter and make the rest lowercase for proper element recognition
+                if (elementSymbol.length > 0) {
+                    elementSymbol = elementSymbol.charAt(0).toUpperCase() + elementSymbol.slice(1).toLowerCase();
                 }
                 
-                // Extract original atom names and prepare modified content
-                const extractedNames = [];
-                let modifiedXYZ = lines[0] + '\n' + lines[1] + '\n';
-                let hasNumberedAtoms = false;
+                extractedNames.push(originalName);
+                modifiedXYZ += `${elementSymbol}  ${parts[1]}  ${parts[2]}  ${parts[3]}\n`;
+            }
+        }
+        
+        // Store the original data
+        setOriginalAtomNames(extractedNames);
+        originalXYZContent = xyzContent;
+        
+        // Clear database metadata since this is not a database load
+        window.databaseMetadata = null;
+        
+        // Set the flag to indicate numbered atoms should be used
+        shouldUseNumberedAtoms = hasNumberedAtoms;
+        console.log('loadXYZWithNumberedAtoms: Detected numbered atoms:', hasNumberedAtoms, 'Setting shouldUseNumberedAtoms to:', shouldUseNumberedAtoms);
+        
+        // Save current display mode
+        const currentDisplayMode = displayMode || 'default';
+        
+        // Load the structure with element symbols only
+        Jmol.script(jmolApplet0, `load inline "${modifiedXYZ}"`);
+        
+        // Apply original atom names after a short delay to ensure structure is loaded
+        setTimeout(() => {
+            applyOriginalAtomNames();
+            // Also refresh atom names to ensure they're properly maintained
+            setTimeout(() => {
+                refreshAtomNames();
+                console.log('loadXYZWithNumberedAtoms: Atom names refreshed after loading');
                 
-                for (let i = 2; i < atomCount + 2 && i < lines.length; i++) {
-                    const parts = lines[i].trim().split(/\s+/);
-                    if (parts.length >= 4) {
-                        const originalName = parts[0];
-                        let elementSymbol = originalName.replace(/\d+/g, ''); // Remove numbers for JSmol
-                        
-                        // Check if this atom name contains numbers (indicating numbered atoms)
-                        if (originalName !== elementSymbol && /\d/.test(originalName)) {
-                            hasNumberedAtoms = true;
-                        }
-                        
-                        // Capitalize the first letter and make the rest lowercase for proper element recognition
-                        if (elementSymbol.length > 0) {
-                            elementSymbol = elementSymbol.charAt(0).toUpperCase() + elementSymbol.slice(1).toLowerCase();
-                        }
-                        
-                        extractedNames.push(originalName);
-                        modifiedXYZ += `${elementSymbol}  ${parts[1]}  ${parts[2]}  ${parts[3]}\n`;
-                    }
+                // Update MOL file data for JSME integration after structure loading
+                try {
+                    lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                    debugLog('XYZ', 'Updated lastMolFile after loading XYZ with numbered atoms');
+                } catch (molError) {
+                    console.error('Error updating MOL file data in loadXYZWithNumberedAtoms:', molError);
                 }
                 
-                // Store the original data
-                setOriginalAtomNames(extractedNames);
-                originalXYZContent = xyzContent;
-                
-                // Clear database metadata since this is not a database load
-                window.databaseMetadata = null;
-                
-                // Set the flag to indicate numbered atoms should be used
-                shouldUseNumberedAtoms = hasNumberedAtoms;
-                console.log('loadXYZWithNumberedAtoms: Detected numbered atoms:', hasNumberedAtoms, 'Setting shouldUseNumberedAtoms to:', shouldUseNumberedAtoms);
-                
-                // Save current display mode
-                const currentDisplayMode = displayMode || 'default';
-                
-                // Load the structure with element symbols only
-                Jmol.script(jmolApplet0, `load inline "${modifiedXYZ}"`);
-                
-                // Apply original atom names after a short delay to ensure structure is loaded
+                // Restore display mode after everything is loaded
                 setTimeout(() => {
-                    applyOriginalAtomNames();
-                    // Also refresh atom names to ensure they're properly maintained
-                    setTimeout(() => {
-                        refreshAtomNames();
-                        console.log('loadXYZWithNumberedAtoms: Atom names refreshed after loading');
-                        
-                        // Update MOL file data for JSME integration after structure loading
-                        try {
-                            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                            debugLog('XYZ', 'Updated lastMolFile after loading XYZ with numbered atoms');
-                        } catch (molError) {
-                            console.error('Error updating MOL file data in loadXYZWithNumberedAtoms:', molError);
-                        }
-                        
-                        // Restore display mode after everything is loaded
-                        setTimeout(() => {
-                            console.log('loadXYZWithNumberedAtoms: Restoring display mode:', currentDisplayMode);
-                            setDisplayMode(currentDisplayMode);
-                            
-                            // Apply all JSmol preferences after loading
-                            if (typeof applyJSmolPreferences === 'function') {
-                                applyJSmolPreferences();
-                                console.log('loadXYZWithNumberedAtoms: Applied JSmol preferences');
-                            }
-                        }, 100);
-                    }, 100);
-                }, 100);
-                
-            } catch (error) {
-                console.error('Error loading XYZ with numbered atoms:', error);
-                // Save current display mode
-                const currentDisplayMode = displayMode || 'default';
-                
-                // Fallback to normal loading
-                Jmol.script(jmolApplet0, `load inline "${xyzContent}"`);
-                
-                // Restore display mode after fallback loading
-                setTimeout(() => {
-                    console.log('loadXYZWithNumberedAtoms fallback: Restoring display mode:', currentDisplayMode);
+                    console.log('loadXYZWithNumberedAtoms: Restoring display mode:', currentDisplayMode);
                     setDisplayMode(currentDisplayMode);
                     
-                    // Apply all JSmol preferences after fallback loading
+                    // Apply all JSmol preferences after loading
                     if (typeof applyJSmolPreferences === 'function') {
                         applyJSmolPreferences();
-                        console.log('loadXYZWithNumberedAtoms fallback: Applied JSmol preferences');
+                        console.log('loadXYZWithNumberedAtoms: Applied JSmol preferences');
                     }
-                }, 200);
-            }
-        }
-        
-        // Apply the original numbered atom names to the loaded structure
-        function applyOriginalAtomNames() {
-            if (!originalAtomNames) return;
-            
-            try {
-                for (let i = 0; i < originalAtomNames.length; i++) {
-                    const atomName = originalAtomNames[i];
-                    Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${atomName}"`);
-                }
-                document.getElementById('status').innerHTML = 'Structure loaded with preserved numbered atom names';
-            } catch (error) {
-                console.error('Error applying atom names:', error);
-            }
-        }
-
-        // Function to refresh and maintain numbered atom names
-        let refreshAtomNamesTimeout = null;
-        let lastRefreshTime = 0;
-        const REFRESH_THROTTLE_MS = 1000; // Don't refresh more than once per second
-        
-        function refreshAtomNames() {
-            // Throttle the function to prevent excessive calls
-            const now = Date.now();
-            if (now - lastRefreshTime < REFRESH_THROTTLE_MS) {
-                // Clear any pending refresh and schedule a new one
-                if (refreshAtomNamesTimeout) {
-                    clearTimeout(refreshAtomNamesTimeout);
-                }
-                refreshAtomNamesTimeout = setTimeout(() => {
-                    refreshAtomNamesImmediate();
-                    lastRefreshTime = Date.now();
-                }, REFRESH_THROTTLE_MS - (now - lastRefreshTime));
-                return false;
-            }
-            
-            lastRefreshTime = now;
-            return refreshAtomNamesImmediate();
-        }
-        
-        function refreshAtomNamesImmediate() {
-            console.log('refreshAtomNames: Starting atom name refresh');
-            
-            try {
-                const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
-                if (!atomCount || atomCount === 0) {
-                    console.warn('refreshAtomNames: No atoms found');
-                    return false;
-                }
-                
-                // If we have preserved atom names, reapply them
-                if (window.originalAtomNames && window.originalAtomNames.length === atomCount) {
-                    console.log('refreshAtomNames: Reapplying preserved atom names');
-                    for (let i = 0; i < atomCount; i++) {
-                        const atomName = window.originalAtomNames[i];
-                        Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${atomName}"`);
-                    }
-                    return true;
-                } else {
-                    // Try to extract current atom names and preserve them if they look numbered
-                    console.log('refreshAtomNames: Extracting current atom names');
-                    const currentNames = [];
-                    let hasNumberedNames = false;
-                    
-                    for (let i = 0; i < atomCount; i++) {
-                        let atomName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
-                        if (!atomName || atomName === 'null' || atomName === '') {
-                            const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
-                            // Only generate numbered names if the flag indicates we should
-                            atomName = shouldUseNumberedAtoms ? (element + (i + 1)) : element;
-                        } else if (!shouldUseNumberedAtoms && /^[A-Z][a-z]?\d+$/.test(atomName)) {
-                            // Atom name has numbers but we don't want numbered atoms - extract just the element
-                            const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
-                            atomName = element;
-                        } else if (shouldUseNumberedAtoms && atomName.length <= 2 && !/\d/.test(atomName)) {
-                            // Atom name is just element symbol but we want numbered atoms
-                            atomName = atomName + (i + 1);
-                        }
-                        
-                        currentNames.push(atomName);
-                        
-                        // Check if this looks like a numbered atom name (element + number)
-                        if (/^[A-Z][a-z]?\d+$/.test(atomName)) {
-                            hasNumberedNames = true;
-                        }
-                    }
-                    
-                    if (hasNumberedNames) {
-                        console.log('refreshAtomNames: Found numbered names, preserving them');
-                        setOriginalAtomNames(currentNames);
-                        return true;
-                    } else {
-                        // Apply the corrected non-numbered names back to JSmol if needed
-                        let needsUpdate = false;
-                        for (let i = 0; i < atomCount; i++) {
-                            const currentJSmolName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
-                            if (currentJSmolName !== currentNames[i]) {
-                                needsUpdate = true;
-                                break;
-                            }
-                        }
-                        
-                        if (needsUpdate) {
-                            console.log('refreshAtomNames: Applying corrected non-numbered names to JSmol');
-                            for (let i = 0; i < atomCount; i++) {
-                                Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${currentNames[i]}"`);
-                            }
-                        }
-                        
-                        // Store the corrected names
-                        setOriginalAtomNames(currentNames);
-                        return true;
-                    }
-                }
-                
-                return false;
-            } catch (error) {
-                console.error('refreshAtomNames: Error refreshing atom names:', error);
-                return false;
-            }
-        }
-
-        // Function to force a complete refresh of molecular data
-        function forceRefreshMolecularData() {
-            console.log('forceRefreshMolecularData: Starting complete molecular data refresh');
-            
-            try {
-                // Refresh atom names first
-                const atomNamesRefreshed = refreshAtomNames();
-                console.log('forceRefreshMolecularData: Atom names refreshed:', atomNamesRefreshed);
-                
-                // Try to get fresh XYZ data using multiple approaches
-                const xyzData = getXYZDataWithNumberedAtoms();
-                console.log('forceRefreshMolecularData: XYZ data retrieved:', xyzData ? 'Success' : 'Failed');
-                
-                if (xyzData) {
-                    console.log('forceRefreshMolecularData: XYZ data preview:', xyzData.substring(0, 200) + '...');
-                    
-                    // Update ElemCo input with fresh data
-                    updateElemCoInput();
-                    
-                    return true;
-                } else {
-                    console.warn('forceRefreshMolecularData: Could not retrieve XYZ data');
-                    return false;
-                }
-                
-            } catch (error) {
-                console.error('forceRefreshMolecularData: Error during refresh:', error);
-                return false;
-            }
-        }
-
-        // Add initialization with better error handling and cleanup
-        $(document).ready(function() {
-            try {
-                console.log('Initializing JSmol...');
-                console.log('User Agent:', navigator.userAgent);
-                console.log('WebGL Support:', !!window.WebGLRenderingContext);
-                console.log('Hardware Concurrency:', navigator.hardwareConcurrency);
-                console.log('Memory:', navigator.deviceMemory || 'unknown');
-                
-                // Check for graphics capabilities
-                if (window.WebGLRenderingContext) {
-                    const canvas = document.createElement('canvas');
-                    const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-                    if (gl) {
-                        console.log('WebGL Renderer:', gl.getParameter(gl.RENDERER));
-                        console.log('WebGL Vendor:', gl.getParameter(gl.VENDOR));
-                        console.log('WebGL Version:', gl.getParameter(gl.VERSION));
-                    }
-                }
-                
-                Jmol.setDocument(0);
-                // Create inner container for JSmol
-                $("#viewer").html('<div id="viewer-inner"></div>');
-                $("#viewer-inner").html(Jmol.getAppletHtml("jmolApplet0", Info));
-                initDraggable();
-                initResizeObserver();
-                
-                // Add performance monitoring
-                let frameCount = 0;
-                let lastTime = performance.now();
-                function monitorPerformance() {
-                    frameCount++;
-                    const currentTime = performance.now();
-                    if (currentTime - lastTime >= 5000) { // Every 5 seconds
-                        const fps = (frameCount * 1000) / (currentTime - lastTime);
-                        console.log(`Performance: ${fps.toFixed(1)} FPS, Memory: ${(performance.memory?.usedJSHeapSize/1024/1024 || 0).toFixed(1)}MB`);
-                        frameCount = 0;
-                        lastTime = currentTime;
-                    }
-                    requestAnimationFrame(monitorPerformance);
-                }
-                if (window.performance && window.performance.memory) {
-                    monitorPerformance();
-                }
-                
-                // Add window focus/blur handling for resource management
-                window.addEventListener('focus', function() {
-                    // Resume any paused operations when window gains focus
-                    if (jmolApplet0 && jmolApplet0._ready) {
-                        throttledRepaint(() => {
-                            // Minimal repaint on focus
-                        });
-                    }
-                });
-                
-                window.addEventListener('blur', function() {
-                    // Pause intensive operations when window loses focus
-                    isSpinning = false;
-                    if (jmolApplet0 && jmolApplet0._ready) {
-                        try {
-                            Jmol.script(jmolApplet0, 'spin off');
-                            const spinButton = document.getElementById('spinButton');
-                            if (spinButton) {
-                                spinButton.textContent = 'Spin';
-                            }
-                        } catch (e) {
-                            console.error('Error stopping spin on blur:', e);
-                        }
-                    }
-                });
-
-                // Initialize database input handlers with retry
-                setTimeout(() => {
-                    setupDatabaseInputHandlers();
                 }, 100);
+            }, 100);
+        }, 100);
+        
+    } catch (error) {
+        console.error('Error loading XYZ with numbered atoms:', error);
+        // Save current display mode
+        const currentDisplayMode = displayMode || 'default';
+        
+        // Fallback to normal loading
+        Jmol.script(jmolApplet0, `load inline "${xyzContent}"`);
+        
+        // Restore display mode after fallback loading
+        setTimeout(() => {
+            console.log('loadXYZWithNumberedAtoms fallback: Restoring display mode:', currentDisplayMode);
+            setDisplayMode(currentDisplayMode);
+            
+            // Apply all JSmol preferences after fallback loading
+            if (typeof applyJSmolPreferences === 'function') {
+                applyJSmolPreferences();
+                console.log('loadXYZWithNumberedAtoms fallback: Applied JSmol preferences');
+            }
+        }, 200);
+    }
+}
+
+// Apply the original numbered atom names to the loaded structure
+function applyOriginalAtomNames() {
+    if (!originalAtomNames) return;
+    
+    try {
+        for (let i = 0; i < originalAtomNames.length; i++) {
+            const atomName = originalAtomNames[i];
+            Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${atomName}"`);
+        }
+        document.getElementById('status').innerHTML = 'Structure loaded with preserved numbered atom names';
+    } catch (error) {
+        console.error('Error applying atom names:', error);
+    }
+}
+
+// Function to refresh and maintain numbered atom names
+let refreshAtomNamesTimeout = null;
+let lastRefreshTime = 0;
+const REFRESH_THROTTLE_MS = 1000; // Don't refresh more than once per second
+
+function refreshAtomNames() {
+    // Throttle the function to prevent excessive calls
+    const now = Date.now();
+    if (now - lastRefreshTime < REFRESH_THROTTLE_MS) {
+        // Clear any pending refresh and schedule a new one
+        if (refreshAtomNamesTimeout) {
+            clearTimeout(refreshAtomNamesTimeout);
+        }
+        refreshAtomNamesTimeout = setTimeout(() => {
+            refreshAtomNamesImmediate();
+            lastRefreshTime = Date.now();
+        }, REFRESH_THROTTLE_MS - (now - lastRefreshTime));
+        return false;
+    }
+    
+    lastRefreshTime = now;
+    return refreshAtomNamesImmediate();
+}
+
+function refreshAtomNamesImmediate() {
+    console.log('refreshAtomNames: Starting atom name refresh');
+    
+    try {
+        const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+        if (!atomCount || atomCount === 0) {
+            console.warn('refreshAtomNames: No atoms found');
+            return false;
+        }
+        
+        // If we have preserved atom names, reapply them
+        if (window.originalAtomNames && window.originalAtomNames.length === atomCount) {
+            console.log('refreshAtomNames: Reapplying preserved atom names');
+            for (let i = 0; i < atomCount; i++) {
+                const atomName = window.originalAtomNames[i];
+                Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${atomName}"`);
+            }
+            return true;
+        } else {
+            // Try to extract current atom names and preserve them if they look numbered
+            console.log('refreshAtomNames: Extracting current atom names');
+            const currentNames = [];
+            let hasNumberedNames = false;
+            
+            for (let i = 0; i < atomCount; i++) {
+                let atomName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
+                if (!atomName || atomName === 'null' || atomName === '') {
+                    const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
+                    // Only generate numbered names if the flag indicates we should
+                    atomName = shouldUseNumberedAtoms ? (element + (i + 1)) : element;
+                } else if (!shouldUseNumberedAtoms && /^[A-Z][a-z]?\d+$/.test(atomName)) {
+                    // Atom name has numbers but we don't want numbered atoms - extract just the element
+                    const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`) || 'X';
+                    atomName = element;
+                } else if (shouldUseNumberedAtoms && atomName.length <= 2 && !/\d/.test(atomName)) {
+                    // Atom name is just element symbol but we want numbered atoms
+                    atomName = atomName + (i + 1);
+                }
                 
-            } catch (e) {
-                console.error('Error during initialization:', e);
-                document.getElementById('status').innerHTML = 'Error during initialization: ' + e.message;
+                currentNames.push(atomName);
+                
+                // Check if this looks like a numbered atom name (element + number)
+                if (/^[A-Z][a-z]?\d+$/.test(atomName)) {
+                    hasNumberedNames = true;
+                }
+            }
+            
+            if (hasNumberedNames) {
+                console.log('refreshAtomNames: Found numbered names, preserving them');
+                setOriginalAtomNames(currentNames);
+                return true;
+            } else {
+                // Apply the corrected non-numbered names back to JSmol if needed
+                let needsUpdate = false;
+                for (let i = 0; i < atomCount; i++) {
+                    const currentJSmolName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
+                    if (currentJSmolName !== currentNames[i]) {
+                        needsUpdate = true;
+                        break;
+                    }
+                }
+                
+                if (needsUpdate) {
+                    console.log('refreshAtomNames: Applying corrected non-numbered names to JSmol');
+                    for (let i = 0; i < atomCount; i++) {
+                        Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${currentNames[i]}"`);
+                    }
+                }
+                
+                // Store the corrected names
+                setOriginalAtomNames(currentNames);
+                return true;
+            }
+        }
+        
+        return false;
+    } catch (error) {
+        console.error('refreshAtomNames: Error refreshing atom names:', error);
+        return false;
+    }
+}
+
+// Function to force a complete refresh of molecular data
+function forceRefreshMolecularData() {
+    console.log('forceRefreshMolecularData: Starting complete molecular data refresh');
+    
+    try {
+        // Refresh atom names first
+        const atomNamesRefreshed = refreshAtomNames();
+        console.log('forceRefreshMolecularData: Atom names refreshed:', atomNamesRefreshed);
+        
+        // Try to get fresh XYZ data using multiple approaches
+        const xyzData = getXYZDataWithNumberedAtoms();
+        console.log('forceRefreshMolecularData: XYZ data retrieved:', xyzData ? 'Success' : 'Failed');
+        
+        if (xyzData) {
+            console.log('forceRefreshMolecularData: XYZ data preview:', xyzData.substring(0, 200) + '...');
+            
+            // Update ElemCo input with fresh data
+            updateElemCoInput();
+            
+            return true;
+        } else {
+            console.warn('forceRefreshMolecularData: Could not retrieve XYZ data');
+            return false;
+        }
+        
+    } catch (error) {
+        console.error('forceRefreshMolecularData: Error during refresh:', error);
+        return false;
+    }
+}
+
+// Add initialization with better error handling and cleanup
+$(document).ready(function() {
+    try {
+        console.log('Initializing JSmol...');
+        console.log('User Agent:', navigator.userAgent);
+        console.log('WebGL Support:', !!window.WebGLRenderingContext);
+        console.log('Hardware Concurrency:', navigator.hardwareConcurrency);
+        console.log('Memory:', navigator.deviceMemory || 'unknown');
+        
+        // Check for graphics capabilities
+        if (window.WebGLRenderingContext) {
+            const canvas = document.createElement('canvas');
+            const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+            if (gl) {
+                console.log('WebGL Renderer:', gl.getParameter(gl.RENDERER));
+                console.log('WebGL Vendor:', gl.getParameter(gl.VENDOR));
+                console.log('WebGL Version:', gl.getParameter(gl.VERSION));
+            }
+        }
+        
+        Jmol.setDocument(0);
+        // Create inner container for JSmol
+        $("#viewer").html('<div id="viewer-inner"></div>');
+        $("#viewer-inner").html(Jmol.getAppletHtml("jmolApplet0", Info));
+        initDraggable();
+        initResizeObserver();
+        
+        // Add performance monitoring
+        let frameCount = 0;
+        let lastTime = performance.now();
+        function monitorPerformance() {
+            frameCount++;
+            const currentTime = performance.now();
+            if (currentTime - lastTime >= 5000) { // Every 5 seconds
+                const fps = (frameCount * 1000) / (currentTime - lastTime);
+                console.log(`Performance: ${fps.toFixed(1)} FPS, Memory: ${(performance.memory?.usedJSHeapSize/1024/1024 || 0).toFixed(1)}MB`);
+                frameCount = 0;
+                lastTime = currentTime;
+            }
+            requestAnimationFrame(monitorPerformance);
+        }
+        if (window.performance && window.performance.memory) {
+            monitorPerformance();
+        }
+        
+        // Add window focus/blur handling for resource management
+        window.addEventListener('focus', function() {
+            // Resume any paused operations when window gains focus
+            if (jmolApplet0 && jmolApplet0._ready) {
+                throttledRepaint(() => {
+                    // Minimal repaint on focus
+                });
             }
         });
+        
+        window.addEventListener('blur', function() {
+            // Pause intensive operations when window loses focus
+            isSpinning = false;
+            if (jmolApplet0 && jmolApplet0._ready) {
+                try {
+                    Jmol.script(jmolApplet0, 'spin off');
+                    const spinButton = document.getElementById('spinButton');
+                    if (spinButton) {
+                        spinButton.textContent = 'Spin';
+                    }
+                } catch (e) {
+                    console.error('Error stopping spin on blur:', e);
+                }
+            }
+        });
+
+        // Initialize database input handlers with retry
+        setTimeout(() => {
+            setupDatabaseInputHandlers();
+        }, 100);
+        
+    } catch (e) {
+        console.error('Error during initialization:', e);
+        document.getElementById('status').innerHTML = 'Error during initialization: ' + e.message;
+    }
+});
 

--- a/js/orbitals.js
+++ b/js/orbitals.js
@@ -1,208 +1,208 @@
-        var currentOrbitalIndex = 1;
-        var orbitalsVisible = false;
-        
-        function toggleOrbitalControls() {
-            var orbitalControls = document.getElementById('orbitalControls');
-            if (orbitalControls.style.display === 'none' || !orbitalControls.style.display) {
-                orbitalControls.style.display = 'block';
-                // For molden files, ensure orbitals are loaded
-                let fileName = Jmol.evaluateVar(jmolApplet0, '_modelFile.name');
-                if (fileName && fileName.toLowerCase().endsWith('.molden')) {
-                    Jmol.script(jmolApplet0, 'mo fill nomesh;');
-                }
-                // Initialize orbital visualization if not already visible
-                if (!orbitalsVisible) {
-                    Jmol.script(jmolApplet0, 'mo fill nomesh translucent 0.5');
-                    getOrbitalInfo();
-                }
-            } else {
-                orbitalControls.style.display = 'none';
-                Jmol.script(jmolApplet0, 'mo delete');
-                orbitalsVisible = false;
-            }
-        }
-        
-        function showOrbital(index) {
-            if (index < 1 || (numOrbitals > 0 && index > numOrbitals)) return;
-            currentOrbitalIndex = index;
-            document.getElementById('currentOrbital').textContent = index;
-            Jmol.script(jmolApplet0, 'mo ' + index + ' fill nomesh translucent 0.5');
-            orbitalsVisible = true;
-            updateOrbitalList();
-        }
-        
-        function changeOrbital(delta) {
-            if (orbitalsVisible) {
-                showOrbital(currentOrbitalIndex + delta);
-            }
-        }
-        
-        document.addEventListener('keydown', function(event) {
-            if (orbitalsVisible) {
-                if (event.key === 'ArrowUp') {
-                    changeOrbital(-1);
-                    event.preventDefault();
-                } else if (event.key === 'ArrowDown') {
-                    changeOrbital(1);
-                    event.preventDefault();
-                }
-            }
-        });
+var currentOrbitalIndex = 1;
+var orbitalsVisible = false;
 
-        var homoOrbital = 0;
-        var lumoOrbital = 0;
-        var numOrbitals = 0;
-        var orbitals = [];
+function toggleOrbitalControls() {
+    var orbitalControls = document.getElementById('orbitalControls');
+    if (orbitalControls.style.display === 'none' || !orbitalControls.style.display) {
+        orbitalControls.style.display = 'block';
+        // For molden files, ensure orbitals are loaded
+        let fileName = Jmol.evaluateVar(jmolApplet0, '_modelFile.name');
+        if (fileName && fileName.toLowerCase().endsWith('.molden')) {
+            Jmol.script(jmolApplet0, 'mo fill nomesh;');
+        }
+        // Initialize orbital visualization if not already visible
+        if (!orbitalsVisible) {
+            Jmol.script(jmolApplet0, 'mo fill nomesh translucent 0.5');
+            getOrbitalInfo();
+        }
+    } else {
+        orbitalControls.style.display = 'none';
+        Jmol.script(jmolApplet0, 'mo delete');
+        orbitalsVisible = false;
+    }
+}
+
+function showOrbital(index) {
+    if (index < 1 || (numOrbitals > 0 && index > numOrbitals)) return;
+    currentOrbitalIndex = index;
+    document.getElementById('currentOrbital').textContent = index;
+    Jmol.script(jmolApplet0, 'mo ' + index + ' fill nomesh translucent 0.5');
+    orbitalsVisible = true;
+    updateOrbitalList();
+}
+
+function changeOrbital(delta) {
+    if (orbitalsVisible) {
+        showOrbital(currentOrbitalIndex + delta);
+    }
+}
+
+document.addEventListener('keydown', function(event) {
+    if (orbitalsVisible) {
+        if (event.key === 'ArrowUp') {
+            changeOrbital(-1);
+            event.preventDefault();
+        } else if (event.key === 'ArrowDown') {
+            changeOrbital(1);
+            event.preventDefault();
+        }
+    }
+});
+
+var homoOrbital = 0;
+var lumoOrbital = 0;
+var numOrbitals = 0;
+var orbitals = [];
+
+function getOrbitalInfo() {
+    try {
+        // Get orbital information
+        Jmol.script(jmolApplet0, 'mo list');
         
-        function getOrbitalInfo() {
-            try {
-                // Get orbital information
-                Jmol.script(jmolApplet0, 'mo list');
+        // Parse the orbital list response to get the real number of orbitals
+        let moListResponse = Jmol.scriptWait(jmolApplet0, 'show mo list');
+        let lines = moListResponse.split('\n');
+        let maxOrbital = 0;
+        homoOrbital = 0;
+        lumoOrbital = 0;
+        
+        // Parse each line to find orbitals and their occupancies
+        // Store them in order to properly identify HOMO/LUMO
+        orbitals = [];
+        
+        for (let line of lines) {
+            let match = line.match(/mo\s+(\d+)\s+#\s+energy\s+([+-]?\d+\.?\d*)\s+occupancy\s+(\d+)/);
+            if (match) {
+                let orbitalNum = parseInt(match[1]);
+                let energy = parseFloat(match[2]);
+                let occupancy = parseInt(match[3]);
                 
-                // Parse the orbital list response to get the real number of orbitals
-                let moListResponse = Jmol.scriptWait(jmolApplet0, 'show mo list');
-                let lines = moListResponse.split('\n');
-                let maxOrbital = 0;
-                homoOrbital = 0;
-                lumoOrbital = 0;
+                orbitals.push({
+                    number: orbitalNum,
+                    energy: energy,
+                    occupancy: occupancy
+                });
                 
-                // Parse each line to find orbitals and their occupancies
-                // Store them in order to properly identify HOMO/LUMO
-                orbitals = [];
-                
-                for (let line of lines) {
-                    let match = line.match(/mo\s+(\d+)\s+#\s+energy\s+([+-]?\d+\.?\d*)\s+occupancy\s+(\d+)/);
-                    if (match) {
-                        let orbitalNum = parseInt(match[1]);
-                        let energy = parseFloat(match[2]);
-                        let occupancy = parseInt(match[3]);
-                        
-                        orbitals.push({
-                            number: orbitalNum,
-                            energy: energy,
-                            occupancy: occupancy
-                        });
-                        
-                        maxOrbital = Math.max(maxOrbital, orbitalNum);
-                    }
-                }
-                
-                // Sort orbitals by number to process them in order
-                orbitals.sort((a, b) => a.number - b.number);
-                
-                // Find HOMO (highest occupied) and LUMO (lowest unoccupied)
-                let foundUnoccupied = false;
-                for (let orbital of orbitals) {
-                    if (orbital.occupancy > 0) {
-                        homoOrbital = orbital.number;
-                    } else if (!foundUnoccupied) {
-                        lumoOrbital = orbital.number;
-                        foundUnoccupied = true;
-                    }
-                }
-                
-                // Update orbital information
-                numOrbitals = maxOrbital;
-                
-                // Set initial display parameters
-                Jmol.script(jmolApplet0, 'mo fill nomesh translucent 0.5');
-                
-                // Update the interface
-                let existingInfo = document.getElementById('orbitalInfoDisplay');
-                if (existingInfo) existingInfo.remove();
-                
-                let orbitalInfo = document.createElement('div');
-                orbitalInfo.id = 'orbitalInfoDisplay';
-                orbitalInfo.innerHTML = `
+                maxOrbital = Math.max(maxOrbital, orbitalNum);
+            }
+        }
+        
+        // Sort orbitals by number to process them in order
+        orbitals.sort((a, b) => a.number - b.number);
+        
+        // Find HOMO (highest occupied) and LUMO (lowest unoccupied)
+        let foundUnoccupied = false;
+        for (let orbital of orbitals) {
+            if (orbital.occupancy > 0) {
+                homoOrbital = orbital.number;
+            } else if (!foundUnoccupied) {
+                lumoOrbital = orbital.number;
+                foundUnoccupied = true;
+            }
+        }
+        
+        // Update orbital information
+        numOrbitals = maxOrbital;
+        
+        // Set initial display parameters
+        Jmol.script(jmolApplet0, 'mo fill nomesh translucent 0.5');
+        
+        // Update the interface
+        let existingInfo = document.getElementById('orbitalInfoDisplay');
+        if (existingInfo) existingInfo.remove();
+        
+        let orbitalInfo = document.createElement('div');
+        orbitalInfo.id = 'orbitalInfoDisplay';
+        orbitalInfo.innerHTML = `
                     <p>Total Orbitals: ${numOrbitals}</p>
                     <p>HOMO: ${homoOrbital}, LUMO: ${lumoOrbital}</p>
                 `;
-                document.getElementById('orbitalControls').insertBefore(
-                    orbitalInfo,
-                    document.getElementById('orbitalList')
-                );
-                
-                // Update UI
-                document.getElementById('status').innerHTML = 'Orbital visualization enabled';
-                updateOrbitalList();
-                
-                // Show HOMO by default if none shown
-                if (!orbitalsVisible) {
-                    showOrbital(homoOrbital);
-                }
-                
-            } catch (e) {
-                console.error('Error getting orbital information:', e);
-                document.getElementById('status').innerHTML = 'Error: Could not get orbital information. Make sure the file contains orbital data.';
-                numOrbitals = 0;
-                homoOrbital = 0;
-                lumoOrbital = 0;
-                updateOrbitalList();
-            }
+        document.getElementById('orbitalControls').insertBefore(
+            orbitalInfo,
+            document.getElementById('orbitalList')
+        );
+        
+        // Update UI
+        document.getElementById('status').innerHTML = 'Orbital visualization enabled';
+        updateOrbitalList();
+        
+        // Show HOMO by default if none shown
+        if (!orbitalsVisible) {
+            showOrbital(homoOrbital);
         }
         
-        function updateOrbitalList() {
-            const list = document.getElementById('orbitalList');
-            list.innerHTML = '';
-            
-            if (numOrbitals === 0) {
-                list.innerHTML = '<div>No orbital information available</div>';
-                return;
-            }
-            
-            // Create orbital entries in groups of 10 for better performance
-            const fragment = document.createDocumentFragment();
-            let selectedDiv = null;
-            for (let i = 1; i <= numOrbitals; i++) {
-                const div = document.createElement('div');
-                // Find orbital energy from the stored orbitals array
-                const orbital = orbitals.find(o => o.number === i);
-                let label = `Orbital ${i}`;
-                if (orbital) {
-                    label += ` (${orbital.energy.toFixed(3)})`;
-                }
-                if (i === homoOrbital) {
-                    label += ' (HOMO)';
-                    div.style.fontWeight = 'bold';
-                    div.style.color = '#0066cc';
-                } else if (i === lumoOrbital) {
-                    label += ' (LUMO)';
-                    div.style.fontWeight = 'bold';
-                    div.style.color = '#cc6600';
-                }
-                div.textContent = label;
-                div.onclick = () => showOrbital(i);
-                if (i === currentOrbitalIndex) {
-                    div.className = 'selected';
-                    selectedDiv = div;
-                }
-                fragment.appendChild(div);
-            }
-            list.appendChild(fragment);
+    } catch (e) {
+        console.error('Error getting orbital information:', e);
+        document.getElementById('status').innerHTML = 'Error: Could not get orbital information. Make sure the file contains orbital data.';
+        numOrbitals = 0;
+        homoOrbital = 0;
+        lumoOrbital = 0;
+        updateOrbitalList();
+    }
+}
 
-            // Keep the selected orbital visible: scroll the list (only the list,
-            // not the page) so the highlighted entry stays in view when navigating
-            // with the arrow keys or HOMO/LUMO buttons.
-            if (selectedDiv) {
-                const itemRect = selectedDiv.getBoundingClientRect();
-                const listRect = list.getBoundingClientRect();
-                if (itemRect.top < listRect.top) {
-                    list.scrollTop -= (listRect.top - itemRect.top);
-                } else if (itemRect.bottom > listRect.bottom) {
-                    list.scrollTop += (itemRect.bottom - listRect.bottom);
-                }
-            }
+function updateOrbitalList() {
+    const list = document.getElementById('orbitalList');
+    list.innerHTML = '';
+    
+    if (numOrbitals === 0) {
+        list.innerHTML = '<div>No orbital information available</div>';
+        return;
+    }
+    
+    // Create orbital entries in groups of 10 for better performance
+    const fragment = document.createDocumentFragment();
+    let selectedDiv = null;
+    for (let i = 1; i <= numOrbitals; i++) {
+        const div = document.createElement('div');
+        // Find orbital energy from the stored orbitals array
+        const orbital = orbitals.find(o => o.number === i);
+        let label = `Orbital ${i}`;
+        if (orbital) {
+            label += ` (${orbital.energy.toFixed(3)})`;
         }
-        
-        function showHOMO() {
-            if (homoOrbital > 0) {
-                showOrbital(homoOrbital);
-            }
+        if (i === homoOrbital) {
+            label += ' (HOMO)';
+            div.style.fontWeight = 'bold';
+            div.style.color = '#0066cc';
+        } else if (i === lumoOrbital) {
+            label += ' (LUMO)';
+            div.style.fontWeight = 'bold';
+            div.style.color = '#cc6600';
         }
-        
-        function showLUMO() {
-            if (lumoOrbital > 0) {
-                showOrbital(lumoOrbital);
-            }
+        div.textContent = label;
+        div.onclick = () => showOrbital(i);
+        if (i === currentOrbitalIndex) {
+            div.className = 'selected';
+            selectedDiv = div;
         }
+        fragment.appendChild(div);
+    }
+    list.appendChild(fragment);
+
+    // Keep the selected orbital visible: scroll the list (only the list,
+    // not the page) so the highlighted entry stays in view when navigating
+    // with the arrow keys or HOMO/LUMO buttons.
+    if (selectedDiv) {
+        const itemRect = selectedDiv.getBoundingClientRect();
+        const listRect = list.getBoundingClientRect();
+        if (itemRect.top < listRect.top) {
+            list.scrollTop -= (listRect.top - itemRect.top);
+        } else if (itemRect.bottom > listRect.bottom) {
+            list.scrollTop += (itemRect.bottom - listRect.bottom);
+        }
+    }
+}
+
+function showHOMO() {
+    if (homoOrbital > 0) {
+        showOrbital(homoOrbital);
+    }
+}
+
+function showLUMO() {
+    if (lumoOrbital > 0) {
+        showOrbital(lumoOrbital);
+    }
+}
 

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -1,551 +1,551 @@
-        // User Preferences System - Core Functions
-        const DEFAULT_PREFERENCES = {
-            // General settings
-            theme: 'default',
-            autoLoadLastMolecule: false,
-            saveWindowPositions: true,
-            showTooltips: true,
-            confirmOverwrite: true,
-            exportFormat: 'png',
-            exportTransparentBackground: true,
-            
-            // Display settings
-            autoSpin: false,
-            defaultDisplayMode: 'ball&stick',
-            showLabels: false,
-            bgColor: '#FFFFFF',
-            antialiasing: true,
-            zoomLevel: '100',
-            
-            // Advanced settings
-            hardwareAcceleration: true,
-            renderQuality: 'medium',
-            memoryLimit: 2048,
-            debugMode: false,
-            detailedLogging: false,
-            
-            // ElemCo.jl settings
-            defaultBasisSet: 'cc-pVDZ',
-            defaultMethod: 'HF',
-            juliaCommand: 'julia',
-            calcTimeout: 5,
-            useDF: false,
-            autoClearOutput: true,
-            saveOutput: false,
+// User Preferences System - Core Functions
+const DEFAULT_PREFERENCES = {
+    // General settings
+    theme: 'default',
+    autoLoadLastMolecule: false,
+    saveWindowPositions: true,
+    showTooltips: true,
+    confirmOverwrite: true,
+    exportFormat: 'png',
+    exportTransparentBackground: true,
+    
+    // Display settings
+    autoSpin: false,
+    defaultDisplayMode: 'ball&stick',
+    showLabels: false,
+    bgColor: '#FFFFFF',
+    antialiasing: true,
+    zoomLevel: '100',
+    
+    // Advanced settings
+    hardwareAcceleration: true,
+    renderQuality: 'medium',
+    memoryLimit: 2048,
+    debugMode: false,
+    detailedLogging: false,
+    
+    // ElemCo.jl settings
+    defaultBasisSet: 'cc-pVDZ',
+    defaultMethod: 'HF',
+    juliaCommand: 'julia',
+    calcTimeout: 5,
+    useDF: false,
+    autoClearOutput: true,
+    saveOutput: false,
 
-            // xtb (g-xTB) settings
-            xtbCommand: 'xtb'
-        };
+    // xtb (g-xTB) settings
+    xtbCommand: 'xtb'
+};
+
+// Switch between preference tabs
+function switchPreferencesTab(tabName) {
+    // Remove active class from all tabs and contents
+    document.querySelectorAll('.preferences-tab').forEach(tab => {
+        tab.classList.remove('active');
+    });
+    document.querySelectorAll('.preferences-tab-content').forEach(content => {
+        content.classList.remove('active');
+    });
+    
+    // Add active class to clicked tab and corresponding content
+    event.target.classList.add('active');
+    document.getElementById(`preferences-${tabName}`).classList.add('active');
+}
+
+// Color picker handling
+function openColorPicker(inputId) {
+    document.getElementById(inputId).click();
+}
+
+function resetBackgroundColor() {
+    const colorInput = document.getElementById('pref-bg-color');
+    const colorPreview = document.getElementById('bg-color-preview');
+    colorInput.value = '#FFFFFF';
+    colorPreview.style.backgroundColor = '#FFFFFF';
+    updateBackgroundColor('#FFFFFF');
+}
+
+function updateBackgroundColor(color) {
+    if (jmolApplet0 && jmolApplet0._ready) {
+        // Convert hex color to JSmol script format [xRRGGBB]
+        const jsmolColor = '[x' + color.replace('#', '') + ']';
+        Jmol.script(jmolApplet0, `background ${jsmolColor}`);
+        console.log('Applied background color:', color, '->', jsmolColor);
         
-        // Switch between preference tabs
-        function switchPreferencesTab(tabName) {
-            // Remove active class from all tabs and contents
-            document.querySelectorAll('.preferences-tab').forEach(tab => {
-                tab.classList.remove('active');
-            });
-            document.querySelectorAll('.preferences-tab-content').forEach(content => {
-                content.classList.remove('active');
-            });
-            
-            // Add active class to clicked tab and corresponding content
-            event.target.classList.add('active');
-            document.getElementById(`preferences-${tabName}`).classList.add('active');
-        }
+        // Update the preference
+        updatePreference('bgColor', color);
+    }
+}
+
+// Enhanced preference loading and saving
+function loadPreferencesIntoUI() {
+    const prefs = getPreferences();
+    
+    // General settings
+    const autoLoadCheckbox = document.getElementById('pref-auto-load');
+    if (autoLoadCheckbox) autoLoadCheckbox.checked = prefs.autoLoadLastMolecule || false;
+    
+    const savePositionsCheckbox = document.getElementById('pref-save-positions');
+    if (savePositionsCheckbox) savePositionsCheckbox.checked = prefs.saveWindowPositions !== false;
+    
+    const showTooltipsCheckbox = document.getElementById('pref-show-tooltips');
+    if (showTooltipsCheckbox) showTooltipsCheckbox.checked = prefs.showTooltips !== false;
+    
+    const confirmOverwriteCheckbox = document.getElementById('pref-confirm-overwrite');
+    if (confirmOverwriteCheckbox) confirmOverwriteCheckbox.checked = prefs.confirmOverwrite !== false;
+    
+    const exportFormatSelect = document.getElementById('pref-export-format');
+    if (exportFormatSelect) exportFormatSelect.value = prefs.exportFormat || 'png';
+    
+    const exportTransparentCheckbox = document.getElementById('pref-export-transparent');
+    if (exportTransparentCheckbox) exportTransparentCheckbox.checked = prefs.exportTransparentBackground !== false;
+    
+    // Display settings  
+    const autoSpinCheckbox = document.getElementById('pref-auto-spin');
+    if (autoSpinCheckbox) autoSpinCheckbox.checked = prefs.autoSpin || false;
+    
+    const displayModeSelect = document.getElementById('pref-display-mode');
+    if (displayModeSelect) {
+        displayModeSelect.value = prefs.defaultDisplayMode || 'ball&stick';
         
-        // Color picker handling
-        function openColorPicker(inputId) {
-            document.getElementById(inputId).click();
-        }
+        // Add change listener for immediate display mode update
+        displayModeSelect.addEventListener('change', function() {
+            applyDisplayMode(this.value);
+            updatePreference('defaultDisplayMode', this.value);
+        });
+    }
+    
+    const showLabelsCheckbox = document.getElementById('pref-show-labels');
+    if (showLabelsCheckbox) {
+        showLabelsCheckbox.checked = prefs.showLabels || false;
         
-        function resetBackgroundColor() {
-            const colorInput = document.getElementById('pref-bg-color');
-            const colorPreview = document.getElementById('bg-color-preview');
-            colorInput.value = '#FFFFFF';
-            colorPreview.style.backgroundColor = '#FFFFFF';
-            updateBackgroundColor('#FFFFFF');
-        }
+        // Add change listener for immediate label update
+        showLabelsCheckbox.addEventListener('change', function() {
+            applyAtomLabels(this.checked);
+        });
+    }
+    
+    const bgColorInput = document.getElementById('pref-bg-color');
+    const bgColorPreview = document.getElementById('bg-color-preview');
+    if (bgColorInput && bgColorPreview) {
+        bgColorInput.value = prefs.bgColor || '#FFFFFF';
+        bgColorPreview.style.backgroundColor = prefs.bgColor || '#FFFFFF';
         
-        function updateBackgroundColor(color) {
+        // Add change listener for immediate background update
+        bgColorInput.addEventListener('change', function() {
+            bgColorPreview.style.backgroundColor = this.value;
+            updateBackgroundColor(this.value);
+        });
+    }
+    
+    const antialiasingCheckbox = document.getElementById('pref-antialiasing');
+    if (antialiasingCheckbox) {
+        antialiasingCheckbox.checked = prefs.antialiasing !== false;
+        
+        // Add change listener for immediate antialiasing update
+        antialiasingCheckbox.addEventListener('change', function() {
             if (jmolApplet0 && jmolApplet0._ready) {
-                // Convert hex color to JSmol script format [xRRGGBB]
-                const jsmolColor = '[x' + color.replace('#', '') + ']';
-                Jmol.script(jmolApplet0, `background ${jsmolColor}`);
-                console.log('Applied background color:', color, '->', jsmolColor);
-                
-                // Update the preference
-                updatePreference('bgColor', color);
+                const antialiasingCmd = this.checked ? 'on' : 'off';
+                Jmol.script(jmolApplet0, `set antialiasDisplay ${antialiasingCmd}`);
+                updatePreference('antialiasing', this.checked);
             }
-        }
+        });
+    }
+    
+    const zoomLevelSelect = document.getElementById('pref-zoom-level');
+    if (zoomLevelSelect) {
+        zoomLevelSelect.value = prefs.zoomLevel || '100';
         
-        // Enhanced preference loading and saving
-        function loadPreferencesIntoUI() {
-            const prefs = getPreferences();
-            
-            // General settings
-            const autoLoadCheckbox = document.getElementById('pref-auto-load');
-            if (autoLoadCheckbox) autoLoadCheckbox.checked = prefs.autoLoadLastMolecule || false;
-            
-            const savePositionsCheckbox = document.getElementById('pref-save-positions');
-            if (savePositionsCheckbox) savePositionsCheckbox.checked = prefs.saveWindowPositions !== false;
-            
-            const showTooltipsCheckbox = document.getElementById('pref-show-tooltips');
-            if (showTooltipsCheckbox) showTooltipsCheckbox.checked = prefs.showTooltips !== false;
-            
-            const confirmOverwriteCheckbox = document.getElementById('pref-confirm-overwrite');
-            if (confirmOverwriteCheckbox) confirmOverwriteCheckbox.checked = prefs.confirmOverwrite !== false;
-            
-            const exportFormatSelect = document.getElementById('pref-export-format');
-            if (exportFormatSelect) exportFormatSelect.value = prefs.exportFormat || 'png';
-            
-            const exportTransparentCheckbox = document.getElementById('pref-export-transparent');
-            if (exportTransparentCheckbox) exportTransparentCheckbox.checked = prefs.exportTransparentBackground !== false;
-            
-            // Display settings  
-            const autoSpinCheckbox = document.getElementById('pref-auto-spin');
-            if (autoSpinCheckbox) autoSpinCheckbox.checked = prefs.autoSpin || false;
-            
-            const displayModeSelect = document.getElementById('pref-display-mode');
-            if (displayModeSelect) {
-                displayModeSelect.value = prefs.defaultDisplayMode || 'ball&stick';
-                
-                // Add change listener for immediate display mode update
-                displayModeSelect.addEventListener('change', function() {
-                    applyDisplayMode(this.value);
-                    updatePreference('defaultDisplayMode', this.value);
-                });
-            }
-            
-            const showLabelsCheckbox = document.getElementById('pref-show-labels');
-            if (showLabelsCheckbox) {
-                showLabelsCheckbox.checked = prefs.showLabels || false;
-                
-                // Add change listener for immediate label update
-                showLabelsCheckbox.addEventListener('change', function() {
-                    applyAtomLabels(this.checked);
-                });
-            }
-            
-            const bgColorInput = document.getElementById('pref-bg-color');
-            const bgColorPreview = document.getElementById('bg-color-preview');
-            if (bgColorInput && bgColorPreview) {
-                bgColorInput.value = prefs.bgColor || '#FFFFFF';
-                bgColorPreview.style.backgroundColor = prefs.bgColor || '#FFFFFF';
-                
-                // Add change listener for immediate background update
-                bgColorInput.addEventListener('change', function() {
-                    bgColorPreview.style.backgroundColor = this.value;
-                    updateBackgroundColor(this.value);
-                });
-            }
-            
-            const antialiasingCheckbox = document.getElementById('pref-antialiasing');
-            if (antialiasingCheckbox) {
-                antialiasingCheckbox.checked = prefs.antialiasing !== false;
-                
-                // Add change listener for immediate antialiasing update
-                antialiasingCheckbox.addEventListener('change', function() {
-                    if (jmolApplet0 && jmolApplet0._ready) {
-                        const antialiasingCmd = this.checked ? 'on' : 'off';
-                        Jmol.script(jmolApplet0, `set antialiasDisplay ${antialiasingCmd}`);
-                        updatePreference('antialiasing', this.checked);
-                    }
-                });
-            }
-            
-            const zoomLevelSelect = document.getElementById('pref-zoom-level');
-            if (zoomLevelSelect) {
-                zoomLevelSelect.value = prefs.zoomLevel || '100';
-                
-                // Add change listener for immediate zoom level update
-                zoomLevelSelect.addEventListener('change', function() {
-                    applyZoomLevel(this.value);
-                });
-            }
-            
-            // Advanced settings
-            const hardwareAccelCheckbox = document.getElementById('pref-hardware-acceleration');
-            if (hardwareAccelCheckbox) hardwareAccelCheckbox.checked = prefs.hardwareAcceleration !== false;
-            
-            const renderQualitySelect = document.getElementById('pref-render-quality');
-            if (renderQualitySelect) renderQualitySelect.value = prefs.renderQuality || 'medium';
-            
-            const memoryLimitInput = document.getElementById('pref-memory-limit');
-            if (memoryLimitInput) memoryLimitInput.value = prefs.memoryLimit || 2048;
-            
-            const debugModeCheckbox = document.getElementById('pref-debug-mode');
-            if (debugModeCheckbox) debugModeCheckbox.checked = prefs.debugMode || false;
-            
-            const detailedLoggingCheckbox = document.getElementById('pref-detailed-logging');
-            if (detailedLoggingCheckbox) detailedLoggingCheckbox.checked = prefs.detailedLogging || false;
-            
-            // ElemCo.jl settings
-            const basisSetSelect = document.getElementById('pref-basis-set');
-            if (basisSetSelect) basisSetSelect.value = prefs.defaultBasisSet || 'cc-pVDZ';
-            
-            const methodSelect = document.getElementById('pref-method');
-            if (methodSelect) methodSelect.value = prefs.defaultMethod || 'HF';
-            
-            const juliaCommandInput = document.getElementById('pref-julia-command');
-            if (juliaCommandInput) juliaCommandInput.value = prefs.juliaCommand || 'julia';
+        // Add change listener for immediate zoom level update
+        zoomLevelSelect.addEventListener('change', function() {
+            applyZoomLevel(this.value);
+        });
+    }
+    
+    // Advanced settings
+    const hardwareAccelCheckbox = document.getElementById('pref-hardware-acceleration');
+    if (hardwareAccelCheckbox) hardwareAccelCheckbox.checked = prefs.hardwareAcceleration !== false;
+    
+    const renderQualitySelect = document.getElementById('pref-render-quality');
+    if (renderQualitySelect) renderQualitySelect.value = prefs.renderQuality || 'medium';
+    
+    const memoryLimitInput = document.getElementById('pref-memory-limit');
+    if (memoryLimitInput) memoryLimitInput.value = prefs.memoryLimit || 2048;
+    
+    const debugModeCheckbox = document.getElementById('pref-debug-mode');
+    if (debugModeCheckbox) debugModeCheckbox.checked = prefs.debugMode || false;
+    
+    const detailedLoggingCheckbox = document.getElementById('pref-detailed-logging');
+    if (detailedLoggingCheckbox) detailedLoggingCheckbox.checked = prefs.detailedLogging || false;
+    
+    // ElemCo.jl settings
+    const basisSetSelect = document.getElementById('pref-basis-set');
+    if (basisSetSelect) basisSetSelect.value = prefs.defaultBasisSet || 'cc-pVDZ';
+    
+    const methodSelect = document.getElementById('pref-method');
+    if (methodSelect) methodSelect.value = prefs.defaultMethod || 'HF';
+    
+    const juliaCommandInput = document.getElementById('pref-julia-command');
+    if (juliaCommandInput) juliaCommandInput.value = prefs.juliaCommand || 'julia';
 
-            const calcTimeoutInput = document.getElementById('pref-calc-timeout');
-            if (calcTimeoutInput) calcTimeoutInput.value = prefs.calcTimeout || 5;
+    const calcTimeoutInput = document.getElementById('pref-calc-timeout');
+    if (calcTimeoutInput) calcTimeoutInput.value = prefs.calcTimeout || 5;
 
-            // xtb settings
-            const xtbCommandInput = document.getElementById('pref-xtb-command');
-            if (xtbCommandInput) xtbCommandInput.value = prefs.xtbCommand || 'xtb';
-            
-            const useDFCheckbox = document.getElementById('pref-use-df');
-            if (useDFCheckbox) useDFCheckbox.checked = prefs.useDF || false;
-            
-            const autoClearOutputCheckbox = document.getElementById('pref-auto-clear-output');
-            if (autoClearOutputCheckbox) autoClearOutputCheckbox.checked = prefs.autoClearOutput !== false;
-            
-            const saveOutputCheckbox = document.getElementById('pref-save-output');
-            if (saveOutputCheckbox) saveOutputCheckbox.checked = prefs.saveOutput || false;
-        }
-        
-        // Save preferences from UI - enhanced version
-        function savePreferencesFromUI() {
-            const prefs = getPreferences();
-            
-            // General settings
-            const autoLoadCheckbox = document.getElementById('pref-auto-load');
-            if (autoLoadCheckbox) prefs.autoLoadLastMolecule = autoLoadCheckbox.checked;
-            
-            const savePositionsCheckbox = document.getElementById('pref-save-positions');
-            if (savePositionsCheckbox) prefs.saveWindowPositions = savePositionsCheckbox.checked;
-            
-            const showTooltipsCheckbox = document.getElementById('pref-show-tooltips');
-            if (showTooltipsCheckbox) prefs.showTooltips = showTooltipsCheckbox.checked;
-            
-            const confirmOverwriteCheckbox = document.getElementById('pref-confirm-overwrite');
-            if (confirmOverwriteCheckbox) prefs.confirmOverwrite = confirmOverwriteCheckbox.checked;
-            
-            const exportFormatSelect = document.getElementById('pref-export-format');
-            if (exportFormatSelect) prefs.exportFormat = exportFormatSelect.value;
-            
-            const exportTransparentCheckbox = document.getElementById('pref-export-transparent');
-            if (exportTransparentCheckbox) prefs.exportTransparentBackground = exportTransparentCheckbox.checked;
-            
-            // Display settings
-            const autoSpinCheckbox = document.getElementById('pref-auto-spin');
-            if (autoSpinCheckbox) prefs.autoSpin = autoSpinCheckbox.checked;
-            
-            const displayModeSelect = document.getElementById('pref-display-mode');
-            if (displayModeSelect) prefs.defaultDisplayMode = displayModeSelect.value;
-            
-            const showLabelsCheckbox = document.getElementById('pref-show-labels');
-            if (showLabelsCheckbox) prefs.showLabels = showLabelsCheckbox.checked;
-            
-            const bgColorInput = document.getElementById('pref-bg-color');
-            if (bgColorInput) prefs.bgColor = bgColorInput.value;
-            
-            const antialiasingCheckbox = document.getElementById('pref-antialiasing');
-            if (antialiasingCheckbox) prefs.antialiasing = antialiasingCheckbox.checked;
-            
-            const zoomLevelSelect = document.getElementById('pref-zoom-level');
-            if (zoomLevelSelect) prefs.zoomLevel = zoomLevelSelect.value;
-            
-            // Advanced settings
-            const hardwareAccelCheckbox = document.getElementById('pref-hardware-acceleration');
-            if (hardwareAccelCheckbox) prefs.hardwareAcceleration = hardwareAccelCheckbox.checked;
-            
-            const renderQualitySelect = document.getElementById('pref-render-quality');
-            if (renderQualitySelect) prefs.renderQuality = renderQualitySelect.value;
-            
-            const memoryLimitInput = document.getElementById('pref-memory-limit');
-            if (memoryLimitInput) prefs.memoryLimit = parseInt(memoryLimitInput.value) || 2048;
-            
-            const debugModeCheckbox = document.getElementById('pref-debug-mode');
-            if (debugModeCheckbox) {
-                prefs.debugMode = debugModeCheckbox.checked;
-                window.jlmolDebug = debugModeCheckbox.checked; // Apply immediately
-            }
-            
-            const detailedLoggingCheckbox = document.getElementById('pref-detailed-logging');
-            if (detailedLoggingCheckbox) prefs.detailedLogging = detailedLoggingCheckbox.checked;
-            
-            // ElemCo.jl settings
-            const basisSetSelect = document.getElementById('pref-basis-set');
-            if (basisSetSelect) prefs.defaultBasisSet = basisSetSelect.value;
-            
-            const methodSelect = document.getElementById('pref-method');
-            if (methodSelect) prefs.defaultMethod = methodSelect.value;
-            
-            const juliaCommandInput = document.getElementById('pref-julia-command');
-            if (juliaCommandInput) prefs.juliaCommand = juliaCommandInput.value.trim() || 'julia';
+    // xtb settings
+    const xtbCommandInput = document.getElementById('pref-xtb-command');
+    if (xtbCommandInput) xtbCommandInput.value = prefs.xtbCommand || 'xtb';
+    
+    const useDFCheckbox = document.getElementById('pref-use-df');
+    if (useDFCheckbox) useDFCheckbox.checked = prefs.useDF || false;
+    
+    const autoClearOutputCheckbox = document.getElementById('pref-auto-clear-output');
+    if (autoClearOutputCheckbox) autoClearOutputCheckbox.checked = prefs.autoClearOutput !== false;
+    
+    const saveOutputCheckbox = document.getElementById('pref-save-output');
+    if (saveOutputCheckbox) saveOutputCheckbox.checked = prefs.saveOutput || false;
+}
 
-            const calcTimeoutInput = document.getElementById('pref-calc-timeout');
-            if (calcTimeoutInput) prefs.calcTimeout = parseInt(calcTimeoutInput.value) || 5;
+// Save preferences from UI - enhanced version
+function savePreferencesFromUI() {
+    const prefs = getPreferences();
+    
+    // General settings
+    const autoLoadCheckbox = document.getElementById('pref-auto-load');
+    if (autoLoadCheckbox) prefs.autoLoadLastMolecule = autoLoadCheckbox.checked;
+    
+    const savePositionsCheckbox = document.getElementById('pref-save-positions');
+    if (savePositionsCheckbox) prefs.saveWindowPositions = savePositionsCheckbox.checked;
+    
+    const showTooltipsCheckbox = document.getElementById('pref-show-tooltips');
+    if (showTooltipsCheckbox) prefs.showTooltips = showTooltipsCheckbox.checked;
+    
+    const confirmOverwriteCheckbox = document.getElementById('pref-confirm-overwrite');
+    if (confirmOverwriteCheckbox) prefs.confirmOverwrite = confirmOverwriteCheckbox.checked;
+    
+    const exportFormatSelect = document.getElementById('pref-export-format');
+    if (exportFormatSelect) prefs.exportFormat = exportFormatSelect.value;
+    
+    const exportTransparentCheckbox = document.getElementById('pref-export-transparent');
+    if (exportTransparentCheckbox) prefs.exportTransparentBackground = exportTransparentCheckbox.checked;
+    
+    // Display settings
+    const autoSpinCheckbox = document.getElementById('pref-auto-spin');
+    if (autoSpinCheckbox) prefs.autoSpin = autoSpinCheckbox.checked;
+    
+    const displayModeSelect = document.getElementById('pref-display-mode');
+    if (displayModeSelect) prefs.defaultDisplayMode = displayModeSelect.value;
+    
+    const showLabelsCheckbox = document.getElementById('pref-show-labels');
+    if (showLabelsCheckbox) prefs.showLabels = showLabelsCheckbox.checked;
+    
+    const bgColorInput = document.getElementById('pref-bg-color');
+    if (bgColorInput) prefs.bgColor = bgColorInput.value;
+    
+    const antialiasingCheckbox = document.getElementById('pref-antialiasing');
+    if (antialiasingCheckbox) prefs.antialiasing = antialiasingCheckbox.checked;
+    
+    const zoomLevelSelect = document.getElementById('pref-zoom-level');
+    if (zoomLevelSelect) prefs.zoomLevel = zoomLevelSelect.value;
+    
+    // Advanced settings
+    const hardwareAccelCheckbox = document.getElementById('pref-hardware-acceleration');
+    if (hardwareAccelCheckbox) prefs.hardwareAcceleration = hardwareAccelCheckbox.checked;
+    
+    const renderQualitySelect = document.getElementById('pref-render-quality');
+    if (renderQualitySelect) prefs.renderQuality = renderQualitySelect.value;
+    
+    const memoryLimitInput = document.getElementById('pref-memory-limit');
+    if (memoryLimitInput) prefs.memoryLimit = parseInt(memoryLimitInput.value) || 2048;
+    
+    const debugModeCheckbox = document.getElementById('pref-debug-mode');
+    if (debugModeCheckbox) {
+        prefs.debugMode = debugModeCheckbox.checked;
+        window.jlmolDebug = debugModeCheckbox.checked; // Apply immediately
+    }
+    
+    const detailedLoggingCheckbox = document.getElementById('pref-detailed-logging');
+    if (detailedLoggingCheckbox) prefs.detailedLogging = detailedLoggingCheckbox.checked;
+    
+    // ElemCo.jl settings
+    const basisSetSelect = document.getElementById('pref-basis-set');
+    if (basisSetSelect) prefs.defaultBasisSet = basisSetSelect.value;
+    
+    const methodSelect = document.getElementById('pref-method');
+    if (methodSelect) prefs.defaultMethod = methodSelect.value;
+    
+    const juliaCommandInput = document.getElementById('pref-julia-command');
+    if (juliaCommandInput) prefs.juliaCommand = juliaCommandInput.value.trim() || 'julia';
 
-            // xtb settings
-            const xtbCommandInput = document.getElementById('pref-xtb-command');
-            if (xtbCommandInput) prefs.xtbCommand = xtbCommandInput.value.trim() || 'xtb';
-            
-            const useDFCheckbox = document.getElementById('pref-use-df');
-            if (useDFCheckbox) prefs.useDF = useDFCheckbox.checked;
-            
-            const autoClearOutputCheckbox = document.getElementById('pref-auto-clear-output');
-            if (autoClearOutputCheckbox) prefs.autoClearOutput = autoClearOutputCheckbox.checked;
-            
-            const saveOutputCheckbox = document.getElementById('pref-save-output');
-            if (saveOutputCheckbox) prefs.saveOutput = saveOutputCheckbox.checked;
-            
-            // Save to storage
-            window.userPreferences = prefs;
-            savePreferences(prefs);
-            
-            // Apply preferences immediately
-            applyPreferences();
-            
-            // Hide panel after saving
-            hidePreferencesPanel();
+    const calcTimeoutInput = document.getElementById('pref-calc-timeout');
+    if (calcTimeoutInput) prefs.calcTimeout = parseInt(calcTimeoutInput.value) || 5;
+
+    // xtb settings
+    const xtbCommandInput = document.getElementById('pref-xtb-command');
+    if (xtbCommandInput) prefs.xtbCommand = xtbCommandInput.value.trim() || 'xtb';
+    
+    const useDFCheckbox = document.getElementById('pref-use-df');
+    if (useDFCheckbox) prefs.useDF = useDFCheckbox.checked;
+    
+    const autoClearOutputCheckbox = document.getElementById('pref-auto-clear-output');
+    if (autoClearOutputCheckbox) prefs.autoClearOutput = autoClearOutputCheckbox.checked;
+    
+    const saveOutputCheckbox = document.getElementById('pref-save-output');
+    if (saveOutputCheckbox) prefs.saveOutput = saveOutputCheckbox.checked;
+    
+    // Save to storage
+    window.userPreferences = prefs;
+    savePreferences(prefs);
+    
+    // Apply preferences immediately
+    applyPreferences();
+    
+    // Hide panel after saving
+    hidePreferencesPanel();
+}
+
+// Enhanced apply preferences function
+function applyPreferences() {
+    const prefs = getPreferences();
+    
+    // Apply auto-spin preference if enabled
+    if (prefs.autoSpin && !isSpinning) {
+        toggleSpin();
+    }
+    
+    // Apply background color
+    if (prefs.bgColor && jmolApplet0 && jmolApplet0._ready) {
+        updateBackgroundColor(prefs.bgColor);
+    }
+    
+    // Apply debug mode
+    window.jlmolDebug = prefs.debugMode || false;
+    
+    // Apply display mode if set
+    if (prefs.defaultDisplayMode) {
+        try {
+            if (displayMode !== prefs.defaultDisplayMode) {
+                console.log('Applying preferred display mode:', prefs.defaultDisplayMode);
+            }
+        } catch (e) {
+            console.warn('Could not apply display mode preference:', e);
+        }
+    }
+    
+    // Apply default basis set to ElemCo panel
+    try {
+        const basisSelect = document.getElementById('elemco-basis');
+        if (basisSelect && prefs.defaultBasisSet) {
+            basisSelect.value = prefs.defaultBasisSet;
         }
         
-        // Enhanced apply preferences function
-        function applyPreferences() {
-            const prefs = getPreferences();
-            
-            // Apply auto-spin preference if enabled
-            if (prefs.autoSpin && !isSpinning) {
-                toggleSpin();
-            }
-            
-            // Apply background color
-            if (prefs.bgColor && jmolApplet0 && jmolApplet0._ready) {
-                updateBackgroundColor(prefs.bgColor);
-            }
-            
-            // Apply debug mode
-            window.jlmolDebug = prefs.debugMode || false;
-            
-            // Apply display mode if set
-            if (prefs.defaultDisplayMode) {
-                try {
-                    if (displayMode !== prefs.defaultDisplayMode) {
-                        console.log('Applying preferred display mode:', prefs.defaultDisplayMode);
-                    }
-                } catch (e) {
-                    console.warn('Could not apply display mode preference:', e);
-                }
-            }
-            
-            // Apply default basis set to ElemCo panel
-            try {
-                const basisSelect = document.getElementById('elemco-basis');
-                if (basisSelect && prefs.defaultBasisSet) {
-                    basisSelect.value = prefs.defaultBasisSet;
-                }
-                
-                // Apply default method to ElemCo panel
-                const methodSelect = document.getElementById('elemco-method');
-                if (methodSelect && prefs.defaultMethod) {
-                    methodSelect.value = prefs.defaultMethod;
-                }
-                
-                // Apply DF preference
-                const dfCheckbox = document.getElementById('elemco-df');
-                if (dfCheckbox && prefs.useDF !== undefined) {
-                    dfCheckbox.checked = prefs.useDF;
-                    updateMethodOptions(); // Update available methods based on DF setting
-                }
-                
-                // Update ElemCo input with these preferences
-                if ((basisSelect || methodSelect) && typeof updateElemCoInput === 'function') {
-                    updateElemCoInput();
-                }
-            } catch (e) {
-                console.warn('Could not apply ElemCo preferences:', e);
-            }
+        // Apply default method to ElemCo panel
+        const methodSelect = document.getElementById('elemco-method');
+        if (methodSelect && prefs.defaultMethod) {
+            methodSelect.value = prefs.defaultMethod;
         }
         
-        // Load preferences from localStorage
-        function loadPreferences() {
-            try {
-                const saved = localStorage.getItem('jlmol-preferences');
-                if (saved) {
-                    return { ...DEFAULT_PREFERENCES, ...JSON.parse(saved) };
-                }
-            } catch (error) {
-                console.warn('Error loading preferences:', error);
-            }
-            return { ...DEFAULT_PREFERENCES };
+        // Apply DF preference
+        const dfCheckbox = document.getElementById('elemco-df');
+        if (dfCheckbox && prefs.useDF !== undefined) {
+            dfCheckbox.checked = prefs.useDF;
+            updateMethodOptions(); // Update available methods based on DF setting
         }
         
-        // Save preferences to localStorage
-        function savePreferences(preferences) {
-            try {
-                localStorage.setItem('jlmol-preferences', JSON.stringify(preferences));
-                document.getElementById('status').innerHTML = 'Preferences saved';
-                return true;
-            } catch (error) {
-                console.error('Error saving preferences:', error);
-                document.getElementById('status').innerHTML = 'Error saving preferences';
-                return false;
-            }
+        // Update ElemCo input with these preferences
+        if ((basisSelect || methodSelect) && typeof updateElemCoInput === 'function') {
+            updateElemCoInput();
+        }
+    } catch (e) {
+        console.warn('Could not apply ElemCo preferences:', e);
+    }
+}
+
+// Load preferences from localStorage
+function loadPreferences() {
+    try {
+        const saved = localStorage.getItem('jlmol-preferences');
+        if (saved) {
+            return { ...DEFAULT_PREFERENCES, ...JSON.parse(saved) };
+        }
+    } catch (error) {
+        console.warn('Error loading preferences:', error);
+    }
+    return { ...DEFAULT_PREFERENCES };
+}
+
+// Save preferences to localStorage
+function savePreferences(preferences) {
+    try {
+        localStorage.setItem('jlmol-preferences', JSON.stringify(preferences));
+        document.getElementById('status').innerHTML = 'Preferences saved';
+        return true;
+    } catch (error) {
+        console.error('Error saving preferences:', error);
+        document.getElementById('status').innerHTML = 'Error saving preferences';
+        return false;
+    }
+}
+
+// Get current preferences
+function getPreferences() {
+    return window.userPreferences || loadPreferences();
+}
+
+// Apply JSmol-specific preferences to the viewer
+function applyJSmolPreferences() {
+    if (!jmolApplet0 || !jmolApplet0._ready) {
+        console.log('JSmol not ready, skipping preference application');
+        return;
+    }
+    
+    const prefs = getPreferences();
+    
+    try {
+        // Apply background color
+        if (prefs.bgColor) {
+            const jsmolColor = '[x' + prefs.bgColor.replace('#', '') + ']';
+            Jmol.script(jmolApplet0, `background ${jsmolColor}`);
+            console.log('Applied background color:', prefs.bgColor, '->', jsmolColor);
         }
         
-        // Get current preferences
-        function getPreferences() {
-            return window.userPreferences || loadPreferences();
+        // Apply antialiasing
+        if (prefs.antialiasing !== undefined) {
+            const antialiasingCmd = prefs.antialiasing ? 'on' : 'off';
+            Jmol.script(jmolApplet0, `set antialiasDisplay ${antialiasingCmd}`);
+            console.log('Applied antialiasing:', prefs.antialiasing);
         }
         
-        // Apply JSmol-specific preferences to the viewer
-        function applyJSmolPreferences() {
-            if (!jmolApplet0 || !jmolApplet0._ready) {
-                console.log('JSmol not ready, skipping preference application');
-                return;
-            }
-            
-            const prefs = getPreferences();
-            
-            try {
-                // Apply background color
-                if (prefs.bgColor) {
-                    const jsmolColor = '[x' + prefs.bgColor.replace('#', '') + ']';
-                    Jmol.script(jmolApplet0, `background ${jsmolColor}`);
-                    console.log('Applied background color:', prefs.bgColor, '->', jsmolColor);
-                }
-                
-                // Apply antialiasing
-                if (prefs.antialiasing !== undefined) {
-                    const antialiasingCmd = prefs.antialiasing ? 'on' : 'off';
-                    Jmol.script(jmolApplet0, `set antialiasDisplay ${antialiasingCmd}`);
-                    console.log('Applied antialiasing:', prefs.antialiasing);
-                }
-                
-                // Apply atom labels
-                if (prefs.showLabels) {
-                    Jmol.script(jmolApplet0, 'label %e');
-                    console.log('Applied atom labels: ON');
-                } else {
-                    Jmol.script(jmolApplet0, 'label off');
-                }
-                
-                // Apply display mode
-                if (prefs.defaultDisplayMode) {
-                    applyDisplayMode(prefs.defaultDisplayMode);
-                    console.log('Applied display mode:', prefs.defaultDisplayMode);
-                }
-                
-                // Apply zoom level
-                if (prefs.zoomLevel && prefs.zoomLevel !== '100') {
-                    const zoom = parseInt(prefs.zoomLevel);
-                    Jmol.script(jmolApplet0, `zoom ${zoom}`);
-                    console.log('Applied zoom level:', zoom);
-                }
-                
-                // Apply auto-spin
-                if (prefs.autoSpin && !isSpinning) {
-                    Jmol.script(jmolApplet0, 'spin on');
-                    isSpinning = true;
-                    console.log('Applied auto-spin: ON');
-                }
-                
-            } catch (error) {
-                console.error('Error applying JSmol preferences:', error);
-            }
+        // Apply atom labels
+        if (prefs.showLabels) {
+            Jmol.script(jmolApplet0, 'label %e');
+            console.log('Applied atom labels: ON');
+        } else {
+            Jmol.script(jmolApplet0, 'label off');
         }
         
-        // Helper function to apply display mode
-        function applyDisplayMode(mode) {
-            if (!jmolApplet0 || !jmolApplet0._ready) return;
-            
-            try {
-                switch (mode) {
-                    case 'wireframe':
-                        Jmol.script(jmolApplet0, 'wireframe only');
-                        break;
-                    case 'ball&stick':
-                        Jmol.script(jmolApplet0, 'wireframe 0.15; spacefill 20%');
-                        break;
-                    case 'spacefill':
-                        Jmol.script(jmolApplet0, 'spacefill only');
-                        break;
-                    default:
-                        Jmol.script(jmolApplet0, 'wireframe 0.15; spacefill 20%');
-                }
-                displayMode = mode;
-            } catch (error) {
-                console.error('Error applying display mode:', error);
-            }
+        // Apply display mode
+        if (prefs.defaultDisplayMode) {
+            applyDisplayMode(prefs.defaultDisplayMode);
+            console.log('Applied display mode:', prefs.defaultDisplayMode);
         }
         
-        // Helper function to apply zoom level
-        function applyZoomLevel(zoomLevel) {
-            if (!jmolApplet0 || !jmolApplet0._ready) return;
-            
-            try {
-                const zoom = parseInt(zoomLevel);
-                Jmol.script(jmolApplet0, `zoom ${zoom}`);
-                updatePreference('zoomLevel', zoomLevel);
-            } catch (error) {
-                console.error('Error applying zoom level:', error);
-            }
+        // Apply zoom level
+        if (prefs.zoomLevel && prefs.zoomLevel !== '100') {
+            const zoom = parseInt(prefs.zoomLevel);
+            Jmol.script(jmolApplet0, `zoom ${zoom}`);
+            console.log('Applied zoom level:', zoom);
         }
         
-        // Helper function to apply atom labels
-        function applyAtomLabels(showLabels) {
-            if (!jmolApplet0 || !jmolApplet0._ready) return;
-            
-            try {
-                if (showLabels) {
-                    Jmol.script(jmolApplet0, 'label %e');
-                } else {
-                    Jmol.script(jmolApplet0, 'label off');
-                }
-                updatePreference('showLabels', showLabels);
-            } catch (error) {
-                console.error('Error applying atom labels:', error);
-            }
+        // Apply auto-spin
+        if (prefs.autoSpin && !isSpinning) {
+            Jmol.script(jmolApplet0, 'spin on');
+            isSpinning = true;
+            console.log('Applied auto-spin: ON');
         }
         
-        // Update a specific preference
-        function updatePreference(key, value) {
-            const preferences = getPreferences();
-            preferences[key] = value;
-            window.userPreferences = preferences;
-            savePreferences(preferences);
+    } catch (error) {
+        console.error('Error applying JSmol preferences:', error);
+    }
+}
+
+// Helper function to apply display mode
+function applyDisplayMode(mode) {
+    if (!jmolApplet0 || !jmolApplet0._ready) return;
+    
+    try {
+        switch (mode) {
+            case 'wireframe':
+                Jmol.script(jmolApplet0, 'wireframe only');
+                break;
+            case 'ball&stick':
+                Jmol.script(jmolApplet0, 'wireframe 0.15; spacefill 20%');
+                break;
+            case 'spacefill':
+                Jmol.script(jmolApplet0, 'spacefill only');
+                break;
+            default:
+                Jmol.script(jmolApplet0, 'wireframe 0.15; spacefill 20%');
         }
-        
-        // Initialize preferences
-        function initPreferences() {
-            // Load preferences
-            window.userPreferences = loadPreferences();
-            
-            // Apply preferences
-            applyPreferences();
-            
-            console.log('User preferences initialized');
+        displayMode = mode;
+    } catch (error) {
+        console.error('Error applying display mode:', error);
+    }
+}
+
+// Helper function to apply zoom level
+function applyZoomLevel(zoomLevel) {
+    if (!jmolApplet0 || !jmolApplet0._ready) return;
+    
+    try {
+        const zoom = parseInt(zoomLevel);
+        Jmol.script(jmolApplet0, `zoom ${zoom}`);
+        updatePreference('zoomLevel', zoomLevel);
+    } catch (error) {
+        console.error('Error applying zoom level:', error);
+    }
+}
+
+// Helper function to apply atom labels
+function applyAtomLabels(showLabels) {
+    if (!jmolApplet0 || !jmolApplet0._ready) return;
+    
+    try {
+        if (showLabels) {
+            Jmol.script(jmolApplet0, 'label %e');
+        } else {
+            Jmol.script(jmolApplet0, 'label off');
         }
-        
-        // Show preferences panel
-        function showPreferencesPanel() {
-            const panel = document.getElementById('preferencesPanel');
-            if (panel) {
-                panel.style.display = 'block';
-                // Reset transform to avoid it appearing in a strange location if previously dragged
-                panel.style.transform = 'translate(0px, 0px)';
-                loadPreferencesIntoUI();
-            }
-        }
-        
-        // Hide preferences panel
-        function hidePreferencesPanel() {
-            const panel = document.getElementById('preferencesPanel');
-            if (panel) {
-                panel.style.display = 'none';
-            }
-        }
-        
-        // Reset preferences to defaults
-        function resetPreferencesToDefaults() {
-            if (confirm('Reset all preferences to default values?')) {
-                window.userPreferences = { ...DEFAULT_PREFERENCES };
-                savePreferences(window.userPreferences);
-                loadPreferencesIntoUI();
-                applyPreferences();
-                document.getElementById('status').innerHTML = 'Preferences reset to defaults';
-            }
-        }
+        updatePreference('showLabels', showLabels);
+    } catch (error) {
+        console.error('Error applying atom labels:', error);
+    }
+}
+
+// Update a specific preference
+function updatePreference(key, value) {
+    const preferences = getPreferences();
+    preferences[key] = value;
+    window.userPreferences = preferences;
+    savePreferences(preferences);
+}
+
+// Initialize preferences
+function initPreferences() {
+    // Load preferences
+    window.userPreferences = loadPreferences();
+    
+    // Apply preferences
+    applyPreferences();
+    
+    console.log('User preferences initialized');
+}
+
+// Show preferences panel
+function showPreferencesPanel() {
+    const panel = document.getElementById('preferencesPanel');
+    if (panel) {
+        panel.style.display = 'block';
+        // Reset transform to avoid it appearing in a strange location if previously dragged
+        panel.style.transform = 'translate(0px, 0px)';
+        loadPreferencesIntoUI();
+    }
+}
+
+// Hide preferences panel
+function hidePreferencesPanel() {
+    const panel = document.getElementById('preferencesPanel');
+    if (panel) {
+        panel.style.display = 'none';
+    }
+}
+
+// Reset preferences to defaults
+function resetPreferencesToDefaults() {
+    if (confirm('Reset all preferences to default values?')) {
+        window.userPreferences = { ...DEFAULT_PREFERENCES };
+        savePreferences(window.userPreferences);
+        loadPreferencesIntoUI();
+        applyPreferences();
+        document.getElementById('status').innerHTML = 'Preferences reset to defaults';
+    }
+}

--- a/js/search.js
+++ b/js/search.js
@@ -1,556 +1,556 @@
-        function handleFileSelect(evt) {
-            var files = evt.target.files;
-            if (files.length > 0) {
-                var file = files[0];
-                var reader = new FileReader();
-                reader.onload = function(e) {
-                    try {
-                        // Save current display mode
-                        const currentDisplayMode = displayMode || 'default';
-                        
-                        const fileContent = e.target.result;
-                        const fileName = file.name.toLowerCase();
-                        
-                        // Check if it's an XYZ file and use custom loader
-                        if (fileName.endsWith('.xyz')) {
-                            // Don't automatically set shouldUseNumberedAtoms to true
-                            // Instead, let loadXYZWithNumberedAtoms detect if numbered atoms are present
-                            loadXYZWithNumberedAtoms(fileContent);
-                        } else {
-                            // Clear numbered atom names for non-XYZ files
-                            clearOriginalAtomNames();
-                            originalXYZContent = null;
-                            shouldUseNumberedAtoms = false; // Non-XYZ files should not use numbered atoms
-                            
-                            // Clear database metadata since this is not a database load
-                            window.databaseMetadata = null;
-                            
-                            // Use normal loading for other file types
-                            Jmol.script(jmolApplet0, 'load inline "' + fileContent + '" filter "NOSORT"');
-                            document.getElementById('status').innerHTML = 'File loaded successfully';
-                            
-                            // Refresh atom names to remove any numbered indices for non-XYZ files
-                            setTimeout(() => {
-                                refreshAtomNames();
-                                console.log('handleFileSelect: Atom names refreshed for non-XYZ file');
-                                
-                                // Update MOL file data for JSME integration after file loading
-                                try {
-                                    lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                                    debugLog('File', 'Updated lastMolFile after loading non-XYZ file');
-                                } catch (molError) {
-                                    console.error('Error updating MOL file data in handleFileSelect:', molError);
-                                }
-                            }, 100);
-                        }
-                        
-                        // Restore display mode after loading with a delay
-                        setTimeout(() => {
-                            console.log('handleFileSelect: Restoring display mode:', currentDisplayMode);
-                            setDisplayMode(currentDisplayMode);
-                            
-                            // Apply all JSmol preferences after loading
-                            if (typeof applyJSmolPreferences === 'function') {
-                                applyJSmolPreferences();
-                                console.log('handleFileSelect: Applied JSmol preferences');
-                            }
-                        }, 300);
-                        
-                    } catch (err) {
-                        document.getElementById('status').innerHTML = 'Error loading file: ' + err.message;
-                    }
-                };
-                reader.readAsText(file);
-            }
-        }
-
-        function loadSample(filename) {
+function handleFileSelect(evt) {
+    var files = evt.target.files;
+    if (files.length > 0) {
+        var file = files[0];
+        var reader = new FileReader();
+        reader.onload = function(e) {
             try {
                 // Save current display mode
                 const currentDisplayMode = displayMode || 'default';
                 
-                // Clear any existing numbered atom names since this is a sample load
-                clearOriginalAtomNames();
-                originalXYZContent = null;
-                shouldUseNumberedAtoms = false; // Sample loads should not use numbered atoms
+                const fileContent = e.target.result;
+                const fileName = file.name.toLowerCase();
                 
-                // Clear database metadata since this is not a database load
-                window.databaseMetadata = null;
-                
-                Jmol.script(jmolApplet0, 'load "jsmol/data/' + filename + '"');
-                document.getElementById('status').innerHTML = 'Sample loaded successfully';
+                // Check if it's an XYZ file and use custom loader
+                if (fileName.endsWith('.xyz')) {
+                    // Don't automatically set shouldUseNumberedAtoms to true
+                    // Instead, let loadXYZWithNumberedAtoms detect if numbered atoms are present
+                    loadXYZWithNumberedAtoms(fileContent);
+                } else {
+                    // Clear numbered atom names for non-XYZ files
+                    clearOriginalAtomNames();
+                    originalXYZContent = null;
+                    shouldUseNumberedAtoms = false; // Non-XYZ files should not use numbered atoms
+                    
+                    // Clear database metadata since this is not a database load
+                    window.databaseMetadata = null;
+                    
+                    // Use normal loading for other file types
+                    Jmol.script(jmolApplet0, 'load inline "' + fileContent + '" filter "NOSORT"');
+                    document.getElementById('status').innerHTML = 'File loaded successfully';
+                    
+                    // Refresh atom names to remove any numbered indices for non-XYZ files
+                    setTimeout(() => {
+                        refreshAtomNames();
+                        console.log('handleFileSelect: Atom names refreshed for non-XYZ file');
+                        
+                        // Update MOL file data for JSME integration after file loading
+                        try {
+                            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                            debugLog('File', 'Updated lastMolFile after loading non-XYZ file');
+                        } catch (molError) {
+                            console.error('Error updating MOL file data in handleFileSelect:', molError);
+                        }
+                    }, 100);
+                }
                 
                 // Restore display mode after loading with a delay
                 setTimeout(() => {
-                    console.log('loadSample: Restoring display mode:', currentDisplayMode);
+                    console.log('handleFileSelect: Restoring display mode:', currentDisplayMode);
                     setDisplayMode(currentDisplayMode);
                     
                     // Apply all JSmol preferences after loading
                     if (typeof applyJSmolPreferences === 'function') {
                         applyJSmolPreferences();
-                        console.log('loadSample: Applied JSmol preferences');
+                        console.log('handleFileSelect: Applied JSmol preferences');
                     }
-                    
-                    // Refresh atom names to remove any numbered indices
-                    setTimeout(() => {
-                        refreshAtomNames();
-                        console.log('loadSample: Atom names refreshed to remove numbered indices');
-                        
-                        // Update MOL file data for JSME integration after sample loading
-                        try {
-                            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                            debugLog('Sample', 'Updated lastMolFile after loading sample');
-                        } catch (molError) {
-                            console.error('Error updating MOL file data in loadSample:', molError);
-                        }
-                    }, 100);
-                }, 200);
+                }, 300);
                 
             } catch (err) {
-                document.getElementById('status').innerHTML = 'Error loading sample: ' + err.message;
-            }
-        }
-
-        // Database loading functions
-        async function loadFromDatabase(identifier) {
-            try {
-                // Handle PubChem database queries
-                let statusMessage = 'Loading from PubChem...';
-                let loadCommand = identifier;
-                
-                // Store database metadata for XYZ generation
-                let dbMetadata = {
-                    source: 'PubChem',
-                    originalQuery: identifier,
-                    queryType: null,
-                    cid: null,
-                    name: null,
-                    smiles: null,
-                    formula: null
-                };
-                
-                if (identifier.startsWith(':smiles:')) {
-                    const smiles = identifier.substring(8);
-                    statusMessage = `Loading SMILES "${smiles}" from PubChem...`;
-                    dbMetadata.queryType = 'SMILES';
-                    dbMetadata.smiles = smiles;
-                } else if (identifier.startsWith(':formula:')) {
-                    const formula = identifier.substring(9);
-                    statusMessage = `Loading molecular formula "${formula}" from PubChem...`;
-                    dbMetadata.queryType = 'Formula';
-                    dbMetadata.formula = formula;
-                    
-                    // Two-step process for formula searches:
-                    // Step 1: Get CIDs for the formula
-                    document.getElementById('status').innerHTML = `Step 1: Finding compounds with formula "${formula}"...`;
-                    
-                    try {
-                        const cidUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/fastformula/${encodeURIComponent(formula)}/cids/TXT`;
-                        console.log('Fetching CIDs from:', cidUrl);
-                        
-                        const cidResponse = await fetch(cidUrl);
-                        if (!cidResponse.ok) {
-                            throw new Error(`No compounds found for formula "${formula}" (Status: ${cidResponse.status})`);
-                        }
-                        
-                        const cidText = await cidResponse.text();
-                        const cids = cidText.trim().split('\n').filter(line => line.trim());
-                        
-                        if (cids.length === 0) {
-                            throw new Error(`No compounds found for formula "${formula}"`);
-                        }
-                        
-                        const firstCid = cids[0];
-                        console.log(`Found ${cids.length} compounds for formula "${formula}", using CID: ${firstCid}`);
-                        dbMetadata.cid = firstCid;
-                        
-                        // Step 2: Get SDF for the first CID (try 3D first, fallback to 2D)
-                        document.getElementById('status').innerHTML = `Step 2: Loading structure for CID ${firstCid}...`;
-                        
-                        // Try 3D first
-                        let sdfUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${firstCid}/SDF?record_type=3d`;
-                        try {
-                            const sdfTest = await fetch(sdfUrl);
-                            if (!sdfTest.ok) {
-                                // Fallback to 2D if 3D not available
-                                console.log(`3D structure not available for CID ${firstCid}, using 2D structure`);
-                                sdfUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${firstCid}/SDF`;
-                            }
-                        } catch (e) {
-                            // Fallback to 2D if 3D fails
-                            console.log(`3D structure test failed for CID ${firstCid}, using 2D structure`);
-                            sdfUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${firstCid}/SDF`;
-                        }
-                        
-                        loadCommand = sdfUrl;
-                        statusMessage = `Loading molecular formula "${formula}" (CID: ${firstCid}) from PubChem...`;
-                        
-                    } catch (formulaError) {
-                        console.error('Formula search error:', formulaError);
-                        document.getElementById('status').innerHTML = `Error: ${formulaError.message}`;
-                        return;
-                    }
-                } else if (identifier.startsWith(':')) {
-                    const query = identifier.substring(1);
-                    // Check if it's a number (CID) or name
-                    if (/^\d+$/.test(query)) {
-                        statusMessage = `Loading CID ${query} from PubChem...`;
-                        dbMetadata.queryType = 'CID';
-                        dbMetadata.cid = query;
-                    } else {
-                        statusMessage = `Loading "${query}" by name from PubChem...`;
-                        dbMetadata.queryType = 'Name';
-                        dbMetadata.name = query;
-                    }
-                }
-                
-                document.getElementById('status').innerHTML = statusMessage;
-                
-                // Save current display mode
-                const currentDisplayMode = displayMode || 'default';
-                
-                // Clear any existing numbered atom names since this is a database load
-                clearOriginalAtomNames();
-                shouldUseNumberedAtoms = false; // Database loads should not use numbered atoms
-                console.log('loadFromDatabase: Set shouldUseNumberedAtoms to false for database load');
-                
-                // Store metadata globally for XYZ generation
-                window.databaseMetadata = dbMetadata;
-                console.log('Stored database metadata:', dbMetadata);
-                
-                console.log('Loading with command:', loadCommand);
-                Jmol.script(jmolApplet0, 'load "' + loadCommand + '"');
-                
-                // Restore display mode after loading with a delay
-                setTimeout(() => {
-                    setDisplayMode(currentDisplayMode);
-                    document.getElementById('status').innerHTML = 'Structure loaded successfully from PubChem';
-                    
-                    // Apply all JSmol preferences after loading
-                    if (typeof applyJSmolPreferences === 'function') {
-                        applyJSmolPreferences();
-                        console.log('loadFromDatabase: Applied JSmol preferences');
-                    }
-                    
-                    // Refresh atom names to remove any numbered indices
-                    setTimeout(() => {
-                        refreshAtomNames();
-                        console.log('loadFromDatabase: Atom names refreshed to remove numbered indices');
-                        
-                        // Update MOL file data for JSME integration after database loading
-                        try {
-                            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                            debugLog('Database', 'Updated lastMolFile after loading from database');
-                        } catch (molError) {
-                            console.error('Error updating MOL file data in loadFromDatabase:', molError);
-                        }
-                    }, 100);
-                }, 1000);
-                
-            } catch (err) {
-                console.error('loadFromDatabase error:', err);
-                document.getElementById('status').innerHTML = 'Error loading from PubChem: ' + err.message;
-            }
-        }
-
-        // Helper function to detect if a string looks like a molecular formula
-        function isMolecularFormula(str) {
-            // Molecular formula pattern: starts with capital letter, contains only element symbols and numbers
-            // Examples: H2O, C6H12O6, NaCl, C8H10N4O2, CH4, CO2, LiH, BeH2, MgO
-            const formulaPattern = /^[A-Z][a-z]?\d*([A-Z][a-z]?\d*)*$/;
-            
-            // Must match the pattern and contain at least one element symbol
-            if (!formulaPattern.test(str)) {
-                return false;
-            }
-            
-            // Additional check: should not contain SMILES-specific characters
-            if (/[=@#\[\]()]/.test(str)) {
-                return false;
-            }
-            
-            // Check if it contains valid element symbols
-            // Common elements include H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, etc.
-            const validElements = [
-                'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
-                'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca',
-                'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn',
-                'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr',
-                'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn',
-                'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd',
-                'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb',
-                'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg',
-                'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn'
-            ];
-            
-            // Extract all element symbols from the formula
-            const elements = str.match(/[A-Z][a-z]?/g) || [];
-            
-            // Check if all extracted elements are valid
-            for (const element of elements) {
-                if (!validElements.includes(element)) {
-                    return false;
-                }
-            }
-            
-            // Must contain at least one element
-            if (elements.length === 0) {
-                return false;
-            }
-            
-            // If it looks like a molecular formula and contains valid elements, treat it as a formula
-            return true;
-        }
-
-        function looksLikeChemicalName(str) {
-            if (!/^[A-Za-z0-9\s,()-]+$/.test(str) || !/[A-Za-z]/.test(str)) {
-                return false;
-            }
-
-            // IUPAC-style names often use comma-separated locants such as "3,4-" or "N,N-"
-            if (str.includes(',')) {
-                return true;
-            }
-
-            // Numeric locants followed by a hyphen and a word are more likely names than SMILES
-            return /\d+(?:,\d+)*[A-Za-z]?-[A-Za-z]*[a-z]{2,}/.test(str);
-        }
-
-        async function loadFromPubChem() {
-            const query = document.getElementById('pubchemInput').value.trim();
-            if (!query) {
-                document.getElementById('status').innerHTML = 'Please enter a search term';
-                return;
-            }
-            
-            const searchType = getCurrentSearchType();
-            let prefix = ':';
-            
-            // Use explicit search type if selected, otherwise auto-detect
-            if (searchType === 'cid') {
-                prefix = ':';
-            } else if (searchType === 'name') {
-                prefix = ':';
-            } else if (searchType === 'formula') {
-                prefix = ':formula:';
-            } else if (searchType === 'smiles') {
-                prefix = ':smiles:';
-            } else if (searchType === 'auto') {
-                // Auto-detect query type based on input (existing logic)
-                // Check if it's a pure number (CID)
-                if (/^\d+$/.test(query)) {
-                    prefix = ':';
-                }
-                // Check if it's a molecular formula
-                else if (isMolecularFormula(query)) {
-                    prefix = ':formula:';
-                }
-                // Chemical names with locants such as "3,4-" or "2-" should stay name searches
-                else if (looksLikeChemicalName(query)) {
-                    prefix = ':';
-                }
-                // Check if it's a SMILES string (more specific patterns)
-                else if (/[=@#]|[\[\]()]|[cC][cC]|[nN][oO]|[sS][iI]|[pP][hH]|\d[nNcCoOsS]|[nNcCoOsS]\d|\+|-/.test(query) && 
-                         !/^[a-zA-Z\s\-_()]+$/.test(query)) {
-                    prefix = ':smiles:';
-                }
-                // Otherwise treat as name (default)
-                else {
-                    prefix = ':';
-                }
-            }
-            
-            await loadFromDatabase(prefix + query);
-        }
-
-        // Test function for molecular formula search
-        function testFormulaSearch(formula) {
-            const input = document.getElementById('pubchemInput');
-            input.value = formula;
-            
-            // Set search type to formula
-            currentSearchType = 'formula';
-            updateInputPlaceholder();
-            
-            // Update dropdown UI to show formula is selected
-            const options = document.querySelectorAll('.search-type-option');
-            options.forEach(option => option.classList.remove('selected'));
-            const formulaOption = document.querySelector('.search-type-option[data-value="formula"]');
-            if (formulaOption) {
-                formulaOption.classList.add('selected');
-            }
-            
-            // Perform the search
-            loadFromPubChem();
-        }
-
-        // Debug function to test dropdown (can be called from console)
-        window.testDropdown = function() {
-            console.log('Testing dropdown...');
-            const button = document.getElementById('searchTypeSelectorButton');
-            const dropdown = document.getElementById('searchTypeDropdown');
-            
-            console.log('Elements:', { button: !!button, dropdown: !!dropdown });
-            
-            if (button && dropdown) {
-                console.log('Button click listeners:', button.onclick, button.addEventListener ? 'has addEventListener' : 'no addEventListener');
-                console.log('Attempting to toggle dropdown...');
-                toggleSearchTypeDropdown();
-                return 'Dropdown toggle attempted';
-            } else {
-                return 'Elements not found';
+                document.getElementById('status').innerHTML = 'Error loading file: ' + err.message;
             }
         };
+        reader.readAsText(file);
+    }
+}
 
-        // Add keyboard event handlers for database inputs
-        function setupDatabaseInputHandlers() {
-            console.log('setupDatabaseInputHandlers called');
+function loadSample(filename) {
+    try {
+        // Save current display mode
+        const currentDisplayMode = displayMode || 'default';
+        
+        // Clear any existing numbered atom names since this is a sample load
+        clearOriginalAtomNames();
+        originalXYZContent = null;
+        shouldUseNumberedAtoms = false; // Sample loads should not use numbered atoms
+        
+        // Clear database metadata since this is not a database load
+        window.databaseMetadata = null;
+        
+        Jmol.script(jmolApplet0, 'load "jsmol/data/' + filename + '"');
+        document.getElementById('status').innerHTML = 'Sample loaded successfully';
+        
+        // Restore display mode after loading with a delay
+        setTimeout(() => {
+            console.log('loadSample: Restoring display mode:', currentDisplayMode);
+            setDisplayMode(currentDisplayMode);
             
-            const pubchemInput = document.getElementById('pubchemInput');
-            const searchTypeButton = document.getElementById('searchTypeSelectorButton');
-            const dropdown = document.getElementById('searchTypeDropdown');
-            
-            // Check if elements exist
-            if (!pubchemInput || !searchTypeButton || !dropdown) {
-                console.error('Database input elements not found:', {
-                    pubchemInput: !!pubchemInput,
-                    searchTypeButton: !!searchTypeButton,
-                    dropdown: !!dropdown
-                });
-                // Retry after a short delay
-                setTimeout(() => {
-                    console.log('Retrying setupDatabaseInputHandlers...');
-                    setupDatabaseInputHandlers();
-                }, 500);
-                return;
+            // Apply all JSmol preferences after loading
+            if (typeof applyJSmolPreferences === 'function') {
+                applyJSmolPreferences();
+                console.log('loadSample: Applied JSmol preferences');
             }
             
-            // Check if already initialized to prevent duplicate listeners
-            if (pubchemInput._handlersInitialized) {
-                console.log('Database input handlers already initialized, skipping...');
+            // Refresh atom names to remove any numbered indices
+            setTimeout(() => {
+                refreshAtomNames();
+                console.log('loadSample: Atom names refreshed to remove numbered indices');
+                
+                // Update MOL file data for JSME integration after sample loading
+                try {
+                    lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                    debugLog('Sample', 'Updated lastMolFile after loading sample');
+                } catch (molError) {
+                    console.error('Error updating MOL file data in loadSample:', molError);
+                }
+            }, 100);
+        }, 200);
+        
+    } catch (err) {
+        document.getElementById('status').innerHTML = 'Error loading sample: ' + err.message;
+    }
+}
+
+// Database loading functions
+async function loadFromDatabase(identifier) {
+    try {
+        // Handle PubChem database queries
+        let statusMessage = 'Loading from PubChem...';
+        let loadCommand = identifier;
+        
+        // Store database metadata for XYZ generation
+        let dbMetadata = {
+            source: 'PubChem',
+            originalQuery: identifier,
+            queryType: null,
+            cid: null,
+            name: null,
+            smiles: null,
+            formula: null
+        };
+        
+        if (identifier.startsWith(':smiles:')) {
+            const smiles = identifier.substring(8);
+            statusMessage = `Loading SMILES "${smiles}" from PubChem...`;
+            dbMetadata.queryType = 'SMILES';
+            dbMetadata.smiles = smiles;
+        } else if (identifier.startsWith(':formula:')) {
+            const formula = identifier.substring(9);
+            statusMessage = `Loading molecular formula "${formula}" from PubChem...`;
+            dbMetadata.queryType = 'Formula';
+            dbMetadata.formula = formula;
+            
+            // Two-step process for formula searches:
+            // Step 1: Get CIDs for the formula
+            document.getElementById('status').innerHTML = `Step 1: Finding compounds with formula "${formula}"...`;
+            
+            try {
+                const cidUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/fastformula/${encodeURIComponent(formula)}/cids/TXT`;
+                console.log('Fetching CIDs from:', cidUrl);
+                
+                const cidResponse = await fetch(cidUrl);
+                if (!cidResponse.ok) {
+                    throw new Error(`No compounds found for formula "${formula}" (Status: ${cidResponse.status})`);
+                }
+                
+                const cidText = await cidResponse.text();
+                const cids = cidText.trim().split('\n').filter(line => line.trim());
+                
+                if (cids.length === 0) {
+                    throw new Error(`No compounds found for formula "${formula}"`);
+                }
+                
+                const firstCid = cids[0];
+                console.log(`Found ${cids.length} compounds for formula "${formula}", using CID: ${firstCid}`);
+                dbMetadata.cid = firstCid;
+                
+                // Step 2: Get SDF for the first CID (try 3D first, fallback to 2D)
+                document.getElementById('status').innerHTML = `Step 2: Loading structure for CID ${firstCid}...`;
+                
+                // Try 3D first
+                let sdfUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${firstCid}/SDF?record_type=3d`;
+                try {
+                    const sdfTest = await fetch(sdfUrl);
+                    if (!sdfTest.ok) {
+                        // Fallback to 2D if 3D not available
+                        console.log(`3D structure not available for CID ${firstCid}, using 2D structure`);
+                        sdfUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${firstCid}/SDF`;
+                    }
+                } catch (e) {
+                    // Fallback to 2D if 3D fails
+                    console.log(`3D structure test failed for CID ${firstCid}, using 2D structure`);
+                    sdfUrl = `https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/${firstCid}/SDF`;
+                }
+                
+                loadCommand = sdfUrl;
+                statusMessage = `Loading molecular formula "${formula}" (CID: ${firstCid}) from PubChem...`;
+                
+            } catch (formulaError) {
+                console.error('Formula search error:', formulaError);
+                document.getElementById('status').innerHTML = `Error: ${formulaError.message}`;
                 return;
             }
-            
-            console.log('Setting up event handlers...');
-            
-            // Enter key handler
-            const keypressHandler = function(e) {
-                if (e.key === 'Enter') {
-                    loadFromPubChem();
-                }
-            };
-            pubchemInput.addEventListener('keypress', keypressHandler);
-            
-            // Search type selector click handler (remove onclick to avoid conflicts)
-            searchTypeButton.removeAttribute('onclick');
-            const clickHandler = function(e) {
-                console.log('Search type button clicked via event listener!');
-                e.stopPropagation();
-                toggleSearchTypeDropdown();
-            };
-            searchTypeButton.addEventListener('click', clickHandler);
-            
-            // Store handlers for cleanup if needed
-            searchTypeButton._clickHandler = clickHandler;
-            pubchemInput._keypressHandler = keypressHandler;
-            
-            // Dropdown option click handlers
-            const options = dropdown.querySelectorAll('.search-type-option');
-            options.forEach(option => {
-                option.addEventListener('click', function() {
-                    const value = this.getAttribute('data-value');
-                    const label = this.querySelector('.option-label').textContent;
-                    selectSearchType(value, label);
-                    hideSearchTypeDropdown();
-                    updateInputPlaceholder();
-                });
-            });
-            
-            // Close dropdown when clicking outside
-            document.addEventListener('click', function(e) {
-                if (!searchTypeButton.contains(e.target) && !dropdown.contains(e.target)) {
-                    hideSearchTypeDropdown();
-                }
-            });
-            
-            // Mark as initialized
-            pubchemInput._handlersInitialized = true;
-            console.log('Database input handlers initialized successfully');
-            
-            // Initialize selected state
-            updateSelectedOption();
-        }
-        
-        let currentSearchType = 'auto';
-        
-        function getCurrentSearchType() {
-            return currentSearchType;
-        }
-        
-        function selectSearchType(value, label) {
-            currentSearchType = value;
-            updateSelectedOption();
-        }
-        
-        function updateSelectedOption() {
-            const options = document.querySelectorAll('.search-type-option');
-            options.forEach(option => {
-                option.classList.remove('selected');
-                if (option.getAttribute('data-value') === currentSearchType) {
-                    option.classList.add('selected');
-                }
-            });
-        }
-        
-        function toggleSearchTypeDropdown() {
-            const dropdown = document.getElementById('searchTypeDropdown');
-            const button = document.getElementById('searchTypeSelectorButton');
-            
-            if (dropdown.style.display === 'block') {
-                hideSearchTypeDropdown();
+        } else if (identifier.startsWith(':')) {
+            const query = identifier.substring(1);
+            // Check if it's a number (CID) or name
+            if (/^\d+$/.test(query)) {
+                statusMessage = `Loading CID ${query} from PubChem...`;
+                dbMetadata.queryType = 'CID';
+                dbMetadata.cid = query;
             } else {
-                showSearchTypeDropdown();
+                statusMessage = `Loading "${query}" by name from PubChem...`;
+                dbMetadata.queryType = 'Name';
+                dbMetadata.name = query;
             }
         }
         
-        function showSearchTypeDropdown() {
-            const dropdown = document.getElementById('searchTypeDropdown');
-            const button = document.getElementById('searchTypeSelectorButton');
-            
-            dropdown.style.display = 'block';
-            button.classList.add('active');
-            updateSelectedOption();
-        }
+        document.getElementById('status').innerHTML = statusMessage;
         
-        function hideSearchTypeDropdown() {
-            const dropdown = document.getElementById('searchTypeDropdown');
-            const button = document.getElementById('searchTypeSelectorButton');
-            
-            dropdown.style.display = 'none';
-            button.classList.remove('active');
-        }
+        // Save current display mode
+        const currentDisplayMode = displayMode || 'default';
         
-        function updateInputPlaceholder() {
-            const searchType = getCurrentSearchType();
-            const input = document.getElementById('pubchemInput');
+        // Clear any existing numbered atom names since this is a database load
+        clearOriginalAtomNames();
+        shouldUseNumberedAtoms = false; // Database loads should not use numbered atoms
+        console.log('loadFromDatabase: Set shouldUseNumberedAtoms to false for database load');
+        
+        // Store metadata globally for XYZ generation
+        window.databaseMetadata = dbMetadata;
+        console.log('Stored database metadata:', dbMetadata);
+        
+        console.log('Loading with command:', loadCommand);
+        Jmol.script(jmolApplet0, 'load "' + loadCommand + '"');
+        
+        // Restore display mode after loading with a delay
+        setTimeout(() => {
+            setDisplayMode(currentDisplayMode);
+            document.getElementById('status').innerHTML = 'Structure loaded successfully from PubChem';
             
-            switch(searchType) {
-                case 'cid':
-                    input.placeholder = 'Enter PubChem CID (e.g., 1983 for caffeine)';
-                    break;
-                case 'name':
-                    input.placeholder = 'Enter chemical name (e.g., caffeine, aspirin, benzene)';
-                    break;
-                case 'formula':
-                    input.placeholder = 'Enter molecular formula (e.g., C8H10N4O2, H2O, C6H12O6)';
-                    break;
-                case 'smiles':
-                    input.placeholder = 'Enter SMILES string (e.g., C6H6, CC=O, CCO)';
-                    break;
-                case 'auto':
-                default:
-                    input.placeholder = 'PubChem: CID, name, formula, or SMILES (e.g., 1983, aspirin, H2O, CC=O)';
-                    break;
+            // Apply all JSmol preferences after loading
+            if (typeof applyJSmolPreferences === 'function') {
+                applyJSmolPreferences();
+                console.log('loadFromDatabase: Applied JSmol preferences');
             }
+            
+            // Refresh atom names to remove any numbered indices
+            setTimeout(() => {
+                refreshAtomNames();
+                console.log('loadFromDatabase: Atom names refreshed to remove numbered indices');
+                
+                // Update MOL file data for JSME integration after database loading
+                try {
+                    lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+                    debugLog('Database', 'Updated lastMolFile after loading from database');
+                } catch (molError) {
+                    console.error('Error updating MOL file data in loadFromDatabase:', molError);
+                }
+            }, 100);
+        }, 1000);
+        
+    } catch (err) {
+        console.error('loadFromDatabase error:', err);
+        document.getElementById('status').innerHTML = 'Error loading from PubChem: ' + err.message;
+    }
+}
+
+// Helper function to detect if a string looks like a molecular formula
+function isMolecularFormula(str) {
+    // Molecular formula pattern: starts with capital letter, contains only element symbols and numbers
+    // Examples: H2O, C6H12O6, NaCl, C8H10N4O2, CH4, CO2, LiH, BeH2, MgO
+    const formulaPattern = /^[A-Z][a-z]?\d*([A-Z][a-z]?\d*)*$/;
+    
+    // Must match the pattern and contain at least one element symbol
+    if (!formulaPattern.test(str)) {
+        return false;
+    }
+    
+    // Additional check: should not contain SMILES-specific characters
+    if (/[=@#\[\]()]/.test(str)) {
+        return false;
+    }
+    
+    // Check if it contains valid element symbols
+    // Common elements include H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, etc.
+    const validElements = [
+        'H', 'He', 'Li', 'Be', 'B', 'C', 'N', 'O', 'F', 'Ne',
+        'Na', 'Mg', 'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca',
+        'Sc', 'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn',
+        'Ga', 'Ge', 'As', 'Se', 'Br', 'Kr', 'Rb', 'Sr', 'Y', 'Zr',
+        'Nb', 'Mo', 'Tc', 'Ru', 'Rh', 'Pd', 'Ag', 'Cd', 'In', 'Sn',
+        'Sb', 'Te', 'I', 'Xe', 'Cs', 'Ba', 'La', 'Ce', 'Pr', 'Nd',
+        'Pm', 'Sm', 'Eu', 'Gd', 'Tb', 'Dy', 'Ho', 'Er', 'Tm', 'Yb',
+        'Lu', 'Hf', 'Ta', 'W', 'Re', 'Os', 'Ir', 'Pt', 'Au', 'Hg',
+        'Tl', 'Pb', 'Bi', 'Po', 'At', 'Rn'
+    ];
+    
+    // Extract all element symbols from the formula
+    const elements = str.match(/[A-Z][a-z]?/g) || [];
+    
+    // Check if all extracted elements are valid
+    for (const element of elements) {
+        if (!validElements.includes(element)) {
+            return false;
         }
+    }
+    
+    // Must contain at least one element
+    if (elements.length === 0) {
+        return false;
+    }
+    
+    // If it looks like a molecular formula and contains valid elements, treat it as a formula
+    return true;
+}
+
+function looksLikeChemicalName(str) {
+    if (!/^[A-Za-z0-9\s,()-]+$/.test(str) || !/[A-Za-z]/.test(str)) {
+        return false;
+    }
+
+    // IUPAC-style names often use comma-separated locants such as "3,4-" or "N,N-"
+    if (str.includes(',')) {
+        return true;
+    }
+
+    // Numeric locants followed by a hyphen and a word are more likely names than SMILES
+    return /\d+(?:,\d+)*[A-Za-z]?-[A-Za-z]*[a-z]{2,}/.test(str);
+}
+
+async function loadFromPubChem() {
+    const query = document.getElementById('pubchemInput').value.trim();
+    if (!query) {
+        document.getElementById('status').innerHTML = 'Please enter a search term';
+        return;
+    }
+    
+    const searchType = getCurrentSearchType();
+    let prefix = ':';
+    
+    // Use explicit search type if selected, otherwise auto-detect
+    if (searchType === 'cid') {
+        prefix = ':';
+    } else if (searchType === 'name') {
+        prefix = ':';
+    } else if (searchType === 'formula') {
+        prefix = ':formula:';
+    } else if (searchType === 'smiles') {
+        prefix = ':smiles:';
+    } else if (searchType === 'auto') {
+        // Auto-detect query type based on input (existing logic)
+        // Check if it's a pure number (CID)
+        if (/^\d+$/.test(query)) {
+            prefix = ':';
+        }
+        // Check if it's a molecular formula
+        else if (isMolecularFormula(query)) {
+            prefix = ':formula:';
+        }
+        // Chemical names with locants such as "3,4-" or "2-" should stay name searches
+        else if (looksLikeChemicalName(query)) {
+            prefix = ':';
+        }
+        // Check if it's a SMILES string (more specific patterns)
+        else if (/[=@#]|[\[\]()]|[cC][cC]|[nN][oO]|[sS][iI]|[pP][hH]|\d[nNcCoOsS]|[nNcCoOsS]\d|\+|-/.test(query) && 
+                 !/^[a-zA-Z\s\-_()]+$/.test(query)) {
+            prefix = ':smiles:';
+        }
+        // Otherwise treat as name (default)
+        else {
+            prefix = ':';
+        }
+    }
+    
+    await loadFromDatabase(prefix + query);
+}
+
+// Test function for molecular formula search
+function testFormulaSearch(formula) {
+    const input = document.getElementById('pubchemInput');
+    input.value = formula;
+    
+    // Set search type to formula
+    currentSearchType = 'formula';
+    updateInputPlaceholder();
+    
+    // Update dropdown UI to show formula is selected
+    const options = document.querySelectorAll('.search-type-option');
+    options.forEach(option => option.classList.remove('selected'));
+    const formulaOption = document.querySelector('.search-type-option[data-value="formula"]');
+    if (formulaOption) {
+        formulaOption.classList.add('selected');
+    }
+    
+    // Perform the search
+    loadFromPubChem();
+}
+
+// Debug function to test dropdown (can be called from console)
+window.testDropdown = function() {
+    console.log('Testing dropdown...');
+    const button = document.getElementById('searchTypeSelectorButton');
+    const dropdown = document.getElementById('searchTypeDropdown');
+    
+    console.log('Elements:', { button: !!button, dropdown: !!dropdown });
+    
+    if (button && dropdown) {
+        console.log('Button click listeners:', button.onclick, button.addEventListener ? 'has addEventListener' : 'no addEventListener');
+        console.log('Attempting to toggle dropdown...');
+        toggleSearchTypeDropdown();
+        return 'Dropdown toggle attempted';
+    } else {
+        return 'Elements not found';
+    }
+};
+
+// Add keyboard event handlers for database inputs
+function setupDatabaseInputHandlers() {
+    console.log('setupDatabaseInputHandlers called');
+    
+    const pubchemInput = document.getElementById('pubchemInput');
+    const searchTypeButton = document.getElementById('searchTypeSelectorButton');
+    const dropdown = document.getElementById('searchTypeDropdown');
+    
+    // Check if elements exist
+    if (!pubchemInput || !searchTypeButton || !dropdown) {
+        console.error('Database input elements not found:', {
+            pubchemInput: !!pubchemInput,
+            searchTypeButton: !!searchTypeButton,
+            dropdown: !!dropdown
+        });
+        // Retry after a short delay
+        setTimeout(() => {
+            console.log('Retrying setupDatabaseInputHandlers...');
+            setupDatabaseInputHandlers();
+        }, 500);
+        return;
+    }
+    
+    // Check if already initialized to prevent duplicate listeners
+    if (pubchemInput._handlersInitialized) {
+        console.log('Database input handlers already initialized, skipping...');
+        return;
+    }
+    
+    console.log('Setting up event handlers...');
+    
+    // Enter key handler
+    const keypressHandler = function(e) {
+        if (e.key === 'Enter') {
+            loadFromPubChem();
+        }
+    };
+    pubchemInput.addEventListener('keypress', keypressHandler);
+    
+    // Search type selector click handler (remove onclick to avoid conflicts)
+    searchTypeButton.removeAttribute('onclick');
+    const clickHandler = function(e) {
+        console.log('Search type button clicked via event listener!');
+        e.stopPropagation();
+        toggleSearchTypeDropdown();
+    };
+    searchTypeButton.addEventListener('click', clickHandler);
+    
+    // Store handlers for cleanup if needed
+    searchTypeButton._clickHandler = clickHandler;
+    pubchemInput._keypressHandler = keypressHandler;
+    
+    // Dropdown option click handlers
+    const options = dropdown.querySelectorAll('.search-type-option');
+    options.forEach(option => {
+        option.addEventListener('click', function() {
+            const value = this.getAttribute('data-value');
+            const label = this.querySelector('.option-label').textContent;
+            selectSearchType(value, label);
+            hideSearchTypeDropdown();
+            updateInputPlaceholder();
+        });
+    });
+    
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function(e) {
+        if (!searchTypeButton.contains(e.target) && !dropdown.contains(e.target)) {
+            hideSearchTypeDropdown();
+        }
+    });
+    
+    // Mark as initialized
+    pubchemInput._handlersInitialized = true;
+    console.log('Database input handlers initialized successfully');
+    
+    // Initialize selected state
+    updateSelectedOption();
+}
+
+let currentSearchType = 'auto';
+
+function getCurrentSearchType() {
+    return currentSearchType;
+}
+
+function selectSearchType(value, label) {
+    currentSearchType = value;
+    updateSelectedOption();
+}
+
+function updateSelectedOption() {
+    const options = document.querySelectorAll('.search-type-option');
+    options.forEach(option => {
+        option.classList.remove('selected');
+        if (option.getAttribute('data-value') === currentSearchType) {
+            option.classList.add('selected');
+        }
+    });
+}
+
+function toggleSearchTypeDropdown() {
+    const dropdown = document.getElementById('searchTypeDropdown');
+    const button = document.getElementById('searchTypeSelectorButton');
+    
+    if (dropdown.style.display === 'block') {
+        hideSearchTypeDropdown();
+    } else {
+        showSearchTypeDropdown();
+    }
+}
+
+function showSearchTypeDropdown() {
+    const dropdown = document.getElementById('searchTypeDropdown');
+    const button = document.getElementById('searchTypeSelectorButton');
+    
+    dropdown.style.display = 'block';
+    button.classList.add('active');
+    updateSelectedOption();
+}
+
+function hideSearchTypeDropdown() {
+    const dropdown = document.getElementById('searchTypeDropdown');
+    const button = document.getElementById('searchTypeSelectorButton');
+    
+    dropdown.style.display = 'none';
+    button.classList.remove('active');
+}
+
+function updateInputPlaceholder() {
+    const searchType = getCurrentSearchType();
+    const input = document.getElementById('pubchemInput');
+    
+    switch(searchType) {
+        case 'cid':
+            input.placeholder = 'Enter PubChem CID (e.g., 1983 for caffeine)';
+            break;
+        case 'name':
+            input.placeholder = 'Enter chemical name (e.g., caffeine, aspirin, benzene)';
+            break;
+        case 'formula':
+            input.placeholder = 'Enter molecular formula (e.g., C8H10N4O2, H2O, C6H12O6)';
+            break;
+        case 'smiles':
+            input.placeholder = 'Enter SMILES string (e.g., C6H6, CC=O, CCO)';
+            break;
+        case 'auto':
+        default:
+            input.placeholder = 'PubChem: CID, name, formula, or SMILES (e.g., 1983, aspirin, H2O, CC=O)';
+            break;
+    }
+}
 

--- a/js/selection.js
+++ b/js/selection.js
@@ -1,138 +1,138 @@
-        // ===== Central atom selection state =====
-        // Single source of truth shared by the XYZ viewer, the 3D structure (JSmol
-        // picking) and the ElemCo input editor. Holds 0-based atom indices.
-        var selectedAtoms = new Set();
+// ===== Central atom selection state =====
+// Single source of truth shared by the XYZ viewer, the 3D structure (JSmol
+// picking) and the ElemCo input editor. Holds 0-based atom indices.
+var selectedAtoms = new Set();
 
-        // Update any UI that reflects how many atoms are currently selected.
-        function updateSelectionUI() {
-            const countEl = document.getElementById('selection-count');
-            if (countEl) {
-                const n = selectedAtoms.size;
-                countEl.textContent = n > 0 ? `${n} selected` : '';
-            }
-        }
+// Update any UI that reflects how many atoms are currently selected.
+function updateSelectionUI() {
+    const countEl = document.getElementById('selection-count');
+    if (countEl) {
+        const n = selectedAtoms.size;
+        countEl.textContent = n > 0 ? `${n} selected` : '';
+    }
+}
 
-        // Turn the 3D halo on/off for a single atom (atomIndex is 0-based).
-        // Always restores the full selection afterwards: halo flags persist
-        // independently of the selection set, and leaving a partial selection
-        // behind would break features that read the geometry via write("xyz")
-        // (xtb, ElemCo), which only export the currently selected atoms.
-        function applyHaloForAtom(atomIndex, on) {
-            try {
-                Jmol.script(jmolApplet0, `select atomno=${atomIndex + 1}; halos ${on ? 'on' : 'off'}; select all`);
-            } catch (e) {
-                console.error('Error updating halo for atom', atomIndex, e);
-            }
-        }
+// Turn the 3D halo on/off for a single atom (atomIndex is 0-based).
+// Always restores the full selection afterwards: halo flags persist
+// independently of the selection set, and leaving a partial selection
+// behind would break features that read the geometry via write("xyz")
+// (xtb, ElemCo), which only export the currently selected atoms.
+function applyHaloForAtom(atomIndex, on) {
+    try {
+        Jmol.script(jmolApplet0, `select atomno=${atomIndex + 1}; halos ${on ? 'on' : 'off'}; select all`);
+    } catch (e) {
+        console.error('Error updating halo for atom', atomIndex, e);
+    }
+}
 
-        // Select or deselect an atom and keep every view in sync (state Set,
-        // XYZ-viewer row highlight, 3D halo, selection counter).
-        function setAtomSelected(atomIndex, selected) {
-            if (selected) {
-                selectedAtoms.add(atomIndex);
-            } else {
-                selectedAtoms.delete(atomIndex);
-            }
-            // Sync the matching XYZ-viewer row, if the viewer is rendered.
-            const row = document.querySelector(`#xyz-content .xyz-row[data-atom-index="${atomIndex}"]`);
-            if (row) row.classList.toggle('selected', selected);
-            // Sync the 3D structure halo.
-            applyHaloForAtom(atomIndex, selected);
-            updateSelectionUI();
-        }
+// Select or deselect an atom and keep every view in sync (state Set,
+// XYZ-viewer row highlight, 3D halo, selection counter).
+function setAtomSelected(atomIndex, selected) {
+    if (selected) {
+        selectedAtoms.add(atomIndex);
+    } else {
+        selectedAtoms.delete(atomIndex);
+    }
+    // Sync the matching XYZ-viewer row, if the viewer is rendered.
+    const row = document.querySelector(`#xyz-content .xyz-row[data-atom-index="${atomIndex}"]`);
+    if (row) row.classList.toggle('selected', selected);
+    // Sync the 3D structure halo.
+    applyHaloForAtom(atomIndex, selected);
+    updateSelectionUI();
+}
 
-        function toggleAtomSelectionByIndex(atomIndex) {
-            setAtomSelected(atomIndex, !selectedAtoms.has(atomIndex));
-        }
+function toggleAtomSelectionByIndex(atomIndex) {
+    setAtomSelected(atomIndex, !selectedAtoms.has(atomIndex));
+}
 
-        // Clear all selections everywhere.
-        function clearAtomSelection() {
-            selectedAtoms.clear();
-            document.querySelectorAll('#xyz-content .xyz-row.selected')
-                .forEach(r => r.classList.remove('selected'));
-            try {
-                // Turn off every halo, then leave the full molecule selected so
-                // write("xyz") (xtb / ElemCo) still sees all atoms.
-                Jmol.script(jmolApplet0, 'select all; halos off');
-            } catch (e) {
-                console.error('Error clearing halos:', e);
-            }
-            updateSelectionUI();
-        }
+// Clear all selections everywhere.
+function clearAtomSelection() {
+    selectedAtoms.clear();
+    document.querySelectorAll('#xyz-content .xyz-row.selected')
+        .forEach(r => r.classList.remove('selected'));
+    try {
+        // Turn off every halo, then leave the full molecule selected so
+        // write("xyz") (xtb / ElemCo) still sees all atoms.
+        Jmol.script(jmolApplet0, 'select all; halos off');
+    } catch (e) {
+        console.error('Error clearing halos:', e);
+    }
+    updateSelectionUI();
+}
 
-        // After the XYZ viewer rebuilds its rows, restore selection highlighting
-        // and re-draw the 3D halos for the currently selected atoms.
-        function reapplySelectionToRows() {
-            document.querySelectorAll('#xyz-content .xyz-row').forEach(row => {
-                const idx = parseInt(row.dataset.atomIndex);
-                row.classList.toggle('selected', selectedAtoms.has(idx));
-            });
-            if (selectedAtoms.size > 0) {
-                const list = Array.from(selectedAtoms).map(i => 'atomno=' + (i + 1)).join(' or ');
-                try {
-                    Jmol.script(jmolApplet0, `select ${list}; halos on; select all`);
-                } catch (e) {
-                    console.error('Error re-applying halos:', e);
-                }
-            }
-            updateSelectionUI();
+// After the XYZ viewer rebuilds its rows, restore selection highlighting
+// and re-draw the 3D halos for the currently selected atoms.
+function reapplySelectionToRows() {
+    document.querySelectorAll('#xyz-content .xyz-row').forEach(row => {
+        const idx = parseInt(row.dataset.atomIndex);
+        row.classList.toggle('selected', selectedAtoms.has(idx));
+    });
+    if (selectedAtoms.size > 0) {
+        const list = Array.from(selectedAtoms).map(i => 'atomno=' + (i + 1)).join(' or ');
+        try {
+            Jmol.script(jmolApplet0, `select ${list}; halos on; select all`);
+        } catch (e) {
+            console.error('Error re-applying halos:', e);
         }
+    }
+    updateSelectionUI();
+}
 
-        // Selected atom numbers as sorted 1-based indices (for ElemCo / external use).
-        function getSelectedAtomNumbers() {
-            return Array.from(selectedAtoms).map(i => i + 1).sort((a, b) => a - b);
-        }
+// Selected atom numbers as sorted 1-based indices (for ElemCo / external use).
+function getSelectedAtomNumbers() {
+    return Array.from(selectedAtoms).map(i => i + 1).sort((a, b) => a - b);
+}
 
-        // Fired by JSmol when an atom is clicked in the 3D structure. JSmol passes
-        // (appletName, label, atomIndex) with a 0-based atomIndex. Toggles that
-        // atom's selection (disabled while the model-kit editor is active so clicks
-        // there keep editing the geometry instead of selecting).
-        function onJmolAtomPicked(app, label, atomIndex) {
-            if (isDragMinimize) return;
-            try {
-                const idx = parseInt(atomIndex);
-                if (isNaN(idx) || idx < 0) return;
-                toggleAtomSelectionByIndex(idx);
-            } catch (e) {
-                console.error('Error handling atom pick:', e);
-            }
-        }
+// Fired by JSmol when an atom is clicked in the 3D structure. JSmol passes
+// (appletName, label, atomIndex) with a 0-based atomIndex. Toggles that
+// atom's selection (disabled while the model-kit editor is active so clicks
+// there keep editing the geometry instead of selecting).
+function onJmolAtomPicked(app, label, atomIndex) {
+    if (isDragMinimize) return;
+    try {
+        const idx = parseInt(atomIndex);
+        if (isNaN(idx) || idx < 0) return;
+        toggleAtomSelectionByIndex(idx);
+    } catch (e) {
+        console.error('Error handling atom pick:', e);
+    }
+}
 
-        // Fired by JSmol whenever a new structure is loaded. Atom indices from a
-        // previous structure are no longer valid, so drop any stale selection.
-        function onJmolStructureLoaded() {
-            if (selectedAtoms.size === 0) return;
-            selectedAtoms.clear();
-            document.querySelectorAll('#xyz-content .xyz-row.selected')
-                .forEach(r => r.classList.remove('selected'));
-            updateSelectionUI();
-        }
+// Fired by JSmol whenever a new structure is loaded. Atom indices from a
+// previous structure are no longer valid, so drop any stale selection.
+function onJmolStructureLoaded() {
+    if (selectedAtoms.size === 0) return;
+    selectedAtoms.clear();
+    document.querySelectorAll('#xyz-content .xyz-row.selected')
+        .forEach(r => r.classList.remove('selected'));
+    updateSelectionUI();
+}
 
-        // XYZ-viewer row click -> route through the central selection state.
-        function toggleAtomSelection(row) {
-            const atomIndex = parseInt(row.dataset.atomIndex);
-            toggleAtomSelectionByIndex(atomIndex);
-        }
+// XYZ-viewer row click -> route through the central selection state.
+function toggleAtomSelection(row) {
+    const atomIndex = parseInt(row.dataset.atomIndex);
+    toggleAtomSelectionByIndex(atomIndex);
+}
 
-        function hideXYZEditor() {
-            // Don't clear the data when hiding the editor
-            document.getElementById('editor-panel').style.display = 'none';
-            // Clear selections when closing editor - COMMENTED OUT as it corrupts JSmol state
-            // Jmol.script(jmolApplet0, 'select none; halos off');
-            debugLog('XYZ', 'XYZ editor hidden without clearing selections');
-        }
+function hideXYZEditor() {
+    // Don't clear the data when hiding the editor
+    document.getElementById('editor-panel').style.display = 'none';
+    // Clear selections when closing editor - COMMENTED OUT as it corrupts JSmol state
+    // Jmol.script(jmolApplet0, 'select none; halos off');
+    debugLog('XYZ', 'XYZ editor hidden without clearing selections');
+}
 
-        function saveXYZ() {
-            const xyzData = document.getElementById('xyz-content-edit').value;
-            const blob = new Blob([xyzData], { type: 'chemical/x-xyz' });
-            const url = URL.createObjectURL(blob);
-            
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = 'molecule.xyz';
-            document.body.appendChild(a);
-            a.click();
-            document.body.removeChild(a);
-            URL.revokeObjectURL(url);
-        }
+function saveXYZ() {
+    const xyzData = document.getElementById('xyz-content-edit').value;
+    const blob = new Blob([xyzData], { type: 'chemical/x-xyz' });
+    const url = URL.createObjectURL(blob);
+    
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'molecule.xyz';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,123 +1,123 @@
-        // Make editor panel draggable
-        function initDraggable() {
-            function makeDraggable(panel, header) {
-                let isDragging = false;
-                let currentX;
-                let currentY;
-                let initialX;
-                let initialY;
-                let xOffset = 0;
-                let yOffset = 0;
+// Make editor panel draggable
+function initDraggable() {
+    function makeDraggable(panel, header) {
+        let isDragging = false;
+        let currentX;
+        let currentY;
+        let initialX;
+        let initialY;
+        let xOffset = 0;
+        let yOffset = 0;
 
-                header.addEventListener('mousedown', dragStart);
-                document.addEventListener('mousemove', drag);
-                document.addEventListener('mouseup', dragEnd);
+        header.addEventListener('mousedown', dragStart);
+        document.addEventListener('mousemove', drag);
+        document.addEventListener('mouseup', dragEnd);
 
-                function dragStart(e) {
-                    initialX = e.clientX - xOffset;
-                    initialY = e.clientY - yOffset;
+        function dragStart(e) {
+            initialX = e.clientX - xOffset;
+            initialY = e.clientY - yOffset;
 
-                    if (e.target === header) {
-                        isDragging = true;
-                    }
-                }
-
-                function drag(e) {
-                    if (isDragging) {
-                        e.preventDefault();
-                        currentX = e.clientX - initialX;
-                        currentY = e.clientY - initialY;
-                        xOffset = currentX;
-                        yOffset = currentY;
-
-                        panel.style.transform = `translate(${currentX}px, ${currentY}px)`;
-                    }
-                }
-
-                function dragEnd() {
-                    initialX = currentX;
-                    initialY = currentY;
-                    isDragging = false;
-                }
+            if (e.target === header) {
+                isDragging = true;
             }
-
-            // Make all panels draggable
-            makeDraggable(
-                document.getElementById('editor-panel'),
-                document.getElementById('editor-header')
-            );
-            makeDraggable(
-                document.getElementById('orbitalControls'),
-                document.getElementById('orbital-header')
-            );
-            makeDraggable(
-                document.getElementById('elemcoPanel'),
-                document.getElementById('elemco-header')
-            );
-            makeDraggable(
-                document.getElementById('preferencesPanel'),
-                document.getElementById('preferences-header')
-            );
-            makeDraggable(
-                document.getElementById('xtbPanel'),
-                document.getElementById('xtb-header')
-            );
         }
 
-        // Add page zoom functionality
-        let controlsZoom = 100;
+        function drag(e) {
+            if (isDragging) {
+                e.preventDefault();
+                currentX = e.clientX - initialX;
+                currentY = e.clientY - initialY;
+                xOffset = currentX;
+                yOffset = currentY;
+
+                panel.style.transform = `translate(${currentX}px, ${currentY}px)`;
+            }
+        }
+
+        function dragEnd() {
+            initialX = currentX;
+            initialY = currentY;
+            isDragging = false;
+        }
+    }
+
+    // Make all panels draggable
+    makeDraggable(
+        document.getElementById('editor-panel'),
+        document.getElementById('editor-header')
+    );
+    makeDraggable(
+        document.getElementById('orbitalControls'),
+        document.getElementById('orbital-header')
+    );
+    makeDraggable(
+        document.getElementById('elemcoPanel'),
+        document.getElementById('elemco-header')
+    );
+    makeDraggable(
+        document.getElementById('preferencesPanel'),
+        document.getElementById('preferences-header')
+    );
+    makeDraggable(
+        document.getElementById('xtbPanel'),
+        document.getElementById('xtb-header')
+    );
+}
+
+// Add page zoom functionality
+let controlsZoom = 100;
+
+document.addEventListener('wheel', function(e) {
+    // Only zoom if Ctrl is pressed and mouse is over the controls panel
+    if (e.ctrlKey && e.target.closest('#controls')) {
+        e.preventDefault();  // Prevent default browser zoom
         
-        document.addEventListener('wheel', function(e) {
-            // Only zoom if Ctrl is pressed and mouse is over the controls panel
-            if (e.ctrlKey && e.target.closest('#controls')) {
-                e.preventDefault();  // Prevent default browser zoom
-                
-                const delta = e.deltaY < 0 ? 10 : -10;
-                controlsZoom = Math.min(Math.max(40, controlsZoom + delta), 200);  // Limit zoom between 40% and 200%
-                
-                // Apply zoom only to controls panel
-                document.getElementById('controls').style.transform = `scale(${controlsZoom / 100})`;
-                
-                // Update status to show current zoom level
-                document.getElementById('status').innerHTML = `Controls zoom: ${controlsZoom}%`;
-            }
-        }, { passive: false });  // Required for preventDefault to work
+        const delta = e.deltaY < 0 ? 10 : -10;
+        controlsZoom = Math.min(Math.max(40, controlsZoom + delta), 200);  // Limit zoom between 40% and 200%
+        
+        // Apply zoom only to controls panel
+        document.getElementById('controls').style.transform = `scale(${controlsZoom / 100})`;
+        
+        // Update status to show current zoom level
+        document.getElementById('status').innerHTML = `Controls zoom: ${controlsZoom}%`;
+    }
+}, { passive: false });  // Required for preventDefault to work
 
-        function toggleDragMinimize() {
-            isDragMinimize = !isDragMinimize;
-            if (isDragMinimize) {
-                Jmol.script(jmolApplet0, 'set modelkitmode; set picking dragMinimize');
-            } else {
-                Jmol.script(jmolApplet0, 'set modelkitmode false; set picking ident');
-            }
-            document.getElementById('dragMinButton').classList.toggle('active');
-            document.getElementById('dragMinButton').textContent = '3D';
-        }
+function toggleDragMinimize() {
+    isDragMinimize = !isDragMinimize;
+    if (isDragMinimize) {
+        Jmol.script(jmolApplet0, 'set modelkitmode; set picking dragMinimize');
+    } else {
+        Jmol.script(jmolApplet0, 'set modelkitmode false; set picking ident');
+    }
+    document.getElementById('dragMinButton').classList.toggle('active');
+    document.getElementById('dragMinButton').textContent = '3D';
+}
 
-        // Add resize observer for JSmol viewer with throttling
-        function initResizeObserver() {
-            let resizeTimeout;
-            const resizeObserver = new ResizeObserver(entries => {
-                // Throttle resize events to prevent excessive GPU calls
-                clearTimeout(resizeTimeout);
-                resizeTimeout = setTimeout(() => {
-                    for (const entry of entries) {
-                        const width = entry.contentRect.width;
-                        const height = entry.contentRect.height;
-                        // Update JSmol viewer size
-                        if (jmolApplet0 && jmolApplet0._ready) {
-                            try {
-                                Jmol.resizeApplet(jmolApplet0, [width, height]);
-                            } catch (e) {
-                                console.error('Error resizing JSmol:', e);
-                            }
-                        }
+// Add resize observer for JSmol viewer with throttling
+function initResizeObserver() {
+    let resizeTimeout;
+    const resizeObserver = new ResizeObserver(entries => {
+        // Throttle resize events to prevent excessive GPU calls
+        clearTimeout(resizeTimeout);
+        resizeTimeout = setTimeout(() => {
+            for (const entry of entries) {
+                const width = entry.contentRect.width;
+                const height = entry.contentRect.height;
+                // Update JSmol viewer size
+                if (jmolApplet0 && jmolApplet0._ready) {
+                    try {
+                        Jmol.resizeApplet(jmolApplet0, [width, height]);
+                    } catch (e) {
+                        console.error('Error resizing JSmol:', e);
                     }
-                }, 100); // Throttle to 100ms
-            });
+                }
+            }
+        }, 100); // Throttle to 100ms
+    });
 
-            // Start observing the viewer container
-            const viewer = document.getElementById('viewer');
-            resizeObserver.observe(viewer);
-        }
+    // Start observing the viewer container
+    const viewer = document.getElementById('viewer');
+    resizeObserver.observe(viewer);
+}
 

--- a/js/viewer-controls.js
+++ b/js/viewer-controls.js
@@ -1,113 +1,113 @@
-        // Add toggle spin function with proper cleanup
-        function toggleSpin() {
-            isSpinning = !isSpinning;
-            try {
-                Jmol.script(jmolApplet0, isSpinning ? 'spin on' : 'spin off');
-                document.getElementById('spinButton').textContent = isSpinning ? 'Stop' : 'Spin';
-            } catch (e) {
-                console.error('Error toggling spin:', e);
-                isSpinning = false;
-                document.getElementById('spinButton').textContent = 'Spin';
-            }
-        }
+// Add toggle spin function with proper cleanup
+function toggleSpin() {
+    isSpinning = !isSpinning;
+    try {
+        Jmol.script(jmolApplet0, isSpinning ? 'spin on' : 'spin off');
+        document.getElementById('spinButton').textContent = isSpinning ? 'Stop' : 'Spin';
+    } catch (e) {
+        console.error('Error toggling spin:', e);
+        isSpinning = false;
+        document.getElementById('spinButton').textContent = 'Spin';
+    }
+}
 
-        // Add function to set display mode
-        function setDisplayMode(mode) {
-            try {
-                console.log('setDisplayMode: Setting display mode to', mode);
-                
-                // Check if JSmol applet is ready
-                if (!jmolApplet0 || typeof Jmol === 'undefined') {
-                    console.error('setDisplayMode: JSmol applet not ready');
-                    document.getElementById('status').innerHTML = 'JSmol not ready';
-                    return;
-                }
-                
-                // First check if there are any atoms loaded
-                const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
-                if (!atomCount || atomCount === 0) {
-                    console.warn('setDisplayMode: No atoms loaded');
-                    document.getElementById('status').innerHTML = 'No molecule loaded';
-                    return;
-                }
-                
-                let script = '';
-                let buttonText = '';
-                
-                switch(mode) {
-                    case 'wireframe':
-                        script = 'spacefill off; wireframe only; wireframe 0.1';
-                        buttonText = 'Wireframe';
-                        break;
-                    case 'spacefill':
-                        script = 'wireframe off; spacefill only; spacefill 100%';
-                        buttonText = 'Spacefill';
-                        break;
-                    case 'default':
-                    default:
-                        script = 'spacefill 23%; wireframe 0.15';
-                        buttonText = 'Ball & Stick';
-                        mode = 'default';
-                        break;
-                }
-                
-                console.log('setDisplayMode: Executing script:', script);
-                Jmol.script(jmolApplet0, script);
-                
-                // Update button text and store mode
-                const displayButton = document.getElementById('displayButton');
-                if (displayButton) {
-                    displayButton.textContent = buttonText;
-                }
-                
-                displayMode = mode;
-                
-                console.log('setDisplayMode: Successfully set to', mode);
-                
-            } catch (error) {
-                console.error('setDisplayMode: Error setting display mode:', error);
-                document.getElementById('status').innerHTML = 'Error changing display mode';
-            }
+// Add function to set display mode
+function setDisplayMode(mode) {
+    try {
+        console.log('setDisplayMode: Setting display mode to', mode);
+        
+        // Check if JSmol applet is ready
+        if (!jmolApplet0 || typeof Jmol === 'undefined') {
+            console.error('setDisplayMode: JSmol applet not ready');
+            document.getElementById('status').innerHTML = 'JSmol not ready';
+            return;
         }
+        
+        // First check if there are any atoms loaded
+        const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+        if (!atomCount || atomCount === 0) {
+            console.warn('setDisplayMode: No atoms loaded');
+            document.getElementById('status').innerHTML = 'No molecule loaded';
+            return;
+        }
+        
+        let script = '';
+        let buttonText = '';
+        
+        switch(mode) {
+            case 'wireframe':
+                script = 'spacefill off; wireframe only; wireframe 0.1';
+                buttonText = 'Wireframe';
+                break;
+            case 'spacefill':
+                script = 'wireframe off; spacefill only; spacefill 100%';
+                buttonText = 'Spacefill';
+                break;
+            case 'default':
+            default:
+                script = 'spacefill 23%; wireframe 0.15';
+                buttonText = 'Ball & Stick';
+                mode = 'default';
+                break;
+        }
+        
+        console.log('setDisplayMode: Executing script:', script);
+        Jmol.script(jmolApplet0, script);
+        
+        // Update button text and store mode
+        const displayButton = document.getElementById('displayButton');
+        if (displayButton) {
+            displayButton.textContent = buttonText;
+        }
+        
+        displayMode = mode;
+        
+        console.log('setDisplayMode: Successfully set to', mode);
+        
+    } catch (error) {
+        console.error('setDisplayMode: Error setting display mode:', error);
+        document.getElementById('status').innerHTML = 'Error changing display mode';
+    }
+}
 
-        // Update toggleDisplayMode to use setDisplayMode
-        function toggleDisplayMode() {
-            try {
-                console.log('toggleDisplayMode: Current mode:', displayMode);
-                
-                switch(displayMode) {
-                    case 'default':
-                        setDisplayMode('wireframe');
-                        break;
-                    case 'wireframe':
-                        setDisplayMode('spacefill');
-                        break;
-                    case 'spacefill':
-                        setDisplayMode('default');
-                        break;
-                    default:
-                        // If mode is undefined or unknown, start with default
-                        setDisplayMode('default');
-                        break;
-                }
-            } catch (error) {
-                console.error('toggleDisplayMode: Error toggling display mode:', error);
-                document.getElementById('status').innerHTML = 'Error toggling display mode';
-            }
+// Update toggleDisplayMode to use setDisplayMode
+function toggleDisplayMode() {
+    try {
+        console.log('toggleDisplayMode: Current mode:', displayMode);
+        
+        switch(displayMode) {
+            case 'default':
+                setDisplayMode('wireframe');
+                break;
+            case 'wireframe':
+                setDisplayMode('spacefill');
+                break;
+            case 'spacefill':
+                setDisplayMode('default');
+                break;
+            default:
+                // If mode is undefined or unknown, start with default
+                setDisplayMode('default');
+                break;
         }
+    } catch (error) {
+        console.error('toggleDisplayMode: Error toggling display mode:', error);
+        document.getElementById('status').innerHTML = 'Error toggling display mode';
+    }
+}
 
-        // Add zoom control functions
-        function adjustZoom(direction) {
-            if (direction === '+' && currentZoom < 200) {
-                currentZoom += 20;
-            } else if (direction === '-' && currentZoom > 40) {
-                currentZoom -= 20;
-            }
-            Jmol.script(jmolApplet0, 'zoom ' + currentZoom);
-        }
+// Add zoom control functions
+function adjustZoom(direction) {
+    if (direction === '+' && currentZoom < 200) {
+        currentZoom += 20;
+    } else if (direction === '-' && currentZoom > 40) {
+        currentZoom -= 20;
+    }
+    Jmol.script(jmolApplet0, 'zoom ' + currentZoom);
+}
 
-        function resetZoom() {
-            currentZoom = 100;
-            Jmol.script(jmolApplet0, 'zoom 100');
-        }
+function resetZoom() {
+    currentZoom = 100;
+    Jmol.script(jmolApplet0, 'zoom 100');
+}
 

--- a/js/xtb.js
+++ b/js/xtb.js
@@ -1,113 +1,113 @@
-        // ============================================================
-        // xtb (g-xTB) integration
-        // ============================================================
+// ============================================================
+// xtb (g-xTB) integration
+// ============================================================
 
-        function showXtbPanel() {
-            const panel = document.getElementById('xtbPanel');
-            if (panel) panel.style.display = 'block';
+function showXtbPanel() {
+    const panel = document.getElementById('xtbPanel');
+    if (panel) panel.style.display = 'block';
+}
+
+function hideXtbPanel() {
+    const panel = document.getElementById('xtbPanel');
+    if (panel) panel.style.display = 'none';
+}
+
+function clearXtbOutput() {
+    const outputTextarea = document.getElementById('xtb-output');
+    const outputSection = document.getElementById('xtb-output-section');
+    if (outputTextarea) outputTextarea.value = '';
+    if (outputSection) outputSection.style.display = 'none';
+    document.getElementById('status').innerHTML = 'Output cleared';
+}
+
+// Quote-aware command parser (supports paths with spaces and 'wsl ...' commands)
+function parseXtbCommand(cmd) {
+    const parts = [];
+    let current = '';
+    let inQuotes = false;
+    let quoteChar = '';
+    for (let i = 0; i < cmd.length; i++) {
+        const char = cmd[i];
+        if ((char === '"' || char === "'") && !inQuotes) {
+            inQuotes = true;
+            quoteChar = char;
+        } else if (char === quoteChar && inQuotes) {
+            inQuotes = false;
+            quoteChar = '';
+        } else if (char === ' ' && !inQuotes) {
+            if (current.trim()) { parts.push(current.trim()); current = ''; }
+        } else {
+            current += char;
         }
+    }
+    if (current.trim()) parts.push(current.trim());
+    return parts;
+}
 
-        function hideXtbPanel() {
-            const panel = document.getElementById('xtbPanel');
-            if (panel) panel.style.display = 'none';
-        }
-
-        function clearXtbOutput() {
-            const outputTextarea = document.getElementById('xtb-output');
-            const outputSection = document.getElementById('xtb-output-section');
-            if (outputTextarea) outputTextarea.value = '';
-            if (outputSection) outputSection.style.display = 'none';
-            document.getElementById('status').innerHTML = 'Output cleared';
-        }
-
-        // Quote-aware command parser (supports paths with spaces and 'wsl ...' commands)
-        function parseXtbCommand(cmd) {
-            const parts = [];
-            let current = '';
-            let inQuotes = false;
-            let quoteChar = '';
-            for (let i = 0; i < cmd.length; i++) {
-                const char = cmd[i];
-                if ((char === '"' || char === "'") && !inQuotes) {
-                    inQuotes = true;
-                    quoteChar = char;
-                } else if (char === quoteChar && inQuotes) {
-                    inQuotes = false;
-                    quoteChar = '';
-                } else if (char === ' ' && !inQuotes) {
-                    if (current.trim()) { parts.push(current.trim()); current = ''; }
-                } else {
-                    current += char;
-                }
-            }
-            if (current.trim()) parts.push(current.trim());
-            return parts;
-        }
-
-        // Compress a sorted list of 1-based atom numbers into xtb range notation,
-        // e.g. [1,2,3,5,8,9] -> "1-3,5,8-9".
-        function formatAtomRanges(nums) {
-            if (!nums.length) return '';
-            const sorted = [...nums].sort((a, b) => a - b);
-            const parts = [];
-            let start = sorted[0], prev = sorted[0];
-            for (let i = 1; i < sorted.length; i++) {
-                if (sorted[i] === prev + 1) {
-                    prev = sorted[i];
-                } else {
-                    parts.push(start === prev ? `${start}` : `${start}-${prev}`);
-                    start = prev = sorted[i];
-                }
-            }
+// Compress a sorted list of 1-based atom numbers into xtb range notation,
+// e.g. [1,2,3,5,8,9] -> "1-3,5,8-9".
+function formatAtomRanges(nums) {
+    if (!nums.length) return '';
+    const sorted = [...nums].sort((a, b) => a - b);
+    const parts = [];
+    let start = sorted[0], prev = sorted[0];
+    for (let i = 1; i < sorted.length; i++) {
+        if (sorted[i] === prev + 1) {
+            prev = sorted[i];
+        } else {
             parts.push(start === prev ? `${start}` : `${start}-${prev}`);
-            return parts.join(',');
+            start = prev = sorted[i];
         }
+    }
+    parts.push(start === prev ? `${start}` : `${start}-${prev}`);
+    return parts.join(',');
+}
 
-        // Entry point for xtb calculations. mode = 'energy' | 'opt'
-        async function runXtb(mode) {
-            const outputSection = document.getElementById('xtb-output-section');
-            const outputTextarea = document.getElementById('xtb-output');
-            if (!outputSection || !outputTextarea) {
-                document.getElementById('status').innerHTML = 'Error: xtb panel not initialized';
-                return;
-            }
+// Entry point for xtb calculations. mode = 'energy' | 'opt'
+async function runXtb(mode) {
+    const outputSection = document.getElementById('xtb-output-section');
+    const outputTextarea = document.getElementById('xtb-output');
+    if (!outputSection || !outputTextarea) {
+        document.getElementById('status').innerHTML = 'Error: xtb panel not initialized';
+        return;
+    }
 
-            // Ensure a molecule is loaded
-            let xyzData = '';
-            try {
-                xyzData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")') || '';
-            } catch (e) {
-                xyzData = '';
-            }
-            const atomCount = xyzData ? parseInt(xyzData.split('\n')[0]) : 0;
-            if (!atomCount || isNaN(atomCount)) {
-                document.getElementById('status').innerHTML = 'Please load a molecule first';
-                return;
-            }
+    // Ensure a molecule is loaded
+    let xyzData = '';
+    try {
+        xyzData = Jmol.evaluateVar(jmolApplet0, 'write("xyz")') || '';
+    } catch (e) {
+        xyzData = '';
+    }
+    const atomCount = xyzData ? parseInt(xyzData.split('\n')[0]) : 0;
+    if (!atomCount || isNaN(atomCount)) {
+        document.getElementById('status').innerHTML = 'Please load a molecule first';
+        return;
+    }
 
-            outputSection.style.display = 'block';
-            outputTextarea.value = mode === 'opt'
-                ? 'Initializing xtb geometry optimization...\n'
-                : 'Initializing xtb energy calculation...\n';
-            document.getElementById('status').innerHTML = 'Preparing xtb calculation...';
+    outputSection.style.display = 'block';
+    outputTextarea.value = mode === 'opt'
+        ? 'Initializing xtb geometry optimization...\n'
+        : 'Initializing xtb energy calculation...\n';
+    document.getElementById('status').innerHTML = 'Preparing xtb calculation...';
 
-            try {
-                if (typeof require !== 'undefined') {
-                    await runXtbInElectron(xyzData, mode);
-                } else {
-                    showXtbBrowserMessage();
-                }
-            } catch (error) {
-                console.error('Error running xtb calculation:', error);
-                outputTextarea.value = `Error: ${error.message}\n\nTroubleshooting:\n- Ensure xtb is installed and accessible\n- Check the xtb command in Settings\n- For g-xTB, install the parameter files from https://github.com/grimme-lab/g-xtb into $XTBPATH or $HOME`;
-                document.getElementById('status').innerHTML = 'xtb calculation failed - see output for details';
-            }
+    try {
+        if (typeof require !== 'undefined') {
+            await runXtbInElectron(xyzData, mode);
+        } else {
+            showXtbBrowserMessage();
         }
+    } catch (error) {
+        console.error('Error running xtb calculation:', error);
+        outputTextarea.value = `Error: ${error.message}\n\nTroubleshooting:\n- Ensure xtb is installed and accessible\n- Check the xtb command in Settings\n- For g-xTB, install the parameter files from https://github.com/grimme-lab/g-xtb into $XTBPATH or $HOME`;
+        document.getElementById('status').innerHTML = 'xtb calculation failed - see output for details';
+    }
+}
 
-        // Browser fallback message
-        function showXtbBrowserMessage() {
-            const outputTextarea = document.getElementById('xtb-output');
-            outputTextarea.value = `=== jlmol Browser Mode ===
+// Browser fallback message
+function showXtbBrowserMessage() {
+    const outputTextarea = document.getElementById('xtb-output');
+    outputTextarea.value = `=== jlmol Browser Mode ===
 Running xtb directly from the browser is not supported.
 
 Please install jlmol locally (the desktop application) to run xtb calculations.
@@ -117,215 +117,215 @@ The desktop version runs xtb on your machine. You will also need:
 1. xtb with g-xTB support installed and on your PATH (or set the command in Settings -> xtb).
 2. The g-xTB parameter files from https://github.com/grimme-lab/g-xtb,
    placed in $XTBPATH or $HOME.`;
-            document.getElementById('status').innerHTML = 'Please install jlmol locally to run xtb';
+    document.getElementById('status').innerHTML = 'Please install jlmol locally to run xtb';
+}
+
+// Run xtb in the Electron environment
+async function runXtbInElectron(xyzData, mode) {
+    const { spawn } = require('child_process');
+    const fs = require('fs');
+    const path = require('path');
+    const os = require('os');
+
+    const outputTextarea = document.getElementById('xtb-output');
+    const prefs = getPreferences();
+    const xtbCommand = (prefs.xtbCommand || 'xtb').trim();
+    const timeoutMs = (parseInt(prefs.calcTimeout) || 5) * 60 * 1000;
+
+    // Calculation options from the panel
+    const charge = parseInt(document.getElementById('xtb-charge')?.value, 10) || 0;
+    const uhf = Math.max(0, parseInt(document.getElementById('xtb-uhf')?.value, 10) || 0);
+    const extraFlags = (document.getElementById('xtb-extra-flags')?.value || '').trim();
+
+    const commandParts = parseXtbCommand(xtbCommand);
+    if (commandParts.length === 0) {
+        throw new Error('No xtb command configured. Set it in Settings -> xtb.');
+    }
+    const isWSL = commandParts[0].toLowerCase() === 'wsl';
+    const baseCommand = isWSL ? 'wsl' : commandParts[0];
+    const cmdPrefixArgs = commandParts.slice(1); // e.g. ['xtb'] for "wsl xtb", or [] for "xtb"
+
+    // Dedicated working directory (xtb writes several output files into CWD)
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jlmol_xtb_'));
+    fs.writeFileSync(path.join(workDir, 'coord.xyz'), xyzData);
+
+    // Optionally freeze the non-selected atoms during optimization by writing
+    // an xtb xcontrol file with a $fix block (passed via --input). The atoms
+    // listed in $fix are removed from the optimization, so only the currently
+    // selected atoms are relaxed.
+    let inputFileArgs = [];
+    let freezeSummary = '';
+    const freezeUnselected = mode === 'opt' && document.getElementById('xtb-freeze-unselected')?.checked;
+    if (freezeUnselected) {
+        const totalAtoms = parseInt(xyzData.split('\n')[0], 10) || 0;
+        if (selectedAtoms.size === 0) {
+            freezeSummary = '"Relax only selected atoms" is enabled but no atoms are selected — optimizing all atoms.\n';
+        } else {
+            // selectedAtoms holds 0-based indices; xtb uses 1-based numbering.
+            const fixed = [];
+            for (let i = 0; i < totalAtoms; i++) {
+                if (!selectedAtoms.has(i)) fixed.push(i + 1);
+            }
+            if (fixed.length === 0) {
+                freezeSummary = 'All atoms are selected — nothing to freeze, optimizing all atoms.\n';
+            } else {
+                const ranges = formatAtomRanges(fixed);
+                const xcontrol = `$fix\n   atoms: ${ranges}\n$end\n`;
+                fs.writeFileSync(path.join(workDir, 'xtb.inp'), xcontrol);
+                inputFileArgs = ['--input', 'xtb.inp'];
+                freezeSummary = `Relaxing ${selectedAtoms.size} selected atom(s); freezing ${fixed.length} atom(s) via xtb.inp:\n${xcontrol}`;
+            }
+        }
+    }
+
+    let cleanedUp = false;
+    function cleanup() {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        try {
+            fs.rmSync(workDir, { recursive: true, force: true });
+            console.log('xtb working directory cleaned up:', workDir);
+        } catch (e) {
+            console.warn('Could not remove xtb working directory:', workDir, e);
+        }
+    }
+    process.once('exit', cleanup);
+
+    // Build arguments. The geometry file is passed as a relative name; cwd is workDir.
+    const calcArgs = [...cmdPrefixArgs, 'coord.xyz', ...inputFileArgs, '--gxtb', '--chrg', String(charge), '--uhf', String(uhf)];
+    if (mode === 'opt') calcArgs.push('--opt');
+    if (extraFlags) calcArgs.push(...parseXtbCommand(extraFlags));
+
+    const fullCmd = `${xtbCommand} coord.xyz${inputFileArgs.length ? ' --input xtb.inp' : ''} --gxtb${mode === 'opt' ? ' --opt' : ''} --chrg ${charge} --uhf ${uhf}${extraFlags ? ' ' + extraFlags : ''}`;
+    outputTextarea.value = `=== jlmol xtb (g-xTB) Calculation ===\nTimestamp: ${new Date().toISOString()}\nMode: ${mode === 'opt' ? 'Geometry optimization' : 'Single-point energy'}\nxtb command: ${xtbCommand}\nWorking directory: ${workDir}\nFull command: ${fullCmd}\n${freezeSummary ? '\n' + freezeSummary : ''}\n--- Checking xtb availability ---\n`;
+    document.getElementById('status').innerHTML = 'Checking xtb...';
+
+    // Availability check first
+    const versionArgs = [...cmdPrefixArgs, '--version'];
+    const check = spawn(baseCommand, versionArgs, {
+        cwd: workDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: isWSL ? false : true
+    });
+
+    check.on('error', (error) => {
+        cleanup();
+        const wslTip = isWSL ? `\n\nWSL tips:\n- Ensure WSL is installed and xtb exists inside your distribution\n- Try 'wsl xtb --version' in a terminal` : '';
+        outputTextarea.value += `\n=== xtb NOT FOUND ===\nCould not run "${xtbCommand}": ${error.message}\n\nPlease check the xtb command in Settings -> xtb, or install xtb (with g-xTB support) from https://github.com/grimme-lab/g-xtb and make sure it is on your PATH.${wslTip}`;
+        document.getElementById('status').innerHTML = 'xtb not found - see output';
+    });
+
+    check.on('close', (code) => {
+        if (code !== 0) {
+            cleanup();
+            outputTextarea.value += `\nxtb version check failed (exit code ${code}) for command "${xtbCommand}".\nPlease verify the command in Settings -> xtb.`;
+            document.getElementById('status').innerHTML = 'xtb not available - see output';
+            return;
         }
 
-        // Run xtb in the Electron environment
-        async function runXtbInElectron(xyzData, mode) {
-            const { spawn } = require('child_process');
-            const fs = require('fs');
-            const path = require('path');
-            const os = require('os');
+        outputTextarea.value += `xtb found.\n\n--- Starting calculation ---\n`;
+        document.getElementById('status').innerHTML = mode === 'opt' ? 'Optimizing geometry with xtb...' : 'Calculating energy with xtb...';
 
-            const outputTextarea = document.getElementById('xtb-output');
-            const prefs = getPreferences();
-            const xtbCommand = (prefs.xtbCommand || 'xtb').trim();
-            const timeoutMs = (parseInt(prefs.calcTimeout) || 5) * 60 * 1000;
+        const proc = spawn(baseCommand, calcArgs, {
+            cwd: workDir,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            timeout: timeoutMs,
+            shell: isWSL ? false : true
+        });
 
-            // Calculation options from the panel
-            const charge = parseInt(document.getElementById('xtb-charge')?.value, 10) || 0;
-            const uhf = Math.max(0, parseInt(document.getElementById('xtb-uhf')?.value, 10) || 0);
-            const extraFlags = (document.getElementById('xtb-extra-flags')?.value || '').trim();
+        let stdout = '';
+        let outputBuffer = '';
+        const startTime = Date.now();
+        let lastUpdateTime = Date.now();
 
-            const commandParts = parseXtbCommand(xtbCommand);
-            if (commandParts.length === 0) {
-                throw new Error('No xtb command configured. Set it in Settings -> xtb.');
+        function flushOutput() {
+            if (outputBuffer.length > 0) {
+                outputTextarea.value += outputBuffer;
+                outputBuffer = '';
+                outputTextarea.scrollTop = outputTextarea.scrollHeight;
             }
-            const isWSL = commandParts[0].toLowerCase() === 'wsl';
-            const baseCommand = isWSL ? 'wsl' : commandParts[0];
-            const cmdPrefixArgs = commandParts.slice(1); // e.g. ['xtb'] for "wsl xtb", or [] for "xtb"
+        }
 
-            // Dedicated working directory (xtb writes several output files into CWD)
-            const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'jlmol_xtb_'));
-            fs.writeFileSync(path.join(workDir, 'coord.xyz'), xyzData);
+        proc.stdout.on('data', (data) => {
+            const text = data.toString();
+            stdout += text;
+            outputBuffer += text;
+            const now = Date.now();
+            if (now - lastUpdateTime > 100) {
+                flushOutput();
+                lastUpdateTime = now;
+                const elapsed = ((now - startTime) / 1000).toFixed(1);
+                document.getElementById('status').innerHTML = `xtb running... (${elapsed}s)`;
+            }
+        });
 
-            // Optionally freeze the non-selected atoms during optimization by writing
-            // an xtb xcontrol file with a $fix block (passed via --input). The atoms
-            // listed in $fix are removed from the optimization, so only the currently
-            // selected atoms are relaxed.
-            let inputFileArgs = [];
-            let freezeSummary = '';
-            const freezeUnselected = mode === 'opt' && document.getElementById('xtb-freeze-unselected')?.checked;
-            if (freezeUnselected) {
-                const totalAtoms = parseInt(xyzData.split('\n')[0], 10) || 0;
-                if (selectedAtoms.size === 0) {
-                    freezeSummary = '"Relax only selected atoms" is enabled but no atoms are selected — optimizing all atoms.\n';
+        proc.stderr.on('data', (data) => {
+            outputTextarea.value += data.toString();
+            outputTextarea.scrollTop = outputTextarea.scrollHeight;
+        });
+
+        proc.on('error', (error) => {
+            flushOutput();
+            cleanup();
+            outputTextarea.value += `\n=== PROCESS ERROR ===\n${error.message}`;
+            document.getElementById('status').innerHTML = `xtb process error: ${error.message}`;
+        });
+
+        proc.on('close', (exitCode) => {
+            flushOutput();
+            const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+            // NOTE: xtb returns exit code 0 even on failure (e.g. missing g-xTB
+            // parameters), so success is detected from the produced output, not the code.
+            if (mode === 'opt') {
+                const optFile = path.join(workDir, 'xtbopt.xyz');
+                if (fs.existsSync(optFile)) {
+                    let optXyz = '';
+                    try {
+                        optXyz = fs.readFileSync(optFile, 'utf8');
+                    } catch (e) {
+                        optXyz = '';
+                    }
+                    if (optXyz && parseInt(optXyz.split('\n')[0]) > 0) {
+                        applyOptimizedGeometry(optXyz);
+                        outputTextarea.value += `\n\n=== OPTIMIZATION COMPLETED (${elapsed}s) ===\nThe geometry in the viewer has been replaced with the optimized structure.`;
+                        document.getElementById('status').innerHTML = `Geometry optimized with g-xTB (${elapsed}s)`;
+                        cleanup();
+                        return;
+                    }
+                }
+                outputTextarea.value += `\n\n=== OPTIMIZATION FAILED ===\nNo optimized geometry (xtbopt.xyz) was produced. See the output above.\nIf this mentions missing g-xTB parameters, install them from https://github.com/grimme-lab/g-xtb into $XTBPATH or $HOME.`;
+                document.getElementById('status').innerHTML = 'xtb optimization failed - see output';
+            } else {
+                const match = stdout.match(/TOTAL ENERGY\s+(-?\d+\.\d+)/);
+                if (match) {
+                    const energy = match[1];
+                    outputTextarea.value += `\n\n=== ENERGY CALCULATION COMPLETED (${elapsed}s) ===\nTotal energy: ${energy} Eh`;
+                    document.getElementById('status').innerHTML = `g-xTB total energy: ${energy} Eh (${elapsed}s)`;
                 } else {
-                    // selectedAtoms holds 0-based indices; xtb uses 1-based numbering.
-                    const fixed = [];
-                    for (let i = 0; i < totalAtoms; i++) {
-                        if (!selectedAtoms.has(i)) fixed.push(i + 1);
-                    }
-                    if (fixed.length === 0) {
-                        freezeSummary = 'All atoms are selected — nothing to freeze, optimizing all atoms.\n';
-                    } else {
-                        const ranges = formatAtomRanges(fixed);
-                        const xcontrol = `$fix\n   atoms: ${ranges}\n$end\n`;
-                        fs.writeFileSync(path.join(workDir, 'xtb.inp'), xcontrol);
-                        inputFileArgs = ['--input', 'xtb.inp'];
-                        freezeSummary = `Relaxing ${selectedAtoms.size} selected atom(s); freezing ${fixed.length} atom(s) via xtb.inp:\n${xcontrol}`;
-                    }
+                    outputTextarea.value += `\n\n=== ENERGY CALCULATION FAILED ===\nNo total energy was found in the xtb output. See above.\nIf this mentions missing g-xTB parameters, install them from https://github.com/grimme-lab/g-xtb into $XTBPATH or $HOME.`;
+                    document.getElementById('status').innerHTML = 'xtb energy calculation failed - see output';
                 }
             }
+            cleanup();
+        });
+    });
+}
 
-            let cleanedUp = false;
-            function cleanup() {
-                if (cleanedUp) return;
-                cleanedUp = true;
-                try {
-                    fs.rmSync(workDir, { recursive: true, force: true });
-                    console.log('xtb working directory cleaned up:', workDir);
-                } catch (e) {
-                    console.warn('Could not remove xtb working directory:', workDir, e);
-                }
+// Replace the current geometry in the viewer with the optimized structure
+function applyOptimizedGeometry(optXyz) {
+    try {
+        Jmol.script(jmolApplet0, `load inline "${optXyz}" filter "NOSORT"`);
+        setTimeout(() => {
+            if (typeof applyJSmolPreferences === 'function') {
+                try { applyJSmolPreferences(); } catch (e) { console.warn('applyJSmolPreferences failed:', e); }
             }
-            process.once('exit', cleanup);
-
-            // Build arguments. The geometry file is passed as a relative name; cwd is workDir.
-            const calcArgs = [...cmdPrefixArgs, 'coord.xyz', ...inputFileArgs, '--gxtb', '--chrg', String(charge), '--uhf', String(uhf)];
-            if (mode === 'opt') calcArgs.push('--opt');
-            if (extraFlags) calcArgs.push(...parseXtbCommand(extraFlags));
-
-            const fullCmd = `${xtbCommand} coord.xyz${inputFileArgs.length ? ' --input xtb.inp' : ''} --gxtb${mode === 'opt' ? ' --opt' : ''} --chrg ${charge} --uhf ${uhf}${extraFlags ? ' ' + extraFlags : ''}`;
-            outputTextarea.value = `=== jlmol xtb (g-xTB) Calculation ===\nTimestamp: ${new Date().toISOString()}\nMode: ${mode === 'opt' ? 'Geometry optimization' : 'Single-point energy'}\nxtb command: ${xtbCommand}\nWorking directory: ${workDir}\nFull command: ${fullCmd}\n${freezeSummary ? '\n' + freezeSummary : ''}\n--- Checking xtb availability ---\n`;
-            document.getElementById('status').innerHTML = 'Checking xtb...';
-
-            // Availability check first
-            const versionArgs = [...cmdPrefixArgs, '--version'];
-            const check = spawn(baseCommand, versionArgs, {
-                cwd: workDir,
-                stdio: ['pipe', 'pipe', 'pipe'],
-                shell: isWSL ? false : true
-            });
-
-            check.on('error', (error) => {
-                cleanup();
-                const wslTip = isWSL ? `\n\nWSL tips:\n- Ensure WSL is installed and xtb exists inside your distribution\n- Try 'wsl xtb --version' in a terminal` : '';
-                outputTextarea.value += `\n=== xtb NOT FOUND ===\nCould not run "${xtbCommand}": ${error.message}\n\nPlease check the xtb command in Settings -> xtb, or install xtb (with g-xTB support) from https://github.com/grimme-lab/g-xtb and make sure it is on your PATH.${wslTip}`;
-                document.getElementById('status').innerHTML = 'xtb not found - see output';
-            });
-
-            check.on('close', (code) => {
-                if (code !== 0) {
-                    cleanup();
-                    outputTextarea.value += `\nxtb version check failed (exit code ${code}) for command "${xtbCommand}".\nPlease verify the command in Settings -> xtb.`;
-                    document.getElementById('status').innerHTML = 'xtb not available - see output';
-                    return;
-                }
-
-                outputTextarea.value += `xtb found.\n\n--- Starting calculation ---\n`;
-                document.getElementById('status').innerHTML = mode === 'opt' ? 'Optimizing geometry with xtb...' : 'Calculating energy with xtb...';
-
-                const proc = spawn(baseCommand, calcArgs, {
-                    cwd: workDir,
-                    stdio: ['pipe', 'pipe', 'pipe'],
-                    timeout: timeoutMs,
-                    shell: isWSL ? false : true
-                });
-
-                let stdout = '';
-                let outputBuffer = '';
-                const startTime = Date.now();
-                let lastUpdateTime = Date.now();
-
-                function flushOutput() {
-                    if (outputBuffer.length > 0) {
-                        outputTextarea.value += outputBuffer;
-                        outputBuffer = '';
-                        outputTextarea.scrollTop = outputTextarea.scrollHeight;
-                    }
-                }
-
-                proc.stdout.on('data', (data) => {
-                    const text = data.toString();
-                    stdout += text;
-                    outputBuffer += text;
-                    const now = Date.now();
-                    if (now - lastUpdateTime > 100) {
-                        flushOutput();
-                        lastUpdateTime = now;
-                        const elapsed = ((now - startTime) / 1000).toFixed(1);
-                        document.getElementById('status').innerHTML = `xtb running... (${elapsed}s)`;
-                    }
-                });
-
-                proc.stderr.on('data', (data) => {
-                    outputTextarea.value += data.toString();
-                    outputTextarea.scrollTop = outputTextarea.scrollHeight;
-                });
-
-                proc.on('error', (error) => {
-                    flushOutput();
-                    cleanup();
-                    outputTextarea.value += `\n=== PROCESS ERROR ===\n${error.message}`;
-                    document.getElementById('status').innerHTML = `xtb process error: ${error.message}`;
-                });
-
-                proc.on('close', (exitCode) => {
-                    flushOutput();
-                    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-
-                    // NOTE: xtb returns exit code 0 even on failure (e.g. missing g-xTB
-                    // parameters), so success is detected from the produced output, not the code.
-                    if (mode === 'opt') {
-                        const optFile = path.join(workDir, 'xtbopt.xyz');
-                        if (fs.existsSync(optFile)) {
-                            let optXyz = '';
-                            try {
-                                optXyz = fs.readFileSync(optFile, 'utf8');
-                            } catch (e) {
-                                optXyz = '';
-                            }
-                            if (optXyz && parseInt(optXyz.split('\n')[0]) > 0) {
-                                applyOptimizedGeometry(optXyz);
-                                outputTextarea.value += `\n\n=== OPTIMIZATION COMPLETED (${elapsed}s) ===\nThe geometry in the viewer has been replaced with the optimized structure.`;
-                                document.getElementById('status').innerHTML = `Geometry optimized with g-xTB (${elapsed}s)`;
-                                cleanup();
-                                return;
-                            }
-                        }
-                        outputTextarea.value += `\n\n=== OPTIMIZATION FAILED ===\nNo optimized geometry (xtbopt.xyz) was produced. See the output above.\nIf this mentions missing g-xTB parameters, install them from https://github.com/grimme-lab/g-xtb into $XTBPATH or $HOME.`;
-                        document.getElementById('status').innerHTML = 'xtb optimization failed - see output';
-                    } else {
-                        const match = stdout.match(/TOTAL ENERGY\s+(-?\d+\.\d+)/);
-                        if (match) {
-                            const energy = match[1];
-                            outputTextarea.value += `\n\n=== ENERGY CALCULATION COMPLETED (${elapsed}s) ===\nTotal energy: ${energy} Eh`;
-                            document.getElementById('status').innerHTML = `g-xTB total energy: ${energy} Eh (${elapsed}s)`;
-                        } else {
-                            outputTextarea.value += `\n\n=== ENERGY CALCULATION FAILED ===\nNo total energy was found in the xtb output. See above.\nIf this mentions missing g-xTB parameters, install them from https://github.com/grimme-lab/g-xtb into $XTBPATH or $HOME.`;
-                            document.getElementById('status').innerHTML = 'xtb energy calculation failed - see output';
-                        }
-                    }
-                    cleanup();
-                });
-            });
-        }
-
-        // Replace the current geometry in the viewer with the optimized structure
-        function applyOptimizedGeometry(optXyz) {
-            try {
-                Jmol.script(jmolApplet0, `load inline "${optXyz}" filter "NOSORT"`);
-                setTimeout(() => {
-                    if (typeof applyJSmolPreferences === 'function') {
-                        try { applyJSmolPreferences(); } catch (e) { console.warn('applyJSmolPreferences failed:', e); }
-                    }
-                    if (typeof refreshJSMEFromJSmol === 'function') {
-                        try { refreshJSMEFromJSmol(); } catch (e) { /* 2D editor not active */ }
-                    }
-                }, 300);
-            } catch (e) {
-                console.error('Failed to load optimized geometry into viewer:', e);
+            if (typeof refreshJSMEFromJSmol === 'function') {
+                try { refreshJSMEFromJSmol(); } catch (e) { /* 2D editor not active */ }
             }
-        }
+        }, 300);
+    } catch (e) {
+        console.error('Failed to load optimized geometry into viewer:', e);
+    }
+}
 

--- a/js/xyz-editor.js
+++ b/js/xyz-editor.js
@@ -1,256 +1,256 @@
-        function showXYZEditor() {
-            const editorPanel = document.getElementById('editor-panel');
-            editorPanel.style.display = 'block';
+function showXYZEditor() {
+    const editorPanel = document.getElementById('editor-panel');
+    editorPanel.style.display = 'block';
+    
+    try {
+        // Get atom count first
+        const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+        
+        if (!atomCount || atomCount === 0) {
+            document.getElementById('status').innerHTML = 'No structure data available';
+            return;
+        }
+        
+        // Build XYZ data with preserved atom names
+        let xyzData = atomCount + '\n';
+        xyzData += 'Structure with preserved atom names\n';
+        
+        // Get atom data individually to preserve numbered names
+        const atomsData = [];
+        for (let i = 0; i < atomCount; i++) {
+            let atomName;
             
-            try {
-                // Get atom count first
-                const atomCount = Jmol.evaluateVar(jmolApplet0, '{*}.length');
+            // First try to use stored original names if available
+            if (originalAtomNames && i < originalAtomNames.length) {
+                atomName = originalAtomNames[i];
+            } else {
+                // Get atom name from JSmol (may be just element symbol)
+                atomName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
                 
-                if (!atomCount || atomCount === 0) {
-                    document.getElementById('status').innerHTML = 'No structure data available';
-                    return;
-                }
-                
-                // Build XYZ data with preserved atom names
-                let xyzData = atomCount + '\n';
-                xyzData += 'Structure with preserved atom names\n';
-                
-                // Get atom data individually to preserve numbered names
-                const atomsData = [];
-                for (let i = 0; i < atomCount; i++) {
-                    let atomName;
-                    
-                    // First try to use stored original names if available
-                    if (originalAtomNames && i < originalAtomNames.length) {
-                        atomName = originalAtomNames[i];
+                // Check if we need to modify the atom name based on shouldUseNumberedAtoms flag
+                if (!atomName || atomName === 'null' || atomName === '') {
+                    // No atom name from JSmol, generate one
+                    const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`);
+                    if (shouldUseNumberedAtoms) {
+                        atomName = element ? `${element}${i + 1}` : `X${i + 1}`;
                     } else {
-                        // Get atom name from JSmol (may be just element symbol)
-                        atomName = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.atomName`);
-                        
-                        // Check if we need to modify the atom name based on shouldUseNumberedAtoms flag
-                        if (!atomName || atomName === 'null' || atomName === '') {
-                            // No atom name from JSmol, generate one
-                            const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`);
-                            if (shouldUseNumberedAtoms) {
-                                atomName = element ? `${element}${i + 1}` : `X${i + 1}`;
-                            } else {
-                                atomName = element || 'X';
-                            }
-                        } else if (!shouldUseNumberedAtoms && /^[A-Z][a-z]?\d+$/.test(atomName)) {
-                            // Atom name has numbers but we don't want numbered atoms - extract just the element
-                            const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`);
-                            atomName = element || atomName.replace(/\d+/g, '');
-                        } else if (shouldUseNumberedAtoms && atomName.length <= 2 && !/\d/.test(atomName)) {
-                            // Atom name is just element symbol but we want numbered atoms
-                            atomName = `${atomName}${i + 1}`;
-                        }
+                        atomName = element || 'X';
                     }
-                    
-                    // Get coordinates
-                    const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`);
-                    const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`);
-                    const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`);
-                    
-                    const atomData = {
-                        name: atomName,
-                        x: parseFloat(x).toFixed(6),
-                        y: parseFloat(y).toFixed(6),
-                        z: parseFloat(z).toFixed(6)
-                    };
-                    
-                    atomsData.push(atomData);
-                    xyzData += `${atomName}  ${atomData.x}  ${atomData.y}  ${atomData.z}\n`;
+                } else if (!shouldUseNumberedAtoms && /^[A-Z][a-z]?\d+$/.test(atomName)) {
+                    // Atom name has numbers but we don't want numbered atoms - extract just the element
+                    const element = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.element`);
+                    atomName = element || atomName.replace(/\d+/g, '');
+                } else if (shouldUseNumberedAtoms && atomName.length <= 2 && !/\d/.test(atomName)) {
+                    // Atom name is just element symbol but we want numbered atoms
+                    atomName = `${atomName}${i + 1}`;
                 }
-                
-                // Store the XYZ data with preserved names
-                lastXYZData = xyzData;
-                
-                // Create the visual editor interface
-                const xyzContent = document.getElementById('xyz-content');
-                xyzContent.innerHTML = '';
-                
-                // Create table header
-                const headerRow = document.createElement('div');
-                headerRow.className = 'xyz-row header';
-                headerRow.innerHTML = `
+            }
+            
+            // Get coordinates
+            const x = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.x`);
+            const y = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.y`);
+            const z = Jmol.evaluateVar(jmolApplet0, `{atomIndex=${i}}.z`);
+            
+            const atomData = {
+                name: atomName,
+                x: parseFloat(x).toFixed(6),
+                y: parseFloat(y).toFixed(6),
+                z: parseFloat(z).toFixed(6)
+            };
+            
+            atomsData.push(atomData);
+            xyzData += `${atomName}  ${atomData.x}  ${atomData.y}  ${atomData.z}\n`;
+        }
+        
+        // Store the XYZ data with preserved names
+        lastXYZData = xyzData;
+        
+        // Create the visual editor interface
+        const xyzContent = document.getElementById('xyz-content');
+        xyzContent.innerHTML = '';
+        
+        // Create table header
+        const headerRow = document.createElement('div');
+        headerRow.className = 'xyz-row header';
+        headerRow.innerHTML = `
                     <div class="xyz-cell atom-symbol">Atom</div>
                     <div class="xyz-cell coordinate">X</div>
                     <div class="xyz-cell coordinate">Y</div>
                     <div class="xyz-cell coordinate">Z</div>
                 `;
-                xyzContent.appendChild(headerRow);
-                
-                // Add atom rows with preserved names
-                for (let i = 0; i < atomsData.length; i++) {
-                    const atomData = atomsData[i];
-                    const row = document.createElement('div');
-                    row.className = 'xyz-row';
-                    row.innerHTML = `
+        xyzContent.appendChild(headerRow);
+        
+        // Add atom rows with preserved names
+        for (let i = 0; i < atomsData.length; i++) {
+            const atomData = atomsData[i];
+            const row = document.createElement('div');
+            row.className = 'xyz-row';
+            row.innerHTML = `
                         <div class="xyz-cell atom-symbol">${atomData.name}</div>
                         <div class="xyz-cell coordinate">${atomData.x}</div>
                         <div class="xyz-cell coordinate">${atomData.y}</div>
                         <div class="xyz-cell coordinate">${atomData.z}</div>
                     `;
-                    row.dataset.atomIndex = i;
-                    row.onclick = function() {
-                        toggleAtomSelection(this);
-                    };
-                    xyzContent.appendChild(row);
-                }
+            row.dataset.atomIndex = i;
+            row.onclick = function() {
+                toggleAtomSelection(this);
+            };
+            xyzContent.appendChild(row);
+        }
 
-                // Restore selection highlighting/halos for atoms that were already
-                // selected (e.g. via clicking in the 3D structure) before the viewer
-                // was (re)opened.
-                reapplySelectionToRows();
+        // Restore selection highlighting/halos for atoms that were already
+        // selected (e.g. via clicking in the 3D structure) before the viewer
+        // was (re)opened.
+        reapplySelectionToRows();
 
-                // Update textarea content
-                const editArea = document.getElementById('xyz-content-edit');
-                editArea.value = lastXYZData;
-                editArea.style.display = 'none';  // Ensure we start in selection mode
-                xyzContent.style.display = 'block';
-                document.getElementById('toggle-edit-mode').textContent = 'Switch to Edit Mode';
+        // Update textarea content
+        const editArea = document.getElementById('xyz-content-edit');
+        editArea.value = lastXYZData;
+        editArea.style.display = 'none';  // Ensure we start in selection mode
+        xyzContent.style.display = 'block';
+        document.getElementById('toggle-edit-mode').textContent = 'Switch to Edit Mode';
+        
+        // Update MOL file data for JSME integration when XYZ editor is opened
+        // Do this LAST to ensure we get the current state without any modifications
+        try {
+            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
+            debugLog('XYZ', 'Updated lastMolFile when opening XYZ editor, length:', lastMolFile ? lastMolFile.length : 0);
+        } catch (molError) {
+            console.error('Error updating MOL file data in showXYZEditor:', molError);
+        }
+        
+    } catch (err) {
+        document.getElementById('status').innerHTML = 'Error getting structure data: ' + err.message;
+    }
+}
+
+function toggleEditMode() {
+    const selectionView = document.getElementById('xyz-content');
+    const editView = document.getElementById('xyz-content-edit');
+    const editButton = document.getElementById('toggle-edit-mode');
+    
+    if (selectionView.style.display !== 'none') {
+        // Switch to edit mode
+        selectionView.style.display = 'none';
+        editView.style.display = 'block';
+        editButton.textContent = 'Switch to Selection Mode';
+        // Clear any existing selections (keeps state Set, rows and halos in sync)
+        clearAtomSelection();
+    } else {
+        // Switch to selection mode
+        selectionView.style.display = 'block';
+        editView.style.display = 'none';
+        editButton.textContent = 'Switch to Edit Mode';
+        // Re-draw halos for any atoms selected via the 3D structure
+        reapplySelectionToRows();
+    }
+}
+
+function updateStructure() {
+    const editView = document.getElementById('xyz-content-edit');
+    try {
+        const xyzData = editView.value.trim();
+        const lines = xyzData.split('\n');
+        
+        if (lines.length < 3) {
+            throw new Error('Invalid XYZ format');
+        }
+        
+        const atomCount = parseInt(lines[0]);
+        if (isNaN(atomCount) || atomCount <= 0) {
+            throw new Error('Invalid atom count');
+        }
+        
+        // Parse the atom data to extract names and coordinates
+        const atomsData = [];
+        const newOriginalNames = [];
+        for (let i = 2; i < atomCount + 2 && i < lines.length; i++) {
+            const parts = lines[i].trim().split(/\s+/);
+            if (parts.length >= 4) {
+                const atomName = parts[0];
+                let elementSymbol = atomName.replace(/\d+/g, ''); // Extract element symbol
                 
-                // Update MOL file data for JSME integration when XYZ editor is opened
-                // Do this LAST to ensure we get the current state without any modifications
+                // Capitalize the first letter and make the rest lowercase for proper element recognition
+                if (elementSymbol.length > 0) {
+                    elementSymbol = elementSymbol.charAt(0).toUpperCase() + elementSymbol.slice(1).toLowerCase();
+                }
+                
+                newOriginalNames.push(atomName);
+                atomsData.push({
+                    name: atomName,
+                    element: elementSymbol,
+                    x: parseFloat(parts[1]),
+                    y: parseFloat(parts[2]),
+                    z: parseFloat(parts[3])
+                });
+            }
+        }
+        
+        // Load the structure with coordinates only first (using element symbols)
+        let tempXyzData = atomCount + '\n' + lines[1] + '\n';
+        for (const atom of atomsData) {
+            tempXyzData += `${atom.element}  ${atom.x}  ${atom.y}  ${atom.z}\n`;
+        }
+        
+        // Load the structure
+        Jmol.script(jmolApplet0, 'load inline "' + tempXyzData + '"');
+        
+        // Update stored original names
+        setOriginalAtomNames(newOriginalNames);
+        originalXYZContent = xyzData;
+        
+        // Apply the numbered atom names after a short delay
+        setTimeout(() => {
+            for (let i = 0; i < atomsData.length; i++) {
+                const atomName = atomsData[i].name;
+                Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${atomName}"`);
+            }
+            
+            // Refresh atom names to ensure they're properly maintained
+            setTimeout(() => {
+                refreshAtomNames();
+                console.log('updateStructure: Atom names refreshed after update');
+                
+                // Apply all JSmol preferences after structure update
+                if (typeof applyJSmolPreferences === 'function') {
+                    applyJSmolPreferences();
+                    console.log('updateStructure: Applied JSmol preferences');
+                }
+                
+                // Update MOL file data for JSME integration after structure changes
                 try {
                     lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                    debugLog('XYZ', 'Updated lastMolFile when opening XYZ editor, length:', lastMolFile ? lastMolFile.length : 0);
+                    debugLog('XYZ', 'Updated lastMolFile for JSME integration');
+                    
+                    // If JSME editor is currently visible, refresh it with the new structure
+                    if (!is3D && jsmeApplet) {
+                        refreshJSMEFromJSmol();
+                    }
                 } catch (molError) {
-                    console.error('Error updating MOL file data in showXYZEditor:', molError);
+                    console.error('Error updating MOL file data:', molError);
                 }
-                
-            } catch (err) {
-                document.getElementById('status').innerHTML = 'Error getting structure data: ' + err.message;
-            }
-        }
-
-        function toggleEditMode() {
-            const selectionView = document.getElementById('xyz-content');
-            const editView = document.getElementById('xyz-content-edit');
-            const editButton = document.getElementById('toggle-edit-mode');
+            }, 100);
             
-            if (selectionView.style.display !== 'none') {
-                // Switch to edit mode
-                selectionView.style.display = 'none';
-                editView.style.display = 'block';
-                editButton.textContent = 'Switch to Selection Mode';
-                // Clear any existing selections (keeps state Set, rows and halos in sync)
-                clearAtomSelection();
-            } else {
-                // Switch to selection mode
-                selectionView.style.display = 'block';
-                editView.style.display = 'none';
-                editButton.textContent = 'Switch to Edit Mode';
-                // Re-draw halos for any atoms selected via the 3D structure
-                reapplySelectionToRows();
-            }
-        }
+            document.getElementById('status').innerHTML = 'Structure updated successfully with preserved atom names';
+        }, 100);
+        
+        showXYZEditor(); // Refresh the selection view with updated data
+    } catch (err) {
+        document.getElementById('status').innerHTML = 'Error updating structure: ' + err.message;
+    }
+}
 
-        function updateStructure() {
-            const editView = document.getElementById('xyz-content-edit');
-            try {
-                const xyzData = editView.value.trim();
-                const lines = xyzData.split('\n');
-                
-                if (lines.length < 3) {
-                    throw new Error('Invalid XYZ format');
-                }
-                
-                const atomCount = parseInt(lines[0]);
-                if (isNaN(atomCount) || atomCount <= 0) {
-                    throw new Error('Invalid atom count');
-                }
-                
-                // Parse the atom data to extract names and coordinates
-                const atomsData = [];
-                const newOriginalNames = [];
-                for (let i = 2; i < atomCount + 2 && i < lines.length; i++) {
-                    const parts = lines[i].trim().split(/\s+/);
-                    if (parts.length >= 4) {
-                        const atomName = parts[0];
-                        let elementSymbol = atomName.replace(/\d+/g, ''); // Extract element symbol
-                        
-                        // Capitalize the first letter and make the rest lowercase for proper element recognition
-                        if (elementSymbol.length > 0) {
-                            elementSymbol = elementSymbol.charAt(0).toUpperCase() + elementSymbol.slice(1).toLowerCase();
-                        }
-                        
-                        newOriginalNames.push(atomName);
-                        atomsData.push({
-                            name: atomName,
-                            element: elementSymbol,
-                            x: parseFloat(parts[1]),
-                            y: parseFloat(parts[2]),
-                            z: parseFloat(parts[3])
-                        });
-                    }
-                }
-                
-                // Load the structure with coordinates only first (using element symbols)
-                let tempXyzData = atomCount + '\n' + lines[1] + '\n';
-                for (const atom of atomsData) {
-                    tempXyzData += `${atom.element}  ${atom.x}  ${atom.y}  ${atom.z}\n`;
-                }
-                
-                // Load the structure
-                Jmol.script(jmolApplet0, 'load inline "' + tempXyzData + '"');
-                
-                // Update stored original names
-                setOriginalAtomNames(newOriginalNames);
-                originalXYZContent = xyzData;
-                
-                // Apply the numbered atom names after a short delay
-                setTimeout(() => {
-                    for (let i = 0; i < atomsData.length; i++) {
-                        const atomName = atomsData[i].name;
-                        Jmol.script(jmolApplet0, `{atomIndex=${i}}.atomName = "${atomName}"`);
-                    }
-                    
-                    // Refresh atom names to ensure they're properly maintained
-                    setTimeout(() => {
-                        refreshAtomNames();
-                        console.log('updateStructure: Atom names refreshed after update');
-                        
-                        // Apply all JSmol preferences after structure update
-                        if (typeof applyJSmolPreferences === 'function') {
-                            applyJSmolPreferences();
-                            console.log('updateStructure: Applied JSmol preferences');
-                        }
-                        
-                        // Update MOL file data for JSME integration after structure changes
-                        try {
-                            lastMolFile = Jmol.evaluateVar(jmolApplet0, 'write("mol")').trim();
-                            debugLog('XYZ', 'Updated lastMolFile for JSME integration');
-                            
-                            // If JSME editor is currently visible, refresh it with the new structure
-                            if (!is3D && jsmeApplet) {
-                                refreshJSMEFromJSmol();
-                            }
-                        } catch (molError) {
-                            console.error('Error updating MOL file data:', molError);
-                        }
-                    }, 100);
-                    
-                    document.getElementById('status').innerHTML = 'Structure updated successfully with preserved atom names';
-                }, 100);
-                
-                showXYZEditor(); // Refresh the selection view with updated data
-            } catch (err) {
-                document.getElementById('status').innerHTML = 'Error updating structure: ' + err.message;
-            }
-        }
-
-        function optimizeStructure() {
-            try {
-                Jmol.script(jmolApplet0, 'minimize');
-                document.getElementById('status').innerHTML = 'Structure optimization started';
-                // Update the XYZ editor after a short delay to allow optimization to complete
-                setTimeout(() => {
-                    showXYZEditor();
-                    document.getElementById('status').innerHTML = 'Structure optimization completed';
-                }, 1000);
-            } catch (err) {
-                document.getElementById('status').innerHTML = 'Error optimizing structure: ' + err.message;
-            }
-        }
+function optimizeStructure() {
+    try {
+        Jmol.script(jmolApplet0, 'minimize');
+        document.getElementById('status').innerHTML = 'Structure optimization started';
+        // Update the XYZ editor after a short delay to allow optimization to complete
+        setTimeout(() => {
+            showXYZEditor();
+            document.getElementById('status').innerHTML = 'Structure optimization completed';
+        }, 1000);
+    } catch (err) {
+        document.getElementById('status').innerHTML = 'Error optimizing structure: ' + err.message;
+    }
+}
 


### PR DESCRIPTION
Cosmetic follow-up to the JS split: the feature files inherited a leftover **8-space base indent** from when the code lived inside the HTML `<script>`. This dedents them to start at column 0.

## Whitespace-only — verified mechanically

A naive dedent would corrupt **multi-line template literals** (the Julia/XYZ/HTML string templates), which would be a behavior change. To avoid that, the dedent:
1. parses each file with **acorn** and skips lines inside multi-line template literals, then
2. **verifies** by comparing the full acorn **token stream** before vs after — for all 14 files the streams are **byte-for-byte identical**, which guarantees the change is purely whitespace with no semantic effect.

The diff is symmetric (3,707 insertions / 3,707 deletions — every touched line only changed its leading whitespace), and all files still pass `node --check`.

Kept as a separate PR so the large whitespace diff never obscures a logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)