### PR TITLE
Add desktop update checker (notify + open download)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Update checker (desktop app): jlmol now checks GitHub for a newer release and, if one is available, shows a dialog with the new version and its release notes and asks whether to update. Choosing "Download update" opens the appropriate installer for your OS (or the release page) in your browser to install manually; "Later" defers until next launch and "Skip this version" suppresses reminders for that version. Checks run quietly once on startup (only prompting when an update exists) and can be triggered any time from **Settings → General → Check for Updates Now**. The automatic startup check can be turned off with "Automatically check for updates on startup" in the same section. The feature is desktop-only (the browser version is always up to date).
+
 ## [1.4.0] - 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -394,6 +394,18 @@ Click the **Settings** button next to the Console button in the main interface t
 #### Application Settings
 
 - **Julia Command**: Configure the command used to run Julia for ElemCo.jl calculations
+- **Automatically check for updates on startup**: When enabled (default), the desktop app quietly checks GitHub for a newer release each time it starts and notifies you if one is available. Use **Check for Updates Now** to check on demand.
+
+### Checking for Updates
+
+The desktop app can tell you when a newer version of jlmol has been released:
+
+- On startup it quietly asks GitHub for the latest release and, only if a newer version exists, shows a dialog with the new version number and release notes.
+- You can check any time from **Settings → General → Check for Updates Now**.
+- If an update is available, choose **Download update** to open the right installer for your operating system (or the [releases page](https://github.com/fkfest/jlmol/releases/latest)) in your browser and install it manually, **Later** to be reminded next launch, or **Skip this version** to stop reminders for that release.
+- Automatic checks can be disabled with **Automatically check for updates on startup**.
+
+Updates are handled manually (jlmol never installs anything on its own), and update checks apply only to the desktop app — the [browser version](https://app.jlmol.com) is always up to date.
 
 ### Julia Command Configuration
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1313,3 +1313,126 @@
                 transform-origin: top left;
             }
         }
+
+        /* ---- Update-available dialog (js/updater.js) ---- */
+        #updateOverlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.45);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            z-index: 100000;
+        }
+
+        #updateDialog {
+            background: white;
+            border: 1px solid #ccc;
+            border-radius: 8px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+            width: 460px;
+            max-width: 90vw;
+            max-height: 85vh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .update-dialog-header {
+            padding: 12px 18px;
+            background: linear-gradient(to bottom, #f8f8f8, #e8e8e8);
+            border-bottom: 1px solid #ccc;
+        }
+
+        .update-dialog-header h3 {
+            margin: 0;
+            font-size: 16px;
+            color: #333;
+        }
+
+        .update-dialog-body {
+            padding: 16px 18px;
+            overflow-y: auto;
+        }
+
+        .update-summary {
+            margin: 0 0 10px 0;
+            font-size: 14px;
+            color: #333;
+        }
+
+        .update-notes-label {
+            font-size: 12px;
+            font-weight: 600;
+            color: #666;
+            margin-bottom: 4px;
+        }
+
+        .update-notes {
+            margin: 0 0 12px 0;
+            padding: 10px;
+            background: #f5f5f5;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            font-size: 12px;
+            line-height: 1.4;
+            color: #333;
+            white-space: pre-wrap;
+            word-break: break-word;
+            max-height: 220px;
+            overflow-y: auto;
+        }
+
+        .update-releasepage-link {
+            font-size: 12px;
+            color: #2e7d32;
+            text-decoration: none;
+        }
+
+        .update-releasepage-link:hover {
+            text-decoration: underline;
+        }
+
+        .update-dialog-footer {
+            padding: 12px 18px;
+            border-top: 1px solid #eee;
+            display: flex;
+            justify-content: flex-end;
+            gap: 8px;
+        }
+
+        .update-dialog-footer button {
+            padding: 8px 16px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            background: #f5f5f5;
+            cursor: pointer;
+            font-size: 13px;
+            font-weight: 500;
+            transition: all 0.2s ease;
+        }
+
+        .update-download-button {
+            background: #4CAF50 !important;
+            color: white;
+            border-color: #45a049 !important;
+        }
+
+        .update-download-button:hover {
+            background: #45a049 !important;
+            transform: translateY(-1px);
+        }
+
+        .update-later-button:hover,
+        .update-skip-button:hover {
+            background: #e0e0e0;
+            transform: translateY(-1px);
+        }
+
+        .update-skip-button {
+            margin-right: auto;
+            color: #666;
+        }

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <script type="text/javascript" src="js/xtb.js"></script>
     <script type="text/javascript" src="js/app-init.js"></script>
     <script type="text/javascript" src="js/preferences.js"></script>
+    <script type="text/javascript" src="js/updater.js"></script>
 </head>
 <body>
     <div id="container">
@@ -357,7 +358,22 @@
                         <div class="preference-description">Display helpful tooltips when hovering over buttons and controls</div>
                     </div>
                 </div>
-                
+
+                <div class="preference-section">
+                    <h4>Updates</h4>
+                    <div class="preference-item">
+                        <label class="preference-checkbox-label">
+                            <input type="checkbox" id="pref-check-updates">
+                            <span>Automatically check for updates on startup</span>
+                        </label>
+                        <div class="preference-description">Quietly check GitHub for a newer release when jlmol starts, and notify you if one is available</div>
+                    </div>
+                    <div class="preference-item">
+                        <button type="button" class="preference-reset-button" onclick="checkForUpdates({ silent: false })" title="Check GitHub for a newer version of jlmol">Check for Updates Now</button>
+                        <div id="update-check-result" class="preference-description" style="margin-top: 6px;"></div>
+                    </div>
+                </div>
+
                 <div class="preference-section">
                     <h4>File Handling</h4>
                     <div class="preference-item">

--- a/js/app-init.js
+++ b/js/app-init.js
@@ -45,6 +45,9 @@ function initializeApplication() {
                 updateInputPlaceholder();
                 setupDatabaseInputHandlers();
                 initPreferences();
+                if (typeof initUpdateChecker === 'function') {
+                    initUpdateChecker();
+                }
                 console.log('Application initialized successfully');
             } catch (error) {
                 console.warn('Error during initialization:', error);

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -8,6 +8,7 @@ const DEFAULT_PREFERENCES = {
     confirmOverwrite: true,
     exportFormat: 'png',
     exportTransparentBackground: true,
+    checkUpdatesOnStartup: true,
     
     // Display settings
     autoSpin: false,
@@ -99,8 +100,15 @@ function loadPreferencesIntoUI() {
     
     const exportTransparentCheckbox = document.getElementById('pref-export-transparent');
     if (exportTransparentCheckbox) exportTransparentCheckbox.checked = prefs.exportTransparentBackground !== false;
-    
-    // Display settings  
+
+    const checkUpdatesCheckbox = document.getElementById('pref-check-updates');
+    if (checkUpdatesCheckbox) checkUpdatesCheckbox.checked = prefs.checkUpdatesOnStartup !== false;
+
+    // Clear any stale "Check for Updates" result from a previous time the panel was open.
+    const updateResult = document.getElementById('update-check-result');
+    if (updateResult) updateResult.textContent = '';
+
+    // Display settings
     const autoSpinCheckbox = document.getElementById('pref-auto-spin');
     if (autoSpinCheckbox) autoSpinCheckbox.checked = prefs.autoSpin || false;
     
@@ -227,7 +235,10 @@ function savePreferencesFromUI() {
     
     const exportTransparentCheckbox = document.getElementById('pref-export-transparent');
     if (exportTransparentCheckbox) prefs.exportTransparentBackground = exportTransparentCheckbox.checked;
-    
+
+    const checkUpdatesCheckbox = document.getElementById('pref-check-updates');
+    if (checkUpdatesCheckbox) prefs.checkUpdatesOnStartup = checkUpdatesCheckbox.checked;
+
     // Display settings
     const autoSpinCheckbox = document.getElementById('pref-auto-spin');
     if (autoSpinCheckbox) prefs.autoSpin = autoSpinCheckbox.checked;

--- a/js/updater.js
+++ b/js/updater.js
@@ -1,0 +1,355 @@
+// Update checker for the jlmol desktop app.
+//
+// jlmol is distributed as unsigned installers on GitHub Releases
+// (Windows .exe, macOS .dmg, Linux .deb/.rpm/.AppImage). Because the app is
+// unsigned and ships package formats that can't be updated in-place (.deb/.rpm),
+// we do NOT attempt a silent in-app auto-install. Instead we:
+//   1. Ask GitHub for the latest published release.
+//   2. Compare its version to the running version (window.appVersion).
+//   3. If newer, show a dialog and — only if the user agrees — open the
+//      appropriate installer / release page in their browser to install manually.
+//
+// Two entry points:
+//   - initUpdateChecker(): quiet check shortly after startup (respects the
+//     "check on startup" preference and any version the user chose to skip).
+//   - checkForUpdates({ silent }): the actual check. silent=false is the manual
+//     "Check for updates" button in Settings, which always reports a result.
+//
+// The whole feature is inert in the browser build (app.jlmol.com): there is
+// nothing to "install" there, so isElectronApp() gates every network call.
+
+const JLMOL_GITHUB_REPO = 'fkfest/jlmol';
+const JLMOL_LATEST_RELEASE_API = `https://api.github.com/repos/${JLMOL_GITHUB_REPO}/releases/latest`;
+const JLMOL_RELEASES_PAGE = `https://github.com/${JLMOL_GITHUB_REPO}/releases/latest`;
+const JLMOL_SKIPPED_VERSION_KEY = 'jlmol-skipped-update-version';
+
+// Guard so the automatic startup check only ever fires once per session.
+let jlmolStartupCheckDone = false;
+
+// True only inside the packaged Electron app (where an install can actually
+// happen). In a normal browser tab this stays false and the feature is disabled.
+function isElectronApp() {
+    try {
+        return typeof process !== 'undefined'
+            && !!(process.versions && process.versions.electron);
+    } catch (e) {
+        return false;
+    }
+}
+
+// "v1.4.0" / "1.4.0-beta" -> [1, 4, 0]. Non-numeric suffixes on a component
+// (e.g. "0-beta") are reduced to their leading integer; missing pieces are 0.
+function parseVersion(v) {
+    return String(v == null ? '' : v)
+        .trim()
+        .replace(/^v/i, '')
+        .split('.')
+        .map(part => parseInt(part, 10) || 0);
+}
+
+// Numeric, component-wise semver-ish compare. Returns 1 if a>b, -1 if a<b, 0 if
+// equal. Handles differing lengths (1.4 vs 1.4.0) and large minors (1.10 > 1.9).
+function compareVersions(a, b) {
+    const A = parseVersion(a);
+    const B = parseVersion(b);
+    const len = Math.max(A.length, B.length);
+    for (let i = 0; i < len; i++) {
+        const x = A[i] || 0;
+        const y = B[i] || 0;
+        if (x > y) return 1;
+        if (x < y) return -1;
+    }
+    return 0;
+}
+
+// The version this build reports (injected by main.js as window.appVersion, or
+// loaded from package.json in the browser build).
+function getCurrentVersion() {
+    return (typeof window !== 'undefined' && window.appVersion) || 'unknown';
+}
+
+// Pick the best URL to send the user to for a given release. On Windows/macOS
+// there is exactly one installer format, so we can deep-link straight to it; on
+// Linux several formats ship (.deb/.rpm/.AppImage) so we send them to the
+// release page to choose. Falls back to the release page whenever unsure.
+function pickDownloadUrl(release) {
+    const page = (release && release.html_url) || JLMOL_RELEASES_PAGE;
+    const assets = (release && Array.isArray(release.assets)) ? release.assets : [];
+
+    let platform = '';
+    try {
+        platform = (typeof process !== 'undefined' && process.platform) || '';
+    } catch (e) {
+        platform = '';
+    }
+
+    const findAsset = (suffix) => {
+        const match = assets.find(a =>
+            a && typeof a.name === 'string' &&
+            a.name.toLowerCase().endsWith(suffix) &&
+            typeof a.browser_download_url === 'string' &&
+            a.browser_download_url.startsWith('https://'));
+        return match ? match.browser_download_url : null;
+    };
+
+    if (platform === 'win32') return findAsset('.exe') || page;
+    if (platform === 'darwin') return findAsset('.dmg') || page;
+    // Linux (deb/rpm/AppImage are ambiguous) and anything else: the release page.
+    return page;
+}
+
+// Open an external URL in the user's default browser. Only https URLs are
+// allowed — nodeIntegration is on and webSecurity is off in this app, so we must
+// never hand an arbitrary scheme (file:, javascript:) to the shell.
+function openExternalUrl(url) {
+    if (typeof url !== 'string' || !url.startsWith('https://')) {
+        console.warn('Refusing to open non-https update URL:', url);
+        return;
+    }
+    try {
+        const { shell } = require('electron');
+        shell.openExternal(url);
+    } catch (e) {
+        // Not in Electron, or shell unavailable — fall back to a normal window.
+        try {
+            window.open(url, '_blank', 'noopener');
+        } catch (e2) {
+            console.error('Could not open update URL:', e2);
+        }
+    }
+}
+
+// Small helper for the manual-check result line in Settings.
+function setUpdateCheckResult(message, isError) {
+    const el = document.getElementById('update-check-result');
+    if (!el) return;
+    el.textContent = message || '';
+    el.style.color = isError ? '#c0392b' : '#2e7d32';
+}
+
+// Fetch the latest release from GitHub and decide what to do.
+//   silent === true  -> automatic startup check: only speak up if there is an
+//                        update the user hasn't chosen to skip.
+//   silent === false -> manual check: always report (up to date / error / update).
+async function checkForUpdates(options) {
+    const opts = options || {};
+    const silent = !!opts.silent;
+
+    if (!isElectronApp()) {
+        if (!silent) {
+            setUpdateCheckResult('Update checks are only available in the desktop app.', false);
+        }
+        return;
+    }
+
+    if (!silent) setUpdateCheckResult('Checking for updates…', false);
+
+    let release;
+    try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 10000);
+        const response = await fetch(JLMOL_LATEST_RELEASE_API, {
+            method: 'GET',
+            headers: { 'Accept': 'application/vnd.github+json' },
+            signal: controller.signal
+        });
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+            throw new Error(`GitHub API responded ${response.status}`);
+        }
+        release = await response.json();
+    } catch (error) {
+        console.warn('Update check failed:', error);
+        if (!silent) {
+            setUpdateCheckResult('Could not check for updates (network error). Please try again later.', true);
+        }
+        return;
+    }
+
+    const latestTag = release && release.tag_name;
+    if (!latestTag) {
+        if (!silent) setUpdateCheckResult('Could not determine the latest version.', true);
+        return;
+    }
+
+    const current = getCurrentVersion();
+    // Never present an update when we don't reliably know the running version
+    // (e.g. window.appVersion ended up 'unknown'): parseVersion('unknown') is [0],
+    // which would make every real release look newer and nag about a version the
+    // user already has.
+    if (current === 'unknown' || !parseVersion(current).some(n => n > 0)) {
+        console.warn('Skipping update check: current version is unknown.');
+        if (!silent) setUpdateCheckResult('Could not determine your current version.', true);
+        return;
+    }
+    const isNewer = compareVersions(latestTag, current) > 0;
+
+    if (!isNewer) {
+        console.log(`jlmol is up to date (running ${current}, latest ${latestTag}).`);
+        if (!silent) {
+            setUpdateCheckResult(`You're on the latest version (v${parseVersion(current).join('.')}).`, false);
+        }
+        return;
+    }
+
+    // A newer release exists. On the silent startup check, honor a version the
+    // user previously chose to skip; a manual check always shows it.
+    if (silent) {
+        let skipped = null;
+        try {
+            skipped = localStorage.getItem(JLMOL_SKIPPED_VERSION_KEY);
+        } catch (e) {
+            skipped = null;
+        }
+        if (skipped && compareVersions(skipped, latestTag) >= 0) {
+            console.log(`Update ${latestTag} available but skipped by user.`);
+            return;
+        }
+    } else {
+        setUpdateCheckResult(`Update available: v${parseVersion(latestTag).join('.')}`, false);
+    }
+
+    showUpdateAvailableModal(release, current);
+}
+
+// Build and show the in-page "update available" dialog. Untrusted strings from
+// the GitHub API (release name / notes) are inserted with textContent only.
+function showUpdateAvailableModal(release, currentVersion) {
+    // Remove a previous instance so repeated checks don't stack dialogs.
+    const existing = document.getElementById('updateOverlay');
+    if (existing) existing.remove();
+
+    const latestTag = release.tag_name;
+    const latestLabel = 'v' + parseVersion(latestTag).join('.');
+    const currentLabel = 'v' + parseVersion(currentVersion).join('.');
+    const downloadUrl = pickDownloadUrl(release);
+    const releasePage = (release && release.html_url) || JLMOL_RELEASES_PAGE;
+
+    const overlay = document.createElement('div');
+    overlay.id = 'updateOverlay';
+
+    const card = document.createElement('div');
+    card.id = 'updateDialog';
+
+    // --- Header ---
+    const header = document.createElement('div');
+    header.className = 'update-dialog-header';
+    header.innerHTML = '<h3>🔄 Update available</h3>';
+
+    // --- Body ---
+    const body = document.createElement('div');
+    body.className = 'update-dialog-body';
+
+    const summary = document.createElement('p');
+    summary.className = 'update-summary';
+    summary.textContent = `A new version of jlmol is available: ${latestLabel} (you have ${currentLabel}).`;
+    body.appendChild(summary);
+
+    // Release notes, if any — plain text, never rendered as HTML.
+    const notes = (release && typeof release.body === 'string') ? release.body.trim() : '';
+    if (notes) {
+        const notesLabel = document.createElement('div');
+        notesLabel.className = 'update-notes-label';
+        notesLabel.textContent = "What's new:";
+        body.appendChild(notesLabel);
+
+        const pre = document.createElement('pre');
+        pre.className = 'update-notes';
+        // Cap very long release notes so the dialog stays manageable.
+        pre.textContent = notes.length > 2000 ? notes.slice(0, 2000) + '\n…' : notes;
+        body.appendChild(pre);
+    }
+
+    const link = document.createElement('a');
+    link.className = 'update-releasepage-link';
+    link.textContent = 'View release notes on GitHub';
+    link.href = '#';
+    link.addEventListener('click', (e) => {
+        e.preventDefault();
+        openExternalUrl(releasePage);
+    });
+    body.appendChild(link);
+
+    // --- Footer buttons ---
+    const footer = document.createElement('div');
+    footer.className = 'update-dialog-footer';
+
+    // Escape closes the dialog. The keydown listener is registered here and torn
+    // down by closeOverlay(), so every dismissal path (buttons, backdrop, Escape)
+    // cleans it up — otherwise repeated checks would leak listeners on document.
+    const onKey = (e) => {
+        if (e.key === 'Escape') closeOverlay();
+    };
+    const closeOverlay = () => {
+        overlay.remove();
+        document.removeEventListener('keydown', onKey);
+    };
+    document.addEventListener('keydown', onKey);
+
+    const downloadBtn = document.createElement('button');
+    downloadBtn.className = 'update-download-button';
+    downloadBtn.textContent = 'Download update';
+    downloadBtn.addEventListener('click', () => {
+        openExternalUrl(downloadUrl);
+        closeOverlay();
+    });
+
+    const laterBtn = document.createElement('button');
+    laterBtn.className = 'update-later-button';
+    laterBtn.textContent = 'Later';
+    laterBtn.addEventListener('click', closeOverlay);
+
+    const skipBtn = document.createElement('button');
+    skipBtn.className = 'update-skip-button';
+    skipBtn.textContent = 'Skip this version';
+    skipBtn.title = "Don't remind me about this version again";
+    skipBtn.addEventListener('click', () => {
+        try {
+            localStorage.setItem(JLMOL_SKIPPED_VERSION_KEY, latestTag);
+        } catch (e) {
+            console.warn('Could not persist skipped version:', e);
+        }
+        closeOverlay();
+    });
+
+    footer.appendChild(skipBtn);
+    footer.appendChild(laterBtn);
+    footer.appendChild(downloadBtn);
+
+    card.appendChild(header);
+    card.appendChild(body);
+    card.appendChild(footer);
+    overlay.appendChild(card);
+
+    // Dismiss (as "Later") on backdrop click.
+    overlay.addEventListener('click', (e) => {
+        if (e.target === overlay) closeOverlay();
+    });
+
+    document.body.appendChild(overlay);
+}
+
+// Called once during app startup. Runs the quiet check a few seconds after
+// launch (so it never competes with JSmol/UI initialization) if the user hasn't
+// turned it off in preferences.
+function initUpdateChecker() {
+    if (jlmolStartupCheckDone) return;
+    jlmolStartupCheckDone = true;
+
+    if (!isElectronApp()) return;
+
+    let enabled = true;
+    try {
+        if (typeof getPreferences === 'function') {
+            enabled = getPreferences().checkUpdatesOnStartup !== false;
+        }
+    } catch (e) {
+        enabled = true;
+    }
+    if (!enabled) return;
+
+    setTimeout(() => {
+        checkForUpdates({ silent: true });
+    }, 4000);
+}


### PR DESCRIPTION
## Summary

Adds an **update checker** to the jlmol desktop app. It checks GitHub Releases for a newer version and, if one is available, shows a dialog with the new version and release notes and asks whether to update. Choosing **Download update** opens the appropriate installer for the user's OS (or the release page) in their browser to install manually — the app never auto-installs anything.

Chosen approach: **notify + open download** (works on all platforms and package formats — `.exe`/`.dmg`/`.deb`/`.rpm`/`.AppImage` — and needs no code signing or release-workflow changes), checked **on startup + a manual Settings button**.

## What's included

- **New module `js/updater.js`**: fetches `…/releases/latest`, compares versions, and renders an in-page modal styled to match the existing panels, with **Download update / Later / Skip this version** (Skip is remembered in `localStorage`).
- **Startup check**: quiet, once per session (~4s after launch, Electron-only), prompts *only* when a newer release exists.
- **Manual check**: **Settings → General → Check for Updates Now**, which always reports a result (up to date / error / update available).
- **Preference**: "Automatically check for updates on startup" (default on), persisted via the existing prefs system.
- **Desktop-only**: inert in the browser build (`app.jlmol.com` is always latest).
- Docs updated (`CHANGELOG.md`, `README.md`).

## Security notes

The renderer runs with `nodeIntegration: true` / `webSecurity: false`, so injection would be RCE. Guards:
- Untrusted release text (notes/name) is rendered via `textContent`, never `innerHTML`.
- Only `https:` URLs are handed to `shell.openExternal`.

## Verification

- `node --check` on all touched JS; `npm run check-version` passes.
- **13 logic** + **14 behavioral** (incl. XSS-safety) + **3 unknown-version** + **7 listener-leak** tests, all green (headless DOM shim with stubbed `fetch`).
- Confirmed against the real GitHub API: latest is `v1.4.0` (= current build, so no false prompt today); Windows asset ends `.exe`; no `.dmg`, so macOS falls back to the release page.
- An adversarial 3-lens review (correctness / security / integration) surfaced 3 low-severity issues, all fixed in this branch (phantom update when version is `unknown`; Escape-listener leak; stale Settings result line).

## Notes for reviewers

- Prompts appear only once a release **newer than `v1.4.0`** is **published** — GitHub's `/releases/latest` ignores drafts/prereleases, and CI currently creates *draft* releases, so they must be published for users to be notified.
- The Electron GUI wasn't launched (no `node_modules` in this env); logic and DOM paths were exercised headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)