### PR TITLE
Keep draggable/resizable panels usable (on-screen, resizable, no stuck drag)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -128,6 +128,8 @@
             justify-content: space-between;
             align-items: center;
             border-bottom: 1px solid #ccc;
+            -webkit-user-select: none;
+            user-select: none;
         }
         #orbital-header h3 {
             margin: 0;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1319,6 +1319,15 @@
             }
         }
 
+        /* While a panel is being dragged (js/ui.js adds this class to <body>),
+           don't let the JSmol viewer or 2D editor capture mouse events. They
+           swallow mouseup, so a release over them would otherwise never reach the
+           document handler and the drag would get stuck to the cursor. */
+        body.dragging-panel #viewer,
+        body.dragging-panel #jsmeContainer {
+            pointer-events: none;
+        }
+
         /* ---- Update-available dialog (js/updater.js) ---- */
         #updateOverlay {
             position: fixed;

--- a/css/styles.css
+++ b/css/styles.css
@@ -116,6 +116,8 @@
             overflow: auto;
             min-width: 200px;
             min-height: 200px;
+            max-width: 90vw;
+            max-height: 90vh;
         }
         #orbital-header {
             cursor: move;
@@ -528,6 +530,7 @@
             overflow-y: auto;
             min-width: 250px; /* Reduced from 300px */
             min-height: 300px; /* Reduced from 400px */
+            max-width: 90vw;
             max-height: 90vh;
         }
         #elemcoPanel * {
@@ -1097,6 +1100,8 @@
             overflow: auto;
             min-width: 400px;
             min-height: 400px;
