### PR TITLE
Fix controls panel clipping on small/mobile screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -702,9 +702,10 @@
             padding: 6px 8px;  /* Reduced horizontal padding */
         }
 
-        /* Keep the Reset button at normal width */
+        /* Keep the Reset button compact so it doesn't overflow narrow screens */
         .control-line button[onclick*="resetZoom"] {
-            min-width: 70px;
+            min-width: 50px;
+            padding: 6px 8px;
         }
 
         /* Edit buttons - make them more compact */

--- a/css/styles.css
+++ b/css/styles.css
@@ -25,10 +25,16 @@
             top: 0;
             left: 0;
         }
-        #controls { 
-            width: 200px; 
+        #controls {
+            width: 200px;
+            flex-shrink: 0;
             padding: 10px;
+            box-sizing: border-box;
+            height: 100vh;
+            overflow-y: auto;
+            overflow-x: hidden;
             transform-origin: top right;
+            -webkit-overflow-scrolling: touch;
         }
         #editor-panel {
             position: fixed;
@@ -1234,4 +1240,30 @@
             color: #777;
             margin-top: 4px;
             font-style: italic;
+        }
+
+        /* Narrow screens (phones / small tablets): stack the viewer on top of
+           the controls so the 200px sidebar isn't clipped horizontally, and let
+           the whole page scroll vertically. */
+        @media (max-width: 768px) {
+            #container {
+                flex-direction: column;
+                height: auto;
+                min-height: 100vh;
+                overflow: visible;
+            }
+            #viewer,
+            #jsmeContainer {
+                flex: none;
+                width: 100%;
+                min-width: 0;
+                height: 60vh;
+            }
+            #controls {
+                width: 100%;
+                flex-shrink: 1;
+                height: auto;
+                overflow-y: visible;
+                transform-origin: top left;
+            }
         }


### PR DESCRIPTION
## Summary
Fixes both vertical and horizontal clipping of the controls sidebar on small/mobile windows, where buttons (e.g. xtb, ElemCo) could become unreachable.

## Changes (CSS only, `css/styles.css`)
- **Vertical scroll (all screen sizes):** `#controls` now scrolls internally (`height: 100vh; overflow-y: auto`), so bottom buttons stay reachable when the window is shorter than the panel.
- **Horizontal clipping (≤768px):** a media query stacks the layout into a single scrollable column — the viewer goes full-width above the controls, `min-width: 0` overrides the 400px minimum that forced overflow, and the page scrolls vertically. The existing `ResizeObserver` on `#viewer` reflows the JSmol canvas automatically.
- **Reset button:** slimmed the zoom Reset button (`min-width: 70px` → `50px`, tighter padding) so it no longer overflows the edge on narrow screens.

No JavaScript changes.

## Testing
Open `index.html` and use the browser's responsive/device mode (or a real phone): below 768px the controls appear full-width under the viewer with vertical page scroll and no horizontal cutoff; at wider widths the original side-by-side layout is unchanged, now with the sidebar scrolling when taller than the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)