### PR TITLE
CI: build releases on Node 22 (fix electron-builder ESM error)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          # Pin the minimum where require() of an ESM module is unflagged.
+          # electron-builder's @noble/hashes v2 is ESM-only and is require()-d,
+          # which throws ERR_REQUIRE_ESM on Node < 22.12 (or < 20.19).
+          node-version: '22.12.0'
 
       - name: Install Dependencies
         run: npm install


### PR DESCRIPTION
## Problem

The **v1.4.1** release build failed (run [29642556509](https://github.com/fkfest/jlmol/actions/runs/29642556509)):

```
Error [ERR_REQUIRE_ESM]: require() of ES Module .../@noble/hashes/blake2.js
from .../app-builder-lib/out/targets/blockmap/blockmap.js not supported.
```

`electron-builder ^26.7.0` now resolves to **26.15.7**, whose `app-builder-lib` depends on **`@noble/hashes@^2`** (ESM-only) while its compiled code still `require()`s it. `require()` of an ESM module is only supported on **Node ≥ 20.19 / 22.12**, but the workflow pinned **Node 18**. (There's no committed lockfile — `package-lock.json` is gitignored — so dependency versions float; v1.4.0 built in May only because `@noble/hashes` still resolved to v1 then.)

## Fix

Bump the release workflow to **Node 22** (and `setup-node@v4`). No application code changes.

## After merge

The `v1.4.1` tag must be re-pointed to a commit that includes this workflow fix (a tag-triggered build uses the workflow file at the tagged commit). The earlier failed run created no release, so nothing was published and moving the tag is safe:

```
git tag -f v1.4.1 <main-after-merge> && git push -f origin v1.4.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)