### PR TITLE
Enable dragging popup panels via touch on mobile

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -13,20 +13,40 @@ function initDraggable() {
         document.addEventListener('mousemove', drag);
         document.addEventListener('mouseup', dragEnd);
 
+        // Touch support so panels can be dragged on mobile devices too.
+        header.addEventListener('touchstart', dragStart, { passive: false });
+        document.addEventListener('touchmove', drag, { passive: false });
+        document.addEventListener('touchend', dragEnd);
+        document.addEventListener('touchcancel', dragEnd);
+
+        // Read the pointer position from either a mouse or a touch event.
+        function getPoint(e) {
+            if (e.touches && e.touches.length) {
+                return { x: e.touches[0].clientX, y: e.touches[0].clientY };
+            }
+            return { x: e.clientX, y: e.clientY };
+        }
+
         function dragStart(e) {
-            initialX = e.clientX - xOffset;
-            initialY = e.clientY - yOffset;
+            const point = getPoint(e);
+            initialX = point.x - xOffset;
+            initialY = point.y - yOffset;
 
             if (e.target === header) {
                 isDragging = true;
+                // Prevent the page from scrolling while dragging on touch.
+                if (e.type === 'touchstart') {
+                    e.preventDefault();
+                }
             }
         }
 
         function drag(e) {
             if (isDragging) {
                 e.preventDefault();
-                currentX = e.clientX - initialX;
-                currentY = e.clientY - initialY;
+                const point = getPoint(e);
+                currentX = point.x - initialX;
+                currentY = point.y - initialY;
                 xOffset = currentX;
                 yOffset = currentY;
 


### PR DESCRIPTION
## Summary
The draggable popup panels (ElemCo input, orbital controls, XYZ editor, preferences, xtb) could be moved by dragging their headers on desktop and in the Electron app, but not on touch devices.

## Cause
`makeDraggable` in `js/ui.js` only registered `mousedown`/`mousemove`/`mouseup`, which don't fire for touch interactions.

## Fix
Added matching `touchstart`/`touchmove`/`touchend`/`touchcancel` handlers that share the existing drag logic, plus a small `getPoint()` helper that reads coordinates from `e.touches[0]` (touch) or `e.clientX/Y` (mouse). `touchmove` uses `{ passive: false }` and `preventDefault()` so the page doesn't scroll while a panel is being dragged.

Applies to all five panels since they share the same helper. No CSS changes.

## Testing
On a phone (or browser device emulation), open the ElemCo panel and drag it by its header — it now moves just like on desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)