### PR TITLE
Refactor (5/N): drop dead duplicate functions from renderer.js

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -18,39 +18,11 @@
     }
 })();
 
-function showElemCoPanel() {
-    document.getElementById('elemcoPanel').style.display = 'block';
-    updateElemCoInput(); // Remove initializeElemCoListeners call since we handle it in DOMContentLoaded
-}
-
-function hideElemCoPanel() {
-    document.getElementById('elemcoPanel').style.display = 'none';
-}
-
-function generateElemCoInput() {
-    updateElemCoInput();
-    document.getElementById('status').innerHTML = 'ElemCo.jl input reset to default';
-}
-
-function copyElemCoInput() {
-    const input = document.getElementById('elemco-input');
-    input.select();
-    document.execCommand('copy');
-    document.getElementById('status').innerHTML = 'Input copied to clipboard';
-}
-
-function runJuliaCalculation() {
-    // This function is defined in index.html and will be called from there
-    if (typeof window.runJuliaCalculation === 'function') {
-        window.runJuliaCalculation();
-    } else {
-        document.getElementById('status').innerHTML = 'Julia calculation function not available';
-    }
-}
-
-// Note: showXtbPanel() and runXtb() are defined as globals in index.html's inline
-// script (like the other panel handlers). No wrappers here — defining them again
-// before that script loads would shadow the real implementations.
+// Note: the ElemCo / Julia / xtb panel handlers (showElemCoPanel, hideElemCoPanel,
+// generateElemCoInput, copyElemCoInput, runJuliaCalculation, showXtbPanel, runXtb, …)
+// are defined as globals in the js/ feature scripts (js/elemco.js, js/xtb.js), which
+// load after this file. We do NOT redefine them here — earlier definitions would just
+// be overridden, and the feature-script versions are authoritative.
 
 // Add event listeners for input changes when the DOM is ready
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Cleanup follow-up to the JS split.

`renderer.js` is loaded **before** the `js/` feature scripts, so its definitions of `showElemCoPanel`, `hideElemCoPanel`, `generateElemCoInput`, `copyElemCoInput`, and `runJuliaCalculation` were always overridden by the authoritative versions in `js/elemco.js` — i.e. dead code that never ran. (The `runJuliaCalculation` one was also just a no-op wrapper that delegated to `window.runJuliaCalculation`, which is itself the overridden global.)

## Change

- Removed those 5 dead function definitions.
- Updated the comment to point at the `js/` feature scripts.
- **Unchanged:** the `checkVersion` IIFE and the `DOMContentLoaded` / `window.load` / `resize` / `visibilitychange` lifecycle listeners (these are the real, non-duplicated work `renderer.js` does).

No runtime behavior changes — the active versions of these functions were already the `js/elemco.js` ones. `node --check renderer.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)