### PR TITLE
CI: publish releases only via electron-builder (no duplicate installer)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,20 +38,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
-            npm run build:linux
+            npm run build:linux -- --publish always
           else
-            npm run build:windows
+            npm run build:windows -- --publish always
           fi
         shell: bash
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          draft: true
-          files: |
-            dist/*.exe
-            dist/*.deb
-            dist/*.rpm
-            dist/*.AppImage
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # electron-builder is the sole publisher (--publish always). It uploads each
+      # installer once, plus the latest*.yml / blockmap update metadata, to a draft
+      # GitHub release (see the "publish" config in package.json). A previous
+      # softprops/action-gh-release step also uploaded dist/*, which double-published
+      # the Windows installer under a differently sanitized name; it has been removed.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
     "directories": {
       "output": "dist"
     },
+    "publish": [
+      {
+        "provider": "github",
+        "releaseType": "draft"
+      }
+    ],
     "win": {
       "target": "nsis",
       "icon": "build/icon.ico"


### PR DESCRIPTION
## Problem

Every release uploads each installer **twice** under differently sanitized names — most visibly the Windows installer as both `jlmol-Setup-1.4.1.exe` and `jlmol.Setup.1.4.1.exe` (same bytes).

The workflow publishes with **two** publishers:
1. **electron-builder** auto-publishes on the tag (because `GH_TOKEN` is in the build step's env). It uploads `jlmol-Setup-1.4.1.exe` (spaces → hyphens) plus `latest.yml` / `.blockmap`.
2. The **`softprops/action-gh-release`** step then uploads `dist/*.exe` = `jlmol Setup 1.4.1.exe`, which GitHub renames spaces → dots → `jlmol.Setup.1.4.1.exe`.

Linux artifacts don't duplicate because their configured name (`jlmol-1.4.1.AppImage`, no spaces) is identical from both publishers, so GitHub dedupes it.

## Fix

Make **electron-builder the sole publisher**:
- Build with `--publish always` — explicit (also clears electron-builder's *"implicit publishing … disabled in v27"* deprecation warning).
- Remove the `softprops/action-gh-release` step.
- Add a `publish` config to `package.json` pinning `releaseType: draft`, so releases still land as **drafts** for manual review (matching the old `draft: true`).

Result: one installer per platform, plus the `latest*.yml`/blockmap auto-update metadata, on a draft release.

## Notes
- Behavior otherwise unchanged: still triggered by `v*` tags, still Windows + Linux, still a draft you publish manually.
- `npm run check-version` passes; no application code touched.
- Not verifiable without a real tag build — worth a glance at the asset list on the next release (or a throwaway pre-release tag) to confirm a single `.exe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)