+            max-width: 90vw;
+            max-height: 90vh;
             border-radius: 8px;
         }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -28,10 +28,11 @@ function initDraggable() {
         document.addEventListener('touchend', dragEnd);
         document.addEventListener('touchcancel', dragEnd);
 
-        // Double-clicking the header snaps the panel back to its default spot —
-        // a quick escape hatch if it's been dragged somewhere awkward.
+        // Double-clicking the header snaps the panel back to its default spot
+        // and default size — a quick escape hatch if it's been dragged somewhere
+        // awkward or resized larger than the screen.
         header.addEventListener('dblclick', (e) => {
-            if (e.target === header) resetPosition();
+            if (e.target === header) resetPanel();
         });
 
         // Read the pointer position from either a mouse or a touch event.
@@ -78,7 +79,12 @@ function initDraggable() {
             panel.style.transform = `translate(${x}px, ${y}px)`;
         }
 
-        function resetPosition() {
+        // Restore the panel's default position and size (clearing the inline
+        // width/height that the CSS resize handle writes reverts it to the size
+        // defined in the stylesheet).
+        function resetPanel() {
+            panel.style.width = '';
+            panel.style.height = '';
             apply(0, 0);
         }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -33,7 +33,7 @@ function initDraggable() {
         // and default size — a quick escape hatch if it's been dragged somewhere
         // awkward or resized larger than the screen.
         header.addEventListener('dblclick', (e) => {
-            if (e.target === header) resetPanel();
+            if (isDragHandle(e.target)) resetPanel();
         });
 
         // Panels are opened by other modules simply setting display:block. Watch
@@ -55,6 +55,18 @@ function initDraggable() {
                 return { x: e.touches[0].clientX, y: e.touches[0].clientY };
             }
             return { x: e.clientX, y: e.clientY };
+        }
+
+        // The header holds the title (and sometimes an icon and a Close button).
+        // A drag or double-click reset should work from the header or any of its
+        // non-interactive parts (title text, icon) — the whole bar, not just the
+        // slivers around the children — but never from a control such as the Close
+        // button, so those keep working normally.
+        function isDragHandle(target) {
+            if (!target || !header.contains(target)) return false;
+            const control = target.closest && target.closest('button, a, input, select, textarea');
+            if (control && header.contains(control)) return false;
+            return true;
         }
 
         // Constrain a candidate translate so the header (the only drag handle)
@@ -156,7 +168,7 @@ function initDraggable() {
             initialX = point.x - xOffset;
             initialY = point.y - yOffset;
 
-            if (e.target === header) {
+            if (isDragHandle(e.target)) {
                 isDragging = true;
                 // While dragging, stop the JSmol viewer / 2D editor from capturing
                 // mouse events. They handle (and swallow) mouseup, so a release over

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,8 +1,9 @@
 // Make editor panel draggable
 function initDraggable() {
     // How far the header must stay inside the window so it's always grabbable.
-    const EDGE = 8;            // min gap kept between the header and the top edge
+    const EDGE = 8;            // min gap kept between a panel and the window edges
     const MIN_VISIBLE_X = 60;  // min px of the header kept reachable horizontally
+    const MIN_PANEL = 120;     // never cap a panel smaller than this
 
     // Every panel we've wired up, so window resizes can re-clamp them all.
     const draggables = [];
@@ -34,6 +35,19 @@ function initDraggable() {
         header.addEventListener('dblclick', (e) => {
             if (e.target === header) resetPanel();
         });
+
+        // Panels are opened by other modules simply setting display:block. Watch
+        // for that so the size limit is applied as soon as a panel is shown, not
+        // only after the first drag. Guarded on the display value so our own
+        // style writes (transform / max-*) don't retrigger it.
+        let lastDisplay = panel.style.display;
+        new MutationObserver(() => {
+            const display = panel.style.display;
+            if (display !== lastDisplay) {
+                lastDisplay = display;
+                if (display !== 'none') applySizeLimit();
+            }
+        }).observe(panel, { attributes: true, attributeFilter: ['style'] });
 
         // Read the pointer position from either a mouse or a touch event.
         function getPoint(e) {
@@ -71,12 +85,48 @@ function initDraggable() {
             };
         }
 
+        // Padding + border around the content box. max-width/height apply to the
+        // content box under the default box-sizing: content-box, so we subtract
+        // this chrome to keep the panel's outer edge (where the resize handle is)
+        // at the intended margin. Measured once — it doesn't change.
+        let chromeW = null;
+        let chromeH = null;
+        function measureChrome() {
+            const cs = getComputedStyle(panel);
+            const px = (v) => parseFloat(v) || 0;
+            if (cs.boxSizing === 'border-box') {
+                chromeW = 0;
+                chromeH = 0;
+                return;
+            }
+            chromeW = px(cs.paddingLeft) + px(cs.paddingRight)
+                + px(cs.borderLeftWidth) + px(cs.borderRightWidth);
+            chromeH = px(cs.paddingTop) + px(cs.paddingBottom)
+                + px(cs.borderTopWidth) + px(cs.borderBottomWidth);
+        }
+
+        // Let the panel grow to fill the space right of / below where it now sits,
+        // leaving only a small margin so the resize handle stays on screen. Using
+        // the panel's live position (not a fixed 90vh/vw) means it neither wastes
+        // visible space when near an edge nor lets the bottom-right handle run off
+        // the screen when positioned lower down. Recomputed on move/resize/show.
+        function applySizeLimit() {
+            const rect = panel.getBoundingClientRect();
+            if (rect.width === 0 && rect.height === 0) return; // not visible
+            if (chromeW === null) measureChrome();
+            const maxW = Math.max(MIN_PANEL, window.innerWidth - rect.left - EDGE - chromeW);
+            const maxH = Math.max(MIN_PANEL, window.innerHeight - rect.top - EDGE - chromeH);
+            panel.style.maxWidth = maxW + 'px';
+            panel.style.maxHeight = maxH + 'px';
+        }
+
         function apply(x, y) {
             currentX = x;
             currentY = y;
             xOffset = x;
             yOffset = y;
             panel.style.transform = `translate(${x}px, ${y}px)`;
+            applySizeLimit();
         }
 
         // Restore the panel's default position and size (clearing the inline

--- a/js/ui.js
+++ b/js/ui.js
@@ -149,12 +149,20 @@ function initDraggable() {
         }
 
         function dragStart(e) {
+            // Only the left mouse button starts a drag (touchstart has no button).
+            if (e.type === 'mousedown' && e.button !== 0) return;
+
             const point = getPoint(e);
             initialX = point.x - xOffset;
             initialY = point.y - yOffset;
 
             if (e.target === header) {
                 isDragging = true;
+                // While dragging, stop the JSmol viewer / 2D editor from capturing
+                // mouse events. They handle (and swallow) mouseup, so a release over
+                // them never reaches our document handler — which would leave the
+                // drag "stuck" and the panel following the mouse afterwards.
+                document.body.classList.add('dragging-panel');
                 // Prevent the page from scrolling while dragging on touch.
                 if (e.type === 'touchstart') {
                     e.preventDefault();
@@ -163,18 +171,34 @@ function initDraggable() {
         }
 
         function drag(e) {
-            if (isDragging) {
-                e.preventDefault();
-                const point = getPoint(e);
-                const c = clampToViewport(point.x - initialX, point.y - initialY);
-                apply(c.x, c.y);
+            if (!isDragging) return;
+
+            // Safety net: a mousemove with no button held means the button was
+            // released somewhere we couldn't see the mouseup (e.g. swallowed by the
+            // viewer, or outside the window). Treat it as the end of the drag rather
+            // than moving the panel. (touchmove has no `buttons`; touch ends cleanly
+            // via touchend/touchcancel.)
+            if (e.type === 'mousemove' && e.buttons === 0) {
+                dragEnd();
+                return;
             }
+
+            e.preventDefault();
+            const point = getPoint(e);
+            const c = clampToViewport(point.x - initialX, point.y - initialY);
+            apply(c.x, c.y);
         }
 
-        function dragEnd() {
+        function dragEnd(e) {
+            // Ignore releases of a non-left mouse button, so pressing/releasing
+            // another button mid-drag doesn't abort an in-progress left drag.
+            // touchend/touchcancel and the internal buttons===0 call pass no mouse
+            // button, so they still end the drag.
+            if (e && e.type === 'mouseup' && e.button !== 0) return;
             initialX = currentX;
             initialY = currentY;
             isDragging = false;
+            document.body.classList.remove('dragging-panel');
         }
 
         draggables.push({ clampIntoView });

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,6 +1,15 @@
 // Make editor panel draggable
 function initDraggable() {
+    // How far the header must stay inside the window so it's always grabbable.
+    const EDGE = 8;            // min gap kept between the header and the top edge
+    const MIN_VISIBLE_X = 60;  // min px of the header kept reachable horizontally
+
+    // Every panel we've wired up, so window resizes can re-clamp them all.
+    const draggables = [];
+
     function makeDraggable(panel, header) {
+        if (!panel || !header) return;
+
         let isDragging = false;
         let currentX;
         let currentY;
@@ -19,12 +28,68 @@ function initDraggable() {
         document.addEventListener('touchend', dragEnd);
         document.addEventListener('touchcancel', dragEnd);
 
+        // Double-clicking the header snaps the panel back to its default spot —
+        // a quick escape hatch if it's been dragged somewhere awkward.
+        header.addEventListener('dblclick', (e) => {
+            if (e.target === header) resetPosition();
+        });
+
         // Read the pointer position from either a mouse or a touch event.
         function getPoint(e) {
             if (e.touches && e.touches.length) {
                 return { x: e.touches[0].clientX, y: e.touches[0].clientY };
             }
             return { x: e.clientX, y: e.clientY };
+        }
+
+        // Constrain a candidate translate so the header (the only drag handle)
+        // always stays reachable: fully on screen vertically, and with at least
+        // MIN_VISIBLE_X px within the window horizontally. Without this a panel
+        // could be dragged past the top edge and become impossible to grab back.
+        function clampToViewport(rawX, rawY) {
+            const rect = header.getBoundingClientRect();
+            const winW = window.innerWidth;
+            const winH = window.innerHeight;
+
+            // Where the header would land if we applied (rawX, rawY).
+            const predLeft = rect.left + (rawX - xOffset);
+            const predTop = rect.top + (rawY - yOffset);
+
+            const minLeft = MIN_VISIBLE_X - rect.width;
+            const maxLeft = winW - MIN_VISIBLE_X;
+            const minTop = EDGE;
+            const maxTop = Math.max(EDGE, winH - rect.height - EDGE);
+
+            const clampedLeft = Math.min(Math.max(predLeft, minLeft), maxLeft);
+            const clampedTop = Math.min(Math.max(predTop, minTop), maxTop);
+
+            // Convert the clamped screen position back into a translate value.
+            return {
+                x: xOffset + (clampedLeft - rect.left),
+                y: yOffset + (clampedTop - rect.top),
+            };
+        }
+
+        function apply(x, y) {
+            currentX = x;
+            currentY = y;
+            xOffset = x;
+            yOffset = y;
+            panel.style.transform = `translate(${x}px, ${y}px)`;
+        }
+
+        function resetPosition() {
+            apply(0, 0);
+        }
+
+        // Nudge a visible panel back into view (e.g. after the window shrinks).
+        function clampIntoView() {
+            const rect = header.getBoundingClientRect();
+            // Skip panels that aren't currently rendered (getBoundingClientRect
+            // returns zeros), otherwise we'd shove hidden panels around.
+            if (rect.width === 0 && rect.height === 0) return;
+            const c = clampToViewport(xOffset, yOffset);
+            apply(c.x, c.y);
         }
 
         function dragStart(e) {
@@ -45,12 +110,8 @@ function initDraggable() {
             if (isDragging) {
                 e.preventDefault();
                 const point = getPoint(e);
-                currentX = point.x - initialX;
-                currentY = point.y - initialY;
-                xOffset = currentX;
-                yOffset = currentY;
-
-                panel.style.transform = `translate(${currentX}px, ${currentY}px)`;
+                const c = clampToViewport(point.x - initialX, point.y - initialY);
+                apply(c.x, c.y);
             }
         }
 
@@ -59,6 +120,8 @@ function initDraggable() {
             initialY = currentY;
             isDragging = false;
         }
+
+        draggables.push({ clampIntoView });
     }
 
     // Make all panels draggable
@@ -82,6 +145,12 @@ function initDraggable() {
         document.getElementById('xtbPanel'),
         document.getElementById('xtb-header')
     );
+
+    // If the window is resized smaller, pull any now-off-screen panel back so its
+    // header stays reachable.
+    window.addEventListener('resize', () => {
+        draggables.forEach(d => d.clampIntoView());
+    });
 }
 
 // Add page zoom functionality


### PR DESCRIPTION
## Summary

Fixes three related annoyances with the draggable in-page panels (XYZ editor, orbitals, ElemCo, preferences, xtb). All changes are confined to `js/ui.js` and `css/styles.css`; no architectural change.

## What's fixed

1. **Panels dragged off-screen become unrecoverable.** The drag applied a CSS `transform` with no bounds check, so a panel pushed past the top edge hid its header — the only drag handle — with no way back. Now the drag is **clamped** so the header always stays reachable (fully visible vertically, ≥60px horizontally); panels are re-clamped on window resize; and **double-clicking a header** snaps the panel back to its default position and size.

2. **Resize handle unreachable / wasted space.** Resizable panels had no (or partial) size caps, so they could grow larger than the window and push the bottom-right resize handle off-screen. Replaced the fixed `90vh/90vw` caps with a **position-aware limit**: each panel may grow until a small margin from the window's right/bottom edges based on where it currently sits (recomputed on move, resize, and show via a small `MutationObserver`), accounting for `content-box` padding/border so the outer edge lands at the intended margin. This also removes the ~1cm of dead space that a fixed `90vh` left when a panel was dragged to the top.

3. **Panel sticks to the cursor after a drag.** JSmol renders as an HTML5 `<canvas>` that swallows `mouseup`, so releasing over the viewer left `isDragging` stuck and the next hover-move kept dragging. Fixed with a **recovery net** (a `mousemove` with `buttons === 0` ends the drag), a **prevention** (`pointer-events: none` on `#viewer`/`#jsmeContainer` while dragging, via a `dragging-panel` body class), and **left-button-only** start/end handling.

## Commits

- `f121af2` Keep draggable panel headers on-screen (clamp drag position)
- `45b2e85` Keep resizable panels within the viewport and add size reset
- `e693930` Size panels to their position so the resize handle stays reachable
- `a7b25b8` Fix panels sticking to the cursor after a drag (missed mouseup)


🤖 Generated with [Claude Code](https://claude.com/claude-code)