### PR TITLE
ElemCo.jl input builder: options browser, method blocks, macros, FCIDUMP, syntax highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ElemCo.jl input builder rework: the ElemCo.jl panel is now a method-driven "building block" editor. A calculation is assembled from an ordered list of steps (Reference, Method, Export, Macro, Custom) that you can add, remove, reorder (with the up/down buttons or by dragging the grip), and collapse. Each step emits its ElemCo.jl macro, and only the options you change from their ElemCo.jl defaults are emitted, as a local `begin … end @set` block, keeping the generated script minimal.
+- Full options browser: every ElemCo.jl calculation option (all 13 groups, ~157 options) can be set through a searchable, grouped browser with typed inputs, each option pre-filled with its default and its description shown on hover, plus one-click reset per option and "chips" summarising the options changed for each step. The option catalogue is generated from ElemCo.jl's own `options.jl`, so it stays in sync with the library (`npm run update-elemco-options`).
+- Composable method selection: correlation methods are grouped (Møller–Plesset, coupled cluster, distinguishable cluster, quasi-variational, factorized SVD, excited states, full CI) with a separate spin selector (closed-shell / unrestricted `U` / restricted-open `R`) that composes the ElemCo.jl method string (e.g. `UCCSD`, `ΛCCSD(T)`, `EOM-UCCSD`), a live read-out of the emitted call, and a "Custom…" free-text method with a density-fitting toggle. Newly selectable methods include ΛCCSD(T), CCD, DCD, QV-CCD/QV-DCD, OQV-CCD/OQV-DCD, EOM-CCSD/EOM-DCSD, FCI and CIPHI.
+- FCIDUMP calculations: a Molecule / FCIDUMP switch in the "System & basis" card. In FCIDUMP mode the basis-set fields are replaced by a FCIDUMP file field and the generated input reads the integrals from that file (`fcidump = "…"`) instead of a geometry and basis, and no reference step is added. The mode is selected automatically when no molecule is loaded.
+- Generic "Macro" step: add any macro exported by ElemCo.jl as a building block, with its signature as an argument hint, its docstring shown on hover, and — for macros that accept one — a local options block. The macro list and docstrings are parsed from ElemCo.jl's source (`npm run update-elemco-macros`).
+- Julia syntax highlighting in the generated-input editor and the custom-code editor.
+- Separate default methods for molecule and FCIDUMP calculations in Settings → ElemCo.jl (defaults: CCSD(T) for molecule, ΛCCSD(T) for FCIDUMP). A molecule calculation adds a DF-HF reference automatically; an FCIDUMP calculation does not.
+
+### Changed
+
+- The ElemCo.jl panel opens wider, its "System & basis" card and each step are collapsible (click the badge or title), the fold indicators are larger, and the panel's fonts and sizes were made consistent.
+- "Insert Selected Atoms" now inserts the atom list at the cursor of whichever field you last edited (an option field, the custom-code editor, or the main input editor), not only the main editor.
+- Clicking or opening a floating panel now brings it to the front, so overlapping panels (e.g. ElemCo.jl over Preferences) can be reordered; panels always stay above the main window.
+- Preference descriptions are shown as hover help (an ⓘ icon next to the option) instead of inline text, so the settings rows stay compact.
+- Density fitting and the reference/correlation choice are now made per step (via the Reference and Method blocks), replacing the previous global "DF" checkbox and single default-method setting.
+
 ## [1.4.1] - 2026-07-18
 
 ### Added

--- a/css/styles.css
+++ b/css/styles.css
@@ -1780,6 +1780,61 @@
             font-style: italic;
         }
 
+        /* --- Julia syntax highlighting: transparent textarea over a colored
+           backdrop; both share identical metrics so text lines up exactly. --- */
+        .elemco-code-wrap {
+            position: relative;
+            width: 100%;
+        }
+        #elemcoPanel .elemco-code-input,
+        #elemcoPanel .elemco-code-backdrop {
+            box-sizing: border-box;
+            width: 100%;
+            margin: 0;
+            padding: 8px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+            font-size: 12.5px;
+            line-height: 1.5;
+            white-space: pre-wrap;
+            overflow-wrap: break-word;
+            word-break: break-word;
+            tab-size: 4;
+        }
+        #elemcoPanel .elemco-code-input {
+            position: relative;
+            z-index: 1;
+            display: block;
+            resize: vertical;
+            overflow: auto;
+            background: transparent;
+            color: transparent;
+            caret-color: #111;
+        }
+        #elemcoPanel .elemco-code-backdrop {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 0;
+            overflow: hidden;
+            pointer-events: none;
+            border-color: transparent;
+            background: #fff;
+            color: #333;
+        }
+        .elemco-code-highlights {
+            min-height: 100%;
+        }
+        .elemco-code-highlights .j-com { color: #8c8c8c; font-style: italic; }
+        .elemco-code-highlights .j-str { color: #067d17; }
+        .elemco-code-highlights .j-key { color: #0033b3; font-weight: 600; }
+        .elemco-code-highlights .j-macro { color: #7a3e9d; font-weight: 600; }
+        .elemco-code-highlights .j-num { color: #1750eb; }
+        .elemco-code-highlights .j-lit { color: #0033b3; }
+
         /* --- drag-to-reorder grip + drop state --- */
         .elemco-step-grip {
             cursor: grab;

--- a/css/styles.css
+++ b/css/styles.css
@@ -518,7 +518,7 @@
 
         #elemcoPanel {
             position: fixed;
-            width: 350px; /* Reduced from 400px */
+            width: 390px;
             padding: 10px;
             display: none;
             background: white;
@@ -530,7 +530,7 @@
             resize: both;
             overflow-x: hidden;
             overflow-y: auto;
-            min-width: 250px; /* Reduced from 300px */
+            min-width: 280px;
             min-height: 300px; /* Reduced from 400px */
             max-width: 90vw;
             max-height: 90vh;
@@ -1768,6 +1768,23 @@
             transform: none;
             box-shadow: none;
             color: #000;
+        }
+        .elemco-card-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+        #elemcoPanel .elemco-card-header .elemco-fold-title {
+            flex: 1;
+            width: auto;
+            margin: 0;
+        }
+        #elemcoPanel .elemco-mode-select {
+            flex: 0 0 auto;
+            width: auto;
+            font-size: 11px;
+            padding: 2px 4px;
         }
 
         /* ===================================================================

--- a/css/styles.css
+++ b/css/styles.css
@@ -1551,6 +1551,24 @@
             padding: 4px 10px;
             font-size: 12px;
         }
+        .elemco-suggest {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin: 4px 0 12px;
+            padding: 6px 8px;
+            font-size: 11px;
+            color: #8a6d00;
+            background: #fff8e1;
+            border: 1px solid #f0e0a0;
+            border-radius: 6px;
+        }
+        .elemco-suggest button {
+            min-width: 0;
+            padding: 3px 10px;
+            font-size: 11px;
+        }
 
         /* --- changed-option chips --- */
         .elemco-chips {
@@ -1628,7 +1646,11 @@
         }
         .elemco-caret {
             color: #888;
-            width: 10px;
+            width: 16px;
+            font-size: 15px;
+            line-height: 1;
+            display: inline-block;
+            text-align: center;
         }
         .elemco-opt-group-title {
             flex: 1;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1711,3 +1711,86 @@
             color: #999;
             font-style: italic;
         }
+
+        /* --- drag-to-reorder grip + drop state --- */
+        .elemco-step-grip {
+            cursor: grab;
+            color: #bbb;
+            font-size: 14px;
+            line-height: 1;
+            padding: 0 2px;
+            -webkit-user-select: none;
+            user-select: none;
+        }
+        .elemco-step-grip:active { cursor: grabbing; }
+        .elemco-step-card.elemco-dragging { opacity: 0.5; }
+        .elemco-step-card.elemco-drag-over { box-shadow: inset 0 3px 0 #4CAF50; }
+
+        /* --- foldable card title (looks like a heading, behaves like a button) --- */
+        #elemcoPanel .elemco-fold-title {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            width: 100%;
+            text-align: left;
+            background: none;
+            border: none;
+            box-shadow: none;
+            padding: 0;
+            margin: 0 0 8px 0;
+            min-width: 0;
+            cursor: pointer;
+        }
+        #elemcoPanel .elemco-fold-title:hover {
+            background: none;
+            transform: none;
+            box-shadow: none;
+            color: #000;
+        }
+
+        /* ===================================================================
+           Typography: one consistent scale across the whole ElemCo panel
+           (base 13 sans; code 12 mono; notes/chips 11; badges 10; headings 15)
+           =================================================================== */
+        #elemcoPanel {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            font-size: 13px;
+            line-height: 1.45;
+            color: #2b2b2b;
+        }
+        #elemcoPanel h3 { font-size: 15px; margin: 0; }
+        #elemcoPanel label,
+        #elemcoPanel select,
+        #elemcoPanel input,
+        #elemcoPanel textarea,
+        #elemcoPanel button {
+            font-family: inherit;
+            font-size: 13px;
+        }
+        #elemcoPanel .elemco-card-title,
+        #elemcoPanel .elemco-steps-label { font-size: 13px; font-weight: 600; }
+        #elemcoPanel .elemco-badge { font-size: 10px; }
+        #elemcoPanel .preview-note,
+        #elemcoPanel .elemco-source-note,
+        #elemcoPanel .elemco-add-step,
+        #elemcoPanel .elemco-add-step button,
+        #elemcoPanel .elemco-chip,
+        #elemcoPanel .elemco-chip-text,
+        #elemcoPanel .elemco-opt-default,
+        #elemcoPanel .elemco-opt-group-count { font-size: 11px; }
+        #elemcoPanel .elemco-step-actions button,
+        #elemcoPanel .elemco-opt-togglebtn,
+        #elemcoPanel .elemco-chip-x,
+        #elemcoPanel .elemco-opt-reset,
+        #elemcoPanel .elemco-opt-group-head,
+        #elemcoPanel .elemco-opt-name,
+        #elemcoPanel .elemco-opt-input,
+        #elemcoPanel .elemco-opt-search { font-size: 12px; }
+        /* monospace only for code-like content */
+        #elemco-input,
+        #elemcoPanel .elemco-step-code,
+        #elemcoPanel .elemco-opt-name,
+        #elemcoPanel .elemco-opt-default,
+        #elemcoPanel .elemco-chip {
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+        }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1536,6 +1536,31 @@
             font-size: 12px;
             resize: vertical;
         }
+        .elemco-method-detail {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            margin-top: 6px;
+            flex-wrap: wrap;
+        }
+        .elemco-detail-label {
+            color: #888;
+            font-size: 11px;
+        }
+        #elemcoPanel .elemco-spin-select {
+            flex: 0 0 auto;
+            width: auto;
+            font-size: 12px;
+            padding: 2px 4px;
+        }
+        .elemco-method-detail .elemco-step-file {
+            flex: 1;
+        }
+        #elemcoPanel .elemco-method-readout {
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+            font-size: 12px;
+            color: #2f6f2f;
+        }
 
         .elemco-add-step {
             display: flex;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1488,6 +1488,27 @@
             align-items: center;
             gap: 6px;
         }
+        .elemco-badge-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 2px;
+            cursor: pointer;
+            -webkit-user-select: none;
+            user-select: none;
+        }
+        .elemco-df-toggle {
+            display: inline-flex;
+            align-items: center;
+            gap: 3px;
+            flex: 0 0 auto;
+            margin: 0;
+            font-size: 11px;
+            color: #555;
+        }
+        .elemco-df-toggle input[type="checkbox"] {
+            width: auto;
+            margin: 0;
+        }
         .elemco-badge {
             font-size: 10px;
             text-transform: uppercase;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1452,3 +1452,262 @@
             margin-right: auto;
             color: #666;
         }
+
+        /* ===================================================================
+           ElemCo.jl builder: global card, step cards, option chips & browser
+           =================================================================== */
+        .elemco-card {
+            border: 1px solid #e0e0e0;
+            border-radius: 6px;
+            padding: 10px;
+            margin-bottom: 12px;
+            background: #fafafa;
+        }
+        .elemco-card-title,
+        .elemco-steps-label {
+            font-weight: bold;
+            font-size: 13px;
+            margin-bottom: 8px;
+            color: #333;
+        }
+        .elemco-steps-label {
+            margin-top: 4px;
+        }
+
+        /* --- step cards (building blocks) --- */
+        .elemco-step-card {
+            border: 1px solid #e0e0e0;
+            border-left: 3px solid #4CAF50;
+            border-radius: 6px;
+            padding: 8px;
+            margin-bottom: 8px;
+            background: #fff;
+        }
+        .elemco-step-head {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .elemco-badge {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            font-weight: bold;
+            color: #fff;
+            background: #4CAF50;
+            border-radius: 3px;
+            padding: 2px 6px;
+            white-space: nowrap;
+        }
+        .elemco-step-method,
+        .elemco-step-file {
+            flex: 1;
+            min-width: 0;
+            padding: 4px;
+        }
+        .elemco-step-custom-label {
+            flex: 1;
+            color: #666;
+            font-style: italic;
+        }
+        .elemco-step-actions {
+            display: flex;
+            align-items: center;
+            gap: 3px;
+            margin-left: auto;
+        }
+        .elemco-step-actions button,
+        .elemco-opt-togglebtn,
+        .elemco-chip-x,
+        .elemco-opt-reset {
+            min-width: 0;
+            padding: 3px 7px;
+            font-size: 12px;
+        }
+        .elemco-step-move,
+        .elemco-step-del {
+            padding: 3px 6px;
+        }
+        .elemco-step-code {
+            width: 100%;
+            height: 70px;
+            margin-top: 6px;
+            font-family: monospace;
+            font-size: 12px;
+            resize: vertical;
+        }
+
+        .elemco-add-step {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 6px;
+            margin-bottom: 12px;
+            font-size: 12px;
+            color: #555;
+        }
+        .elemco-add-step button {
+            min-width: 0;
+            padding: 4px 10px;
+            font-size: 12px;
+        }
+
+        /* --- changed-option chips --- */
+        .elemco-chips {
+            display: none;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-top: 6px;
+        }
+        .elemco-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            background: #eef6ee;
+            border: 1px solid #cfe6cf;
+            border-radius: 10px;
+            padding: 1px 4px 1px 8px;
+            font-size: 11px;
+            font-family: monospace;
+            color: #2f6f2f;
+        }
+        .elemco-chip-x {
+            background: none;
+            border: none;
+            box-shadow: none;
+            color: #2f6f2f;
+            line-height: 1;
+            padding: 0 3px;
+        }
+        .elemco-chip-x:hover {
+            color: #c0392b;
+            background: none;
+            transform: none;
+            box-shadow: none;
+        }
+
+        /* --- options browser --- */
+        .elemco-opt-toggle-row {
+            margin-top: 8px;
+        }
+        .elemco-step-options {
+            margin-top: 8px;
+            border-top: 1px dashed #ddd;
+            padding-top: 8px;
+        }
+        .elemco-opt-search {
+            width: 100%;
+            padding: 5px;
+            margin-bottom: 8px;
+            box-sizing: border-box;
+        }
+        .elemco-opt-group {
+            border: 1px solid #eee;
+            border-radius: 4px;
+            margin-bottom: 6px;
+        }
+        .elemco-opt-group-head {
+            width: 100%;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            text-align: left;
+            min-width: 0;
+            background: #f4f4f4;
+            border: none;
+            border-radius: 4px;
+            padding: 5px 8px;
+            font-weight: bold;
+            font-size: 12px;
+            box-shadow: none;
+        }
+        .elemco-opt-group-head:hover {
+            background: #ececec;
+            transform: none;
+            box-shadow: none;
+        }
+        .elemco-caret {
+            color: #888;
+            width: 10px;
+        }
+        .elemco-opt-group-title {
+            flex: 1;
+            min-width: 0;
+        }
+        .elemco-opt-group-count {
+            color: #4CAF50;
+            font-size: 11px;
+            font-weight: normal;
+        }
+        .elemco-opt-group-body {
+            padding: 4px 6px;
+        }
+        .elemco-opt-divider {
+            margin: 10px 0 6px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: #999;
+            border-top: 1px solid #eee;
+            padding-top: 6px;
+        }
+        .elemco-opt-row {
+            display: grid;
+            grid-template-columns: minmax(80px, 34%) 1fr auto auto;
+            align-items: center;
+            gap: 6px;
+            padding: 3px 2px;
+            border-bottom: 1px solid #f4f4f4;
+        }
+        .elemco-opt-row.elemco-opt-modified {
+            background: #fbfff8;
+        }
+        .elemco-opt-name {
+            font-family: monospace;
+            font-size: 12px;
+            font-weight: normal;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            cursor: help;
+            margin: 0;
+        }
+        .elemco-opt-modified .elemco-opt-name {
+            font-weight: bold;
+        }
+        .elemco-opt-widget {
+            min-width: 0;
+        }
+        .elemco-opt-input {
+            width: 100%;
+            padding: 3px 5px;
+            font-size: 12px;
+            box-sizing: border-box;
+        }
+        .elemco-opt-widget input[type="checkbox"] {
+            width: auto;
+        }
+        .elemco-opt-default {
+            font-size: 11px;
+            color: #999;
+            font-family: monospace;
+            white-space: nowrap;
+            cursor: help;
+        }
+        .elemco-opt-reset {
+            color: #c0392b;
+            line-height: 1;
+        }
+
+        .elemco-editor-toolbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+        .elemco-source-note {
+            color: #999;
+            font-style: italic;
+        }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1797,9 +1797,9 @@
             font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
             font-size: 12.5px;
             line-height: 1.5;
-            white-space: pre-wrap;
-            overflow-wrap: break-word;
-            word-break: break-word;
+            /* No wrapping: a wrapped textarea narrows for its scrollbar and would
+               wrap earlier than the backdrop, drifting the overlay out of sync. */
+            white-space: pre;
             tab-size: 4;
         }
         #elemcoPanel .elemco-code-input {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1295,6 +1295,16 @@
             font-style: italic;
         }
 
+        .preference-help {
+            margin-left: 6px;
+            color: #4CAF50;
+            cursor: help;
+            font-size: 12px;
+            font-style: normal;
+            -webkit-user-select: none;
+            user-select: none;
+        }
+
         /* Narrow screens (phones / small tablets): stack the viewer on top of
            the controls so the 200px sidebar isn't clipped horizontally, and let
            the whole page scroll vertically. */

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
     <script type="text/javascript" src="js/jsme-2d.js"></script>
     <script type="text/javascript" src="js/elemco-options.js"></script>
     <script type="text/javascript" src="js/elemco-methods.js"></script>
+    <script type="text/javascript" src="js/elemco-macros.js"></script>
     <script type="text/javascript" src="js/elemco.js"></script>
     <script type="text/javascript" src="js/elemco-options-ui.js"></script>
     <script type="text/javascript" src="js/elemco-highlight.js"></script>
@@ -259,6 +260,7 @@
             <button type="button" onclick="addElemCoStep('reference')" title="Add a reference (SCF) step">Reference</button>
             <button type="button" onclick="addElemCoStep('correlation')" title="Add a correlation / post-HF method step">Method</button>
             <button type="button" onclick="addElemCoStep('export')" title="Add an @export_molden step">Export</button>
+            <button type="button" onclick="addElemCoStep('macro')" title="Add any exported ElemCo.jl macro">Macro</button>
             <button type="button" onclick="addElemCoStep('custom')" title="Add a raw Julia snippet">Custom</button>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <script type="text/javascript" src="js/elemco-methods.js"></script>
     <script type="text/javascript" src="js/elemco.js"></script>
     <script type="text/javascript" src="js/elemco-options-ui.js"></script>
+    <script type="text/javascript" src="js/elemco-highlight.js"></script>
     <script type="text/javascript" src="js/xtb.js"></script>
     <script type="text/javascript" src="js/app-init.js"></script>
     <script type="text/javascript" src="js/preferences.js"></script>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,10 @@
     <script type="text/javascript" src="js/selection.js"></script>
     <script type="text/javascript" src="js/ui.js"></script>
     <script type="text/javascript" src="js/jsme-2d.js"></script>
+    <script type="text/javascript" src="js/elemco-options.js"></script>
+    <script type="text/javascript" src="js/elemco-methods.js"></script>
     <script type="text/javascript" src="js/elemco.js"></script>
+    <script type="text/javascript" src="js/elemco-options-ui.js"></script>
     <script type="text/javascript" src="js/xtb.js"></script>
     <script type="text/javascript" src="js/app-init.js"></script>
     <script type="text/javascript" src="js/preferences.js"></script>
@@ -179,85 +182,81 @@
             </div>
             <button onclick="hideElemCoPanel()" title="Close ElemCo.jl input panel">Close</button>
         </div>
-        <div class="elemco-input-group">
-            <label for="elemco-method">Method:</label>
-            <div class="method-df-line">
-                <select id="elemco-method">
-                    <option value="HF">HF</option>
-                    <option value="MP2">MP2</option>
-                    <option value="DCSD" selected>DCSD</option>
-                    <option value="CCSD(T)">CCSD(T)</option>
-                    <option value="CCSDT">CCSDT</option>
-                    <option value="DC-CCSDT">DC-CCSDT</option>
+        <!-- Global "System & basis" card: options here apply to the whole run -->
+        <div class="elemco-card" id="elemco-global-card">
+            <div class="elemco-card-title">System &amp; basis</div>
+            <div class="elemco-input-group">
+                <label for="elemco-basis">AO Basis Set:</label>
+                <select id="elemco-basis">
+                    <option value="cc-pVDZ" selected>cc-pVDZ</option>
+                    <option value="cc-pVTZ">cc-pVTZ</option>
+                    <option value="aug-cc-pVDZ">aug-cc-pVDZ</option>
+                    <option value="aug-cc-pVTZ">aug-cc-pVTZ</option>
                 </select>
-                <label class="df-toggle-label" for="elemco-df">
-                    <input type="checkbox" id="elemco-df" onchange="updateMethodOptions()">
-                    <span>DF</span>
-                </label>
             </div>
-        </div>
-        <div class="elemco-input-group">
-            <label for="elemco-basis">AO Basis Set:</label>
-            <select id="elemco-basis">
-                <option value="cc-pVDZ" selected>cc-pVDZ</option>
-                <option value="cc-pVTZ">cc-pVTZ</option>
-                <option value="aug-cc-pVDZ">aug-cc-pVDZ</option>
-                <option value="aug-cc-pVTZ">aug-cc-pVTZ</option>
-            </select>
-        </div>
-        <div class="elemco-input-group">
-            <label for="elemco-jkfit">JKfit Basis:</label>
-            <select id="elemco-jkfit">
-                <option value="auto" selected>Auto (Based on AO)</option>
-                <option value="cc-pVDZ-jkfit">cc-pVDZ-jkfit</option>
-                <option value="cc-pVTZ-jkfit">cc-pVTZ-jkfit</option>
-                <option value="cc-pVQZ-jkfit">cc-pVQZ-jkfit</option>
-                <option value="cc-pV5Z-jkfit">cc-pV5Z-jkfit</option>
-                <option value="def2-universal-jkfit">def2-universal-jkfit</option>
-            </select>
-        </div>
-        <div class="elemco-input-group">
-            <label for="elemco-mpfit">MPfit Basis:</label>
-            <select id="elemco-mpfit">
-                <option value="auto" selected>Auto (Based on AO)</option>
-                <option value="cc-pVDZ-mpfit">cc-pVDZ-mpfit</option>
-                <option value="cc-pVTZ-mpfit">cc-pVTZ-mpfit</option>
-                <option value="cc-pVQZ-mpfit">cc-pVQZ-mpfit</option>
-                <option value="aug-cc-pVDZ-mpfit">aug-cc-pVDZ-mpfit</option>
-                <option value="aug-cc-pVTZ-mpfit">aug-cc-pVTZ-mpfit</option>
-                <option value="aug-cc-pVQZ-mpfit">aug-cc-pVQZ-mpfit</option>
-            </select>
-        </div>
-        <div class="charge-multiplicity-group">
-            <div class="charge-multiplicity-item">
-                <label for="elemco-charge">Charge:</label>
-                <input type="number" id="elemco-charge" value="0" min="-99" max="99">
+            <div class="elemco-input-group">
+                <label for="elemco-jkfit">JKfit Basis:</label>
+                <select id="elemco-jkfit">
+                    <option value="auto" selected>Auto (Based on AO)</option>
+                    <option value="cc-pVDZ-jkfit">cc-pVDZ-jkfit</option>
+                    <option value="cc-pVTZ-jkfit">cc-pVTZ-jkfit</option>
+                    <option value="cc-pVQZ-jkfit">cc-pVQZ-jkfit</option>
+                    <option value="cc-pV5Z-jkfit">cc-pV5Z-jkfit</option>
+                    <option value="def2-universal-jkfit">def2-universal-jkfit</option>
+                </select>
             </div>
-            <div class="charge-multiplicity-item">
-                <label for="elemco-multiplicity">Multiplicity:</label>
-                <input type="number" id="elemco-multiplicity" value="0" min="0" max="99">
+            <div class="elemco-input-group">
+                <label for="elemco-mpfit">MPfit Basis:</label>
+                <select id="elemco-mpfit">
+                    <option value="auto" selected>Auto (Based on AO)</option>
+                    <option value="cc-pVDZ-mpfit">cc-pVDZ-mpfit</option>
+                    <option value="cc-pVTZ-mpfit">cc-pVTZ-mpfit</option>
+                    <option value="cc-pVQZ-mpfit">cc-pVQZ-mpfit</option>
+                    <option value="aug-cc-pVDZ-mpfit">aug-cc-pVDZ-mpfit</option>
+                    <option value="aug-cc-pVTZ-mpfit">aug-cc-pVTZ-mpfit</option>
+                    <option value="aug-cc-pVQZ-mpfit">aug-cc-pVQZ-mpfit</option>
+                </select>
             </div>
+            <div class="charge-multiplicity-group">
+                <div class="charge-multiplicity-item">
+                    <label for="elemco-charge" title="Total charge (wf.charge)">Charge:</label>
+                    <input type="number" id="elemco-charge" value="0" min="-99" max="99">
+                </div>
+                <div class="charge-multiplicity-item">
+                    <label for="elemco-multiplicity" title="Spin: 2·S_z = number of unpaired electrons (wf.ms2). 0 = closed shell.">ms2 (2·S_z):</label>
+                    <input type="number" id="elemco-multiplicity" value="0" min="0" max="99">
+                </div>
+            </div>
+            <div class="elemco-opt-toggle-row">
+                <button type="button" id="elemco-global-optbtn" class="elemco-opt-togglebtn" onclick="toggleGlobalOptions()" title="Set global wavefunction / integral / printing options">Global options ▸</button>
+            </div>
+            <div class="elemco-chips" id="elemco-global-chips"></div>
+            <div class="elemco-step-options" id="elemco-global-options" style="display:none;"></div>
         </div>
-        <div class="elemco-input-group molden-export-group">
-            <label class="molden-toggle-label" for="elemco-molden">
-                <input type="checkbox" id="elemco-molden">
-                <span>Export Molden</span>
-            </label>
-            <input type="text" id="elemco-molden-file" placeholder="orbitals.molden" value="orbitals.molden" title="Filename for molden orbital export">
+
+        <!-- Calculation steps (building blocks): reference, methods, export, ... -->
+        <div class="elemco-steps-label">Calculation steps</div>
+        <div id="elemco-steps"></div>
+        <div class="elemco-add-step">
+            <span>Add step:</span>
+            <button type="button" onclick="addElemCoStep('reference')" title="Add a reference (SCF) step">Reference</button>
+            <button type="button" onclick="addElemCoStep('correlation')" title="Add a correlation / post-HF method step">Method</button>
+            <button type="button" onclick="addElemCoStep('export')" title="Add an @export_molden step">Export</button>
+            <button type="button" onclick="addElemCoStep('custom')" title="Add a raw Julia snippet">Custom</button>
         </div>
+
         <div class="elemco-input-group vertical">
-            <div style="margin-bottom: 8px;">
+            <div class="elemco-editor-toolbar">
                 <a href="https://elem.co.il" target="_blank" rel="noopener noreferrer">Documentation →</a>
-            </div>
-            <label for="elemco-input">Input Editor:</label>
-            <div style="margin-bottom: 6px;">
                 <button type="button" onclick="insertSelectedAtomsIntoElemCo()" title="Insert the list of atoms currently selected in the structure/XYZ viewer at the cursor (e.g. for dummy atoms or active regions)">Insert Selected Atoms</button>
             </div>
+            <label for="elemco-input">Generated input (editable):</label>
             <textarea id="elemco-input"></textarea>
-            <div class="preview-note">Note: Changes to parameters will update this editor. You can also edit directly.</div>
+            <div class="preview-note">Changing steps or options regenerates this script. You can also edit it directly (edits are overwritten on the next change).</div>
+            <div class="preview-note elemco-source-note" id="elemco-source-note"></div>
         </div>
         <div class="action-buttons">
-            <button onclick="generateElemCoInput()" title="Reset input to default settings">Reset Input</button>
+            <button onclick="generateElemCoInput()" title="Reset the whole builder to defaults">Reset</button>
             <button onclick="copyElemCoInput()" title="Copy input text to clipboard">Copy to Clipboard</button>
             <button onclick="runJuliaCalculation()" title="Execute the Julia calculation using ElemCo.jl">Run Calculation</button>
         </div>
@@ -548,15 +547,9 @@
                         </select>
                         <div class="preference-description">Default calculation method</div>
                     </div>
-                    <div class="preference-item">
-                        <label class="preference-checkbox-label">
-                            <input type="checkbox" id="pref-use-df">
-                            <span>Use density fitting by default</span>
-                        </label>
-                        <div class="preference-description">Enable density fitting approximation for faster calculations</div>
-                    </div>
+                    <div class="preference-description" style="margin-top: 6px;">Density fitting and the reference/correlation macros are now chosen per step in the ElemCo.jl panel (Reference and Method blocks).</div>
                 </div>
-                
+
                 <div class="preference-section">
                     <h4>Output Settings</h4>
                     <div class="preference-item">

--- a/index.html
+++ b/index.html
@@ -184,7 +184,8 @@
         </div>
         <!-- Global "System & basis" card: options here apply to the whole run -->
         <div class="elemco-card" id="elemco-global-card">
-            <div class="elemco-card-title">System &amp; basis</div>
+            <button type="button" class="elemco-card-title elemco-fold-title" onclick="toggleElemCoGlobalCard()" title="Show or hide the system &amp; basis settings"><span class="elemco-caret" id="elemco-global-caret">▾</span>System &amp; basis</button>
+            <div id="elemco-global-body">
             <div class="elemco-input-group">
                 <label for="elemco-basis">AO Basis Set:</label>
                 <select id="elemco-basis">
@@ -232,6 +233,7 @@
             </div>
             <div class="elemco-chips" id="elemco-global-chips"></div>
             <div class="elemco-step-options" id="elemco-global-options" style="display:none;"></div>
+            </div><!-- /#elemco-global-body -->
         </div>
 
         <!-- Calculation steps (building blocks): reference, methods, export, ... -->

--- a/index.html
+++ b/index.html
@@ -557,14 +557,14 @@
                         <div class="preference-description">Default basis set for new calculations</div>
                     </div>
                     <div class="preference-item">
-                        <label class="preference-label">Default method:</label>
-                        <select id="pref-method" class="preference-select">
-                            <option value="HF">HF</option>
-                            <option value="MP2">MP2</option>
-                            <option value="DCSD">DCSD</option>
-                            <option value="CCSD(T)">CCSD(T)</option>
-                        </select>
-                        <div class="preference-description">Default calculation method</div>
+                        <label class="preference-label">Default method (molecule):</label>
+                        <select id="pref-method-molecule" class="preference-select"></select>
+                        <div class="preference-description">Default correlated method for molecular (geometry + basis) calculations. A DF-HF reference step is added automatically.</div>
+                    </div>
+                    <div class="preference-item">
+                        <label class="preference-label">Default method (FCIDUMP):</label>
+                        <select id="pref-method-fcidump" class="preference-select"></select>
+                        <div class="preference-description">Default correlated method for FCIDUMP calculations. No reference step is added.</div>
                     </div>
                     <div class="preference-description" style="margin-top: 6px;">Density fitting and the reference/correlation macros are now chosen per step in the ElemCo.jl panel (Reference and Method blocks).</div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
                 </div>
             </div>
             <div class="elemco-opt-toggle-row">
-                <button type="button" id="elemco-global-optbtn" class="elemco-opt-togglebtn" onclick="toggleGlobalOptions()" title="Set global wavefunction / integral / printing options">Global options ▸</button>
+                <button type="button" id="elemco-global-optbtn" class="elemco-opt-togglebtn" onclick="toggleGlobalOptions()" title="Set global wavefunction / integral / printing options"><span class="elemco-caret" id="elemco-global-optcaret">▸</span>Global options</button>
             </div>
             <div class="elemco-chips" id="elemco-global-chips"></div>
             <div class="elemco-step-options" id="elemco-global-options" style="display:none;"></div>

--- a/index.html
+++ b/index.html
@@ -184,8 +184,15 @@
         </div>
         <!-- Global "System & basis" card: options here apply to the whole run -->
         <div class="elemco-card" id="elemco-global-card">
-            <button type="button" class="elemco-card-title elemco-fold-title" onclick="toggleElemCoGlobalCard()" title="Show or hide the system &amp; basis settings"><span class="elemco-caret" id="elemco-global-caret">▾</span>System &amp; basis</button>
+            <div class="elemco-card-header">
+                <button type="button" class="elemco-card-title elemco-fold-title" onclick="toggleElemCoGlobalCard()" title="Show or hide the system &amp; basis settings"><span class="elemco-caret" id="elemco-global-caret">▾</span><span id="elemco-global-titletext">System &amp; basis</span></button>
+                <select id="elemco-mode" class="elemco-mode-select" onchange="setElemCoMode(this.value)" title="Molecule: geometry + basis. FCIDUMP: read integrals from a file.">
+                    <option value="molecule">Molecule</option>
+                    <option value="fcidump">FCIDUMP</option>
+                </select>
+            </div>
             <div id="elemco-global-body">
+            <div id="elemco-molecule-fields">
             <div class="elemco-input-group">
                 <label for="elemco-basis">AO Basis Set:</label>
                 <select id="elemco-basis">
@@ -217,6 +224,13 @@
                     <option value="aug-cc-pVTZ-mpfit">aug-cc-pVTZ-mpfit</option>
                     <option value="aug-cc-pVQZ-mpfit">aug-cc-pVQZ-mpfit</option>
                 </select>
+            </div>
+            </div><!-- /#elemco-molecule-fields -->
+            <div id="elemco-fcidump-fields" style="display:none;">
+                <div class="elemco-input-group">
+                    <label for="elemco-fcidump">FCIDUMP file:</label>
+                    <input type="text" id="elemco-fcidump" value="FCIDUMP" title="Path to the FCIDUMP integrals file">
+                </div>
             </div>
             <div class="charge-multiplicity-group">
                 <div class="charge-multiplicity-item">

--- a/js/app-init.js
+++ b/js/app-init.js
@@ -7,6 +7,10 @@ function initElemCoPanel() {
     if (typeof syncElemCoControlsFromState === 'function') syncElemCoControlsFromState();
     if (typeof renderElemCoSteps === 'function') renderElemCoSteps();
     if (typeof renderGlobalChips === 'function') renderGlobalChips();
+    if (typeof elcAttachJuliaHighlight === 'function') {
+        const ta = document.getElementById('elemco-input');
+        if (ta) elcAttachJuliaHighlight(ta);
+    }
     updateElemCoInput();
 }
 

--- a/js/app-init.js
+++ b/js/app-init.js
@@ -1,20 +1,12 @@
 // Initialize ElemCo panel elements
 function initElemCoPanel() {
-    // Clean up any existing elements first
-    const dfLabel = document.querySelector('.df-toggle-label');
-    if (dfLabel) {
-        // Remove existing content to prevent memory leaks
-        dfLabel.innerHTML = '';
-        dfLabel.innerHTML = `
-                    <input type="checkbox" id="elemco-df" onchange="updateMethodOptions()">
-                    <span>Use DF</span>
-                `;
-    }
-
-    // Initialize method options
-    updateMethodOptions();
-
-    // Update input text
+    // Build the builder state (seeded from preferences) and wire the fixed
+    // System & basis controls, then render the step list and generate the input.
+    if (typeof initElemCoState === 'function') initElemCoState();
+    if (typeof initializeElemCoListeners === 'function') initializeElemCoListeners();
+    if (typeof syncElemCoControlsFromState === 'function') syncElemCoControlsFromState();
+    if (typeof renderElemCoSteps === 'function') renderElemCoSteps();
+    if (typeof renderGlobalChips === 'function') renderGlobalChips();
     updateElemCoInput();
 }
 

--- a/js/elemco-highlight.js
+++ b/js/elemco-highlight.js
@@ -1,0 +1,82 @@
+// Lightweight Julia syntax highlighting for the ElemCo.jl editors.
+//
+// Same overlay technique as the XYZ editor (js/xyz-editor.js): a transparent
+// textarea sits on top of a backdrop <div> that renders the same text with
+// colored token spans. Both share identical metrics (see .elemco-code-* in
+// css/styles.css) so the highlighted text lines up exactly under the caret.
+
+// Tokenize Julia into HTML with token spans. Order matters: strings and comments
+// are matched before keywords so their contents aren't recolored.
+function elcHighlightJulia(code) {
+    const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const re = /("""[\s\S]*?"""|"(?:[^"\\]|\\.)*")|(#[^\n]*)|(@[A-Za-z_][\w!]*)|\b(function|end|begin|using|import|export|module|return|if|elseif|else|for|while|do|in|struct|mutable|const|let|global|local|quote|where)\b|\b(true|false|nothing|missing)\b|(\b\d[\d_]*(?:\.\d+)?(?:[eE][+-]?\d+)?)/g;
+    let out = '';
+    let last = 0;
+    let m;
+    while ((m = re.exec(code)) !== null) {
+        out += esc(code.slice(last, m.index));
+        let cls = 'j-num';
+        if (m[1]) cls = 'j-str';
+        else if (m[2]) cls = 'j-com';
+        else if (m[3]) cls = 'j-macro';
+        else if (m[4]) cls = 'j-key';
+        else if (m[5]) cls = 'j-lit';
+        out += '<span class="' + cls + '">' + esc(m[0]) + '</span>';
+        last = re.lastIndex;
+    }
+    out += esc(code.slice(last));
+    return out;
+}
+
+// Wire a textarea + its backdrop/highlights so the overlay tracks edits & scroll.
+// Exposes ta._elcHighlight() to refresh after programmatic value changes.
+function elcWireHighlight(ta, backdrop, highlights) {
+    const refresh = () => { highlights.innerHTML = elcHighlightJulia(ta.value || ''); };
+    const sync = () => { backdrop.scrollTop = ta.scrollTop; backdrop.scrollLeft = ta.scrollLeft; };
+    ta.addEventListener('input', () => { refresh(); sync(); });
+    ta.addEventListener('scroll', sync);
+    ta._elcHighlight = () => { refresh(); sync(); };
+    refresh();
+}
+
+// Build a fresh highlighted Julia editor. Returns { wrap, textarea }.
+function elcMakeJuliaEditor(extraClass) {
+    const wrap = document.createElement('div');
+    wrap.className = 'elemco-code-wrap';
+    const backdrop = document.createElement('div');
+    backdrop.className = 'elemco-code-backdrop';
+    const highlights = document.createElement('div');
+    highlights.className = 'elemco-code-highlights';
+    backdrop.appendChild(highlights);
+    const ta = document.createElement('textarea');
+    ta.className = 'elemco-code-input' + (extraClass ? ' ' + extraClass : '');
+    ta._elcHl = true;
+    wrap.appendChild(backdrop);
+    wrap.appendChild(ta);
+    elcWireHighlight(ta, backdrop, highlights);
+    return { wrap, textarea: ta };
+}
+
+// Wrap an existing (already in-DOM) textarea in the highlight overlay in place.
+function elcAttachJuliaHighlight(ta) {
+    if (!ta || ta._elcHl || !ta.parentNode) return;
+    ta._elcHl = true;
+    const wrap = document.createElement('div');
+    wrap.className = 'elemco-code-wrap';
+    const backdrop = document.createElement('div');
+    backdrop.className = 'elemco-code-backdrop';
+    const highlights = document.createElement('div');
+    highlights.className = 'elemco-code-highlights';
+    backdrop.appendChild(highlights);
+    ta.parentNode.insertBefore(wrap, ta);
+    wrap.appendChild(backdrop);
+    wrap.appendChild(ta);
+    ta.classList.add('elemco-code-input');
+    elcWireHighlight(ta, backdrop, highlights);
+}
+
+if (typeof window !== 'undefined') {
+    window.elcHighlightJulia = elcHighlightJulia;
+    window.elcMakeJuliaEditor = elcMakeJuliaEditor;
+    window.elcAttachJuliaHighlight = elcAttachJuliaHighlight;
+}

--- a/js/elemco-highlight.js
+++ b/js/elemco-highlight.js
@@ -28,9 +28,30 @@ function elcHighlightJulia(code) {
     return out;
 }
 
+// Native scrollbar thickness (0 on overlay-scrollbar platforms). Measured once.
+let _elcScrollbarSize = null;
+function elcScrollbarSize() {
+    if (_elcScrollbarSize != null) return _elcScrollbarSize;
+    _elcScrollbarSize = 0;
+    try {
+        const d = document.createElement('div');
+        d.style.cssText = 'position:absolute;top:-9999px;left:-9999px;width:100px;height:100px;overflow:scroll;';
+        document.body.appendChild(d);
+        _elcScrollbarSize = d.offsetWidth - d.clientWidth;
+        document.body.removeChild(d);
+    } catch (e) { _elcScrollbarSize = 0; }
+    return _elcScrollbarSize;
+}
+
 // Wire a textarea + its backdrop/highlights so the overlay tracks edits & scroll.
 // Exposes ta._elcHighlight() to refresh after programmatic value changes.
 function elcWireHighlight(ta, backdrop, highlights) {
+    // A textarea's scrollbars reserve space and shrink its client area, so it can
+    // scroll further than the (scrollbar-less) backdrop — at the very bottom/right
+    // the overlay would clamp short and the last line drifts. Pad the highlights by
+    // the scrollbar thickness so both scroll ranges match exactly.
+    const sb = elcScrollbarSize();
+    if (sb > 0) { highlights.style.paddingBottom = sb + 'px'; highlights.style.paddingRight = sb + 'px'; }
     const refresh = () => { highlights.innerHTML = elcHighlightJulia(ta.value || ''); };
     const sync = () => { backdrop.scrollTop = ta.scrollTop; backdrop.scrollLeft = ta.scrollLeft; };
     ta.addEventListener('input', () => { refresh(); sync(); });

--- a/js/elemco-highlight.js
+++ b/js/elemco-highlight.js
@@ -35,7 +35,15 @@ function elcWireHighlight(ta, backdrop, highlights) {
     const sync = () => { backdrop.scrollTop = ta.scrollTop; backdrop.scrollLeft = ta.scrollLeft; };
     ta.addEventListener('input', () => { refresh(); sync(); });
     ta.addEventListener('scroll', sync);
-    ta._elcHighlight = () => { refresh(); sync(); };
+    // After a programmatic value change (e.g. generating the input) the textarea's
+    // scroll position settles on a later frame, so an immediate sync can latch a
+    // stale scrollTop and the overlay drifts. Re-sync on the next frame(s) too.
+    ta._elcHighlight = () => {
+        refresh();
+        sync();
+        if (typeof requestAnimationFrame === 'function') requestAnimationFrame(sync);
+        setTimeout(sync, 0);
+    };
     refresh();
 }
 

--- a/js/elemco-macros.js
+++ b/js/elemco-macros.js
@@ -1,0 +1,221 @@
+// AUTO-GENERATED — do not edit by hand.
+// Source: ElemCo.jl src/ElemCo.jl @ main
+// Regenerate: node scripts/parse-elemco-macros.js [--ref <tag>]
+window.ELEMCO_MACROS = {
+  "sourceRepo": "fkfest/ElemCo.jl",
+  "sourceRef": "main",
+  "sourceUrl": "https://raw.githubusercontent.com/fkfest/ElemCo.jl/main/src/ElemCo.jl",
+  "generated": "2026-07-19",
+  "macros": [
+    {
+      "name": "bohf",
+      "signature": "@bohf(opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run bi-orthogonal HF calculation using FCIDUMP integrals.\n\n The orbital rotations are stored to WfOptions.dump.\n For open-shell systems (or UHF FCIDUMPs), the BO-UHF energy is calculated.\n\n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "bouhf",
+      "signature": "@bouhf(opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run bi-orthogonal UHF calculation using FCIDUMP integrals.\n\n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "cc",
+      "signature": "@cc(method, args...)",
+      "acceptsOptions": true,
+      "doc": "Run coupled cluster calculation.\n\n The type of the method is determined by the first argument (ccsd/ccsd(t)/dcsd etc).\n The method can be specified as a string or as a variable, e.g., \n @cc CCSD or @cc \"CCSD\" or ccmethod=\"CCSD\"; @cc ccmethod.\n \n Optionally, a begin...end block can be provided as the last argument to set \n local options for this call. The options are reset after the call completes."
+    },
+    {
+      "name": "check_molproinfo",
+      "signature": "@check_molproinfo()",
+      "acceptsOptions": false,
+      "doc": "Check if MolproInterface.MolproInfo is initialized and return the files.\n If not initialized, throw an error."
+    },
+    {
+      "name": "ciphi",
+      "signature": "@ciphi(args...)",
+      "acceptsOptions": true,
+      "doc": "Run CIPHI (CIΦ - CI via Perturbative and Heat-Bath Iterative selection) calculation.\n\n Optionally, a begin...end block can be provided as the last argument to set \n local options for this call. The options are reset after the call completes."
+    },
+    {
+      "name": "ciϕ",
+      "signature": "@ciϕ(args...)",
+      "acceptsOptions": true,
+      "doc": "Alias for @ciphi. Run CIPHI (CIΦ - CI via Perturbative and Heat-Bath Iterative selection) calculation.\n\n Optionally, a begin...end block can be provided as the last argument to set \n local options for this call. The options are reset after the call completes."
+    },
+    {
+      "name": "copyfile",
+      "signature": "@copyfile(from_file, to_file, kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Copy file from_file to to_file in EC.scr directory."
+    },
+    {
+      "name": "copywf",
+      "signature": "@copywf(args...)",
+      "acceptsOptions": false,
+      "doc": "Copy wavefunction data from the current trexio dump file to another dump file.\n\n If to_file is not provided, the wavefunction is copied to EC.options.wf.store file.\n Note: This does not check the contents of the files."
+    },
+    {
+      "name": "deletefile",
+      "signature": "@deletefile(filename)",
+      "acceptsOptions": false,
+      "doc": "Delete file filename from EC.scr directory."
+    },
+    {
+      "name": "dfcc",
+      "signature": "@dfcc(method=\"svd-dcsd\", opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run coupled cluster calculation using density fitted integrals.\n\n The type of the method is determined by the first argument.\n The method can be specified as a string or as a variable, e.g., \n @dfcc SVD-DCSD or @dfcc \"SVD-DCSD\" or ccmethod=\"SVD-DCSD\"; @dfcc ccmethod.\n \n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "dfhf",
+      "signature": "@dfhf(opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run DF-HF calculation. The orbitals are stored to WfOptions.dump.\n\n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "dfints",
+      "signature": "@dfints()",
+      "acceptsOptions": false,
+      "doc": "Generate 2 and 4-idx MO integrals using density fitting.\n The MO coefficients are read from WfOptions.dump."
+    },
+    {
+      "name": "dfmcscf",
+      "signature": "@dfmcscf(opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run DF-MCSCF calculation. The orbitals are stored to WfOptions.dump.\n\n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "dfmp2",
+      "signature": "@dfmp2(opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run density-fitted MP2 calculation.\n\n If save is set in CcOptions.save, \n the MP2 doubles amplitudes are saved to save*\"_2\" file.\n\n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "dfuhf",
+      "signature": "@dfuhf(opts_block=nothing)",
+      "acceptsOptions": true,
+      "doc": "Run DF-UHF calculation. The orbitals are stored to WfOptions.dump.\n\n Optionally, a begin...end block can be provided to set local options for this call.\n The options are reset after the call completes."
+    },
+    {
+      "name": "dummy",
+      "signature": "@dummy(atoms)",
+      "acceptsOptions": false,
+      "doc": "Set atoms as dummy atoms in the system.\n atoms is a list of atom indices or atomic symbols.\n\n After running the macro, only the atoms in the list are set as dummy atoms in the system."
+    },
+    {
+      "name": "export_molden",
+      "signature": "@export_molden(filename)",
+      "acceptsOptions": false,
+      "doc": "Export current orbitals to Molden file filename."
+    },
+    {
+      "name": "fci",
+      "signature": "@fci(args...)",
+      "acceptsOptions": true,
+      "doc": "Run FCI calculation.\n\n Optionally, a begin...end block can be provided as the last argument to set \n local options for this call. The options are reset after the call completes."
+    },
+    {
+      "name": "freeze_orbs",
+      "signature": "@freeze_orbs(freeze_orbs)",
+      "acceptsOptions": false,
+      "doc": "Freeze orbitals in the integrals according to an array or range \n freeze_orbs.\n\n Alternatively, the orbitals can be specified as a String with the +/- or :/; syntax, e.g.,\n \"1-5+7-8\", or \"1:5;7-8\"."
+    },
+    {
+      "name": "import_matrix",
+      "signature": "@import_matrix(filename)",
+      "acceptsOptions": false,
+      "doc": "Import matrix from file file.\n\n The type of the matrix is determined automatically."
+    },
+    {
+      "name": "loadfile",
+      "signature": "@loadfile(filename)",
+      "acceptsOptions": false,
+      "doc": "Read file filename from EC.scr directory."
+    },
+    {
+      "name": "loadwf",
+      "signature": "@loadwf(args...)",
+      "acceptsOptions": false,
+      "doc": "Load wavefunction data from the trexio dump file.\n\n The arguments what can be a vector of strings, a string variable or a list of arguments \n specifying what to load.\n Possible values are: \n\n - all: load everything available (overrides other options)\n - orbital_energies: molecular orbital energies\n - orbital_occupations: molecular orbital occupations\n - amplitudes: restricted CC amplitudes (T1, T2)\n - unrestricted_amplitudes: unrestricted CC amplitudes (T1a, T1b, T2a, T2b, T2ab)\n - determinants: selected CI determinants and coefficients\n\n The loaded data are returned as a dictionary with keys corresponding to the requested data.\n basis, orbitals and orbital_type are always included in the output."
+    },
+    {
+      "name": "molpro_input",
+      "signature": "@molpro_input(filename=\"elemcoil\")",
+      "acceptsOptions": false,
+      "doc": "Initialize the Molpro interface with the given filename.\n\n It relies on the Molpro XML file to set up the molecule and basis set.\n If the basis variable exists, it will be updated with the AO basis set from the XML file.\n\n See MolproInterface for more details on the Molpro interface."
+    },
+    {
+      "name": "molpro_output",
+      "signature": "@molpro_output(ecvariables, kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Save key-value pairs from ecvariables to a ECVARIABLES file in the MolproInterface.MolproInfo object.\n \n The ecvariables is a dictionary with the variables to be included in the output.\n The keyword arguments are passed to the MolproInterface.save_ecvariables_to_file function.\n Possible keyword arguments include:\n - prefix::String: prefix for each variable in the output file (default: \"\")\n - new::Bool: if true, create a new file, otherwise append to the existing file (default: true)"
+    },
+    {
+      "name": "opt",
+      "signature": "@opt(opt, kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Alias for @set. Set options for EC::ECInfo. \n \n The first argument opt is the name of the option (e.g., scf, cc, cholesky), see ECInfos.Options.\n The keyword arguments are the options to be set (e.g., thr=1.e-14, maxit=10).\n The current state of the options can be stored in a variable, e.g., opt_cc = @set cc.\n The state can then be restored by @set cc opt_cc.\n If EC is not already initialized, it will be done."
+    },
+    {
+      "name": "reset",
+      "signature": "@reset(opt)",
+      "acceptsOptions": false,
+      "doc": "Reset options for opt to default values."
+    },
+    {
+      "name": "rotate_orbs",
+      "signature": "@rotate_orbs(orb1, orb2, angle, kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Rotate orbitals orb1 and orb2 from WfOptions.dump \n by angle (in degrees). For UHF, spin can be :α or :β (keyword argument).\n \n The orbitals are stored to WfOptions.store."
+    },
+    {
+      "name": "run",
+      "signature": "@run(method, kwargs...)",
+      "acceptsOptions": true,
+      "doc": "general runner"
+    },
+    {
+      "name": "savefile",
+      "signature": "@savefile(filename, arr, kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Save array or tuple of arrays arr to file filename in EC.scr directory."
+    },
+    {
+      "name": "savewf",
+      "signature": "@savewf(args...)",
+      "acceptsOptions": false,
+      "doc": "Save wavefunction data to the trexio dump file.\n\n The argument wf is a dictionary with the data to be saved.\n Possible keys are:\n\n**Orbital data:**\n- \"basis\": basis set information\n- \"orbitals\": molecular orbitals\n- \"rotations\": orbital rotations (alternative to \"orbitals\")\n- \"orbital_type\": type of the orbitals (e.g., \"RHF\", \"UHF\", \"ROHF\", \"MCSCF\")\n- \"orbital_energies\": molecular orbital energies\n- \"orbital_occupations\": molecular orbital occupations\n\n**Restricted CC amplitudes:**\n- \"T1\": singles amplitudes (nvirt × nocc)\n- \"T2\": doubles amplitudes (nvirt × nvirt × nocc × nocc)\n\n**Unrestricted CC amplitudes:**\n- \"T1a\", \"T1b\": α and β singles amplitudes\n- \"T2a\", \"T2b\", \"T2ab\": αα, ββ, and αβ doubles amplitudes\n\n**Selected CI (CIPHI) data:**\n- \"determinants\": vector of determinants\n- \"ci_coefficients\": CI coefficients (vector for single state, matrix for multi-state)"
+    },
+    {
+      "name": "sci",
+      "signature": "@sci(args...)",
+      "acceptsOptions": true,
+      "doc": "Alias for @ciphi. Run CIPHI (CIΦ - CI via Perturbative and Heat-Bath Iterative selection) calculation.\n\n Optionally, a begin...end block can be provided as the last argument to set \n local options for this call. The options are reset after the call completes."
+    },
+    {
+      "name": "set",
+      "signature": "@set(opt, kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Set options for EC::ECInfo. \n \n The first argument opt is the name of the option (e.g., scf, cc, cholesky), see ECInfos.Options.\n The keyword arguments are the options to be set (e.g., thr=1.e-14, maxit=10).\n The current state of the options can be stored in a variable, e.g., opt_cc = @set cc.\n The state can then be restored by @set cc opt_cc.\n If EC is not already initialized, it will be done."
+    },
+    {
+      "name": "show_orbs",
+      "signature": "@show_orbs(range=nothing)",
+      "acceptsOptions": false,
+      "doc": "Show orbitals in the integrals according to an array or range \n range."
+    },
+    {
+      "name": "transform_ints",
+      "signature": "@transform_ints()",
+      "acceptsOptions": false,
+      "doc": "Rotate FCIDump integrals using rotations from WfOptions.dump \n as transformation matrices.\n\n The orbital rotations are read from WfOptions.dump.\n If type of the rotations contains the word biorthogonal, \n the bi-orthogonal orbitals are used."
+    },
+    {
+      "name": "write_ints",
+      "signature": "@write_ints(file=\"FCIDUMP\", kwargs...)",
+      "acceptsOptions": false,
+      "doc": "Write FCIDump integrals to file file."
+    }
+  ]
+};

--- a/js/elemco-methods.js
+++ b/js/elemco-methods.js
@@ -31,7 +31,7 @@ const ELEMCO_METHODS = {
     { id: 'ccsdt',        label: 'CCSDT',             macro: '@cc',    arg: 'ccsdt',         groups: ['cc'] },
     { id: 'dc-ccsdt',     label: 'DC-CCSDT',          macro: '@cc',    arg: 'dc-ccsdt',      groups: ['cc'] },
     { id: 'svd-dcsd',     label: 'SVD-DCSD (DF)',     macro: '@dfcc',  arg: 'svd-dcsd',      groups: ['cc'] },
-    { id: 'svd-dc-ccsdt', label: 'SVD-DC-CCSDT (DF)', macro: '@dfcc',  arg: 'svd-dc-ccsdt',  groups: ['cc'] },
+    { id: 'svd-dc-ccsdt', label: 'SVD-DC-CCSDT',      macro: '@cc',    arg: 'svd-dc-ccsdt',  groups: ['cc'] },
     { id: 'fci',          label: 'FCI',               macro: '@fci',   arg: null,            groups: ['fci', 'davidson'] },
     { id: 'ciphi',        label: 'CIPHI / SCI',       macro: '@ciphi', arg: null,            groups: ['ciphi'] },
   ],

--- a/js/elemco-methods.js
+++ b/js/elemco-methods.js
@@ -1,56 +1,108 @@
 // Curated ElemCo.jl method registry (hand-maintained).
 //
-// The per-option metadata in js/elemco-options.js is generated from ElemCo.jl's
-// options.jl, but the mapping of a user-facing *method* to the macro that runs
-// it — and which option groups are most relevant to that method — is editorial
-// and lives here. Each method knows the macro it emits, an optional method-name
-// argument, and the option groups surfaced first in its options browser (the
-// full set of 13 groups is always reachable via "show all groups").
+// This is deliberately shaped like machine-readable catalog data so it could
+// later be *generated* from an ElemCo.jl-side method catalog (the way
+// js/elemco-options.js is generated from options.jl) with no change to the UI.
 //
-// Macro facts are taken from ElemCo.jl src/ElemCo.jl (public @-macros):
-//   references : @dfhf (RHF), @dfuhf, @dfmcscf, @bohf, @bouhf
-//   correlation: @cc <method>, @dfcc <method>, @dfmp2, @fci, @ciphi
-// A method macro may be followed by a `begin ... end` block of local `@set`
-// lines; those options are automatically reset by ElemCo.jl after the call.
+// Model mirrors ElemCo.jl's ECMethod (src/infos/ecmethods.jl): a method name is
+// `[prefixes…] + core`, where `core` is theory+excitation (CCSD, CCSD(T), DCD,
+// DC-CCSDT, …) and prefixes are composable flags. U/R (spin) come from a separate
+// selector; the remaining prefixes (Λ, EOM-, SVD-, QV-, O, …) are part of a named
+// method. Prefixes are emitted in ElemCo's canonical order.
 
+// References (first step): the SCF wavefunction. These are macros, not method
+// strings (so no core/prefix composition).
 const ELEMCO_METHODS = {
-  // First step of a calculation: the reference wavefunction.
   reference: [
-    { id: 'dfhf',    label: 'DF-HF (RHF)',      macro: '@dfhf',    arg: null, groups: ['scf', 'int'] },
-    { id: 'dfuhf',   label: 'DF-UHF',           macro: '@dfuhf',   arg: null, groups: ['scf', 'int'] },
-    { id: 'dfmcscf', label: 'DF-MCSCF',         macro: '@dfmcscf', arg: null, groups: ['scf', 'wf'] },
-    { id: 'bohf',    label: 'BO-HF (FCIDUMP)',  macro: '@bohf',    arg: null, groups: ['scf'], advanced: true },
-    { id: 'bouhf',   label: 'BO-UHF (FCIDUMP)', macro: '@bouhf',   arg: null, groups: ['scf'], advanced: true },
-  ],
-  // Correlation / post-HF methods run on top of a reference.
-  correlation: [
-    { id: 'mp2',          label: 'MP2 (DF)',          macro: '@dfmp2', arg: null,           groups: ['cc'] },
-    { id: 'ccsd',         label: 'CCSD',              macro: '@cc',    arg: 'ccsd',          groups: ['cc'] },
-    { id: 'ccsd(t)',      label: 'CCSD(T)',           macro: '@cc',    arg: 'ccsd(t)',       groups: ['cc'] },
-    { id: 'dcsd',         label: 'DCSD',              macro: '@cc',    arg: 'dcsd',          groups: ['cc'] },
-    { id: 'ccsdt',        label: 'CCSDT',             macro: '@cc',    arg: 'ccsdt',         groups: ['cc'] },
-    { id: 'dc-ccsdt',     label: 'DC-CCSDT',          macro: '@cc',    arg: 'dc-ccsdt',      groups: ['cc'] },
-    { id: 'svd-dcsd',     label: 'SVD-DCSD (DF)',     macro: '@dfcc',  arg: 'svd-dcsd',      groups: ['cc'] },
-    { id: 'svd-dc-ccsdt', label: 'SVD-DC-CCSDT',      macro: '@cc',    arg: 'svd-dc-ccsdt',  groups: ['cc'] },
-    { id: 'fci',          label: 'FCI',               macro: '@fci',   arg: null,            groups: ['fci', 'davidson'] },
-    { id: 'ciphi',        label: 'CIPHI / SCI',       macro: '@ciphi', arg: null,            groups: ['ciphi'] },
+    { id: 'dfhf',    label: 'DF-HF (RHF)',      macro: '@dfhf',    groups: ['scf', 'int'] },
+    { id: 'dfuhf',   label: 'DF-UHF',           macro: '@dfuhf',   groups: ['scf', 'int'] },
+    { id: 'dfmcscf', label: 'DF-MCSCF',         macro: '@dfmcscf', groups: ['scf', 'wf'] },
+    { id: 'bohf',    label: 'BO-HF (FCIDUMP)',  macro: '@bohf',    groups: ['scf'], advanced: true },
+    { id: 'bouhf',   label: 'BO-UHF (FCIDUMP)', macro: '@bouhf',   groups: ['scf'], advanced: true },
   ],
 };
 
-// Option groups shown on the global "System & basis" card (apply to the whole
-// run, emitted as top-level @set). charge/ms2 have dedicated inputs, so they are
-// excluded from the wf group here to avoid duplication.
+// Canonical prefix order (ElemCo.jl Prefix4Methods). U/R are supplied by the spin
+// selector; the rest are baked into named methods below.
+const ELEMCO_PREFIX_ORDER = ['EOM-', 'SVD-', '2D-', 'FRS-', 'FRT-', 'Λ', 'U', 'R', 'O', 'QV-', 'SOS-'];
+
+// Spin type -> prefix. Closed-shell adds nothing.
+const ELEMCO_SPINS = [
+  { id: '',  label: 'Closed-shell' },
+  { id: 'U', label: 'Unrestricted (U)' },
+  { id: 'R', label: 'Restricted-open (R)' },
+];
+
+// Correlation methods, grouped for the dropdown. `core` = theory+excitation;
+// `prefixes` = the fixed flags that define this named method; `macro` = the macro
+// that runs it; `spins` = whether the U/R selector applies; `groups` = option
+// groups surfaced first. Emitted string = canonical(prefixes + spin) + core.
+const ELEMCO_CORRELATION_GROUPS = [
+  { group: 'Møller–Plesset', methods: [
+    { id: 'mp2', label: 'MP2', core: 'MP2', prefixes: [], macro: '@dfmp2', spins: false, groups: ['cc'] },
+  ] },
+  { group: 'Coupled cluster', methods: [
+    { id: 'ccd',           label: 'CCD',      core: 'CCD',     prefixes: [],    macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'ccsd',          label: 'CCSD',     core: 'CCSD',    prefixes: [],    macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'ccsd_t',        label: 'CCSD(T)',  core: 'CCSD(T)', prefixes: [],    macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'lambda_ccsd_t', label: 'ΛCCSD(T)', core: 'CCSD(T)', prefixes: ['Λ'], macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'ccsdt',         label: 'CCSDT',    core: 'CCSDT',   prefixes: [],    macro: '@cc', spins: true, groups: ['cc'] },
+  ] },
+  { group: 'Distinguishable cluster', methods: [
+    { id: 'dcd',      label: 'DCD',      core: 'DCD',      prefixes: [], macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'dcsd',     label: 'DCSD',     core: 'DCSD',     prefixes: [], macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'dc_ccsdt', label: 'DC-CCSDT', core: 'DC-CCSDT', prefixes: [], macro: '@cc', spins: true, groups: ['cc'] },
+  ] },
+  { group: 'Quasi-variational', methods: [
+    { id: 'qv_ccd',  label: 'QV-CCD',  core: 'CCD', prefixes: ['QV-'],      macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'qv_dcd',  label: 'QV-DCD',  core: 'DCD', prefixes: ['QV-'],      macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'oqv_ccd', label: 'OQV-CCD', core: 'CCD', prefixes: ['O', 'QV-'], macro: '@cc', spins: true, groups: ['cc'] },
+    { id: 'oqv_dcd', label: 'OQV-DCD', core: 'DCD', prefixes: ['O', 'QV-'], macro: '@cc', spins: true, groups: ['cc'] },
+  ] },
+  { group: 'Factorized (SVD)', methods: [
+    { id: 'svd_dcsd',     label: 'SVD-DCSD',     core: 'DCSD',     prefixes: ['SVD-'], macro: '@dfcc', spins: false, groups: ['cc'] },
+    { id: 'svd_dc_ccsdt', label: 'SVD-DC-CCSDT', core: 'DC-CCSDT', prefixes: ['SVD-'], macro: '@cc',   spins: false, groups: ['cc'] },
+  ] },
+  { group: 'Excited states (EOM)', methods: [
+    { id: 'eom_ccsd', label: 'EOM-CCSD', core: 'CCSD', prefixes: ['EOM-'], macro: '@cc', spins: true, groups: ['cc', 'eom'] },
+    { id: 'eom_dcsd', label: 'EOM-DCSD', core: 'DCSD', prefixes: ['EOM-'], macro: '@cc', spins: true, groups: ['cc', 'eom'] },
+  ] },
+  { group: 'Full CI', methods: [
+    { id: 'fci',   label: 'FCI',         core: '', prefixes: [], macro: '@fci',   spins: false, groups: ['fci', 'davidson'] },
+    { id: 'ciphi', label: 'CIPHI / SCI', core: '', prefixes: [], macro: '@ciphi', spins: false, groups: ['ciphi'] },
+  ] },
+];
+
+// Option groups shown on the global "System & basis" card (top-level @set).
 const ELEMCO_GLOBAL_GROUPS = ['wf', 'int', 'print'];
 const ELEMCO_GLOBAL_EXCLUDE = { wf: ['charge', 'ms2'] };
 
+// Flatten correlation methods for id lookup.
+const ELEMCO_CORRELATION_BY_ID = {};
+ELEMCO_CORRELATION_GROUPS.forEach((g) => g.methods.forEach((m) => { ELEMCO_CORRELATION_BY_ID[m.id] = m; }));
+
+function elemcoCorrelationDef(id) { return ELEMCO_CORRELATION_BY_ID[id] || null; }
+
 function elemcoMethodDef(category, id) {
-  const list = ELEMCO_METHODS[category];
-  if (!list) return null;
-  return list.find((m) => m.id === id) || null;
+  if (category === 'reference') return (ELEMCO_METHODS.reference || []).find((m) => m.id === id) || null;
+  if (category === 'correlation') return elemcoCorrelationDef(id);
+  return null;
+}
+
+// (built-in prefixes + spin) in canonical order, then core -> ElemCo.jl method string.
+function elemcoComposeMethod(def, spin) {
+  if (!def) return '';
+  const all = (def.prefixes || []).slice();
+  if (spin) all.push(spin);
+  all.sort((a, b) => ELEMCO_PREFIX_ORDER.indexOf(a) - ELEMCO_PREFIX_ORDER.indexOf(b));
+  return all.join('') + (def.core || '');
 }
 
 if (typeof window !== 'undefined') {
   window.ELEMCO_METHODS = ELEMCO_METHODS;
+  window.ELEMCO_CORRELATION_GROUPS = ELEMCO_CORRELATION_GROUPS;
+  window.ELEMCO_SPINS = ELEMCO_SPINS;
+  window.ELEMCO_PREFIX_ORDER = ELEMCO_PREFIX_ORDER;
   window.ELEMCO_GLOBAL_GROUPS = ELEMCO_GLOBAL_GROUPS;
   window.ELEMCO_GLOBAL_EXCLUDE = ELEMCO_GLOBAL_EXCLUDE;
 }

--- a/js/elemco-methods.js
+++ b/js/elemco-methods.js
@@ -1,0 +1,56 @@
+// Curated ElemCo.jl method registry (hand-maintained).
+//
+// The per-option metadata in js/elemco-options.js is generated from ElemCo.jl's
+// options.jl, but the mapping of a user-facing *method* to the macro that runs
+// it — and which option groups are most relevant to that method — is editorial
+// and lives here. Each method knows the macro it emits, an optional method-name
+// argument, and the option groups surfaced first in its options browser (the
+// full set of 13 groups is always reachable via "show all groups").
+//
+// Macro facts are taken from ElemCo.jl src/ElemCo.jl (public @-macros):
+//   references : @dfhf (RHF), @dfuhf, @dfmcscf, @bohf, @bouhf
+//   correlation: @cc <method>, @dfcc <method>, @dfmp2, @fci, @ciphi
+// A method macro may be followed by a `begin ... end` block of local `@set`
+// lines; those options are automatically reset by ElemCo.jl after the call.
+
+const ELEMCO_METHODS = {
+  // First step of a calculation: the reference wavefunction.
+  reference: [
+    { id: 'dfhf',    label: 'DF-HF (RHF)',      macro: '@dfhf',    arg: null, groups: ['scf', 'int'] },
+    { id: 'dfuhf',   label: 'DF-UHF',           macro: '@dfuhf',   arg: null, groups: ['scf', 'int'] },
+    { id: 'dfmcscf', label: 'DF-MCSCF',         macro: '@dfmcscf', arg: null, groups: ['scf', 'wf'] },
+    { id: 'bohf',    label: 'BO-HF (FCIDUMP)',  macro: '@bohf',    arg: null, groups: ['scf'], advanced: true },
+    { id: 'bouhf',   label: 'BO-UHF (FCIDUMP)', macro: '@bouhf',   arg: null, groups: ['scf'], advanced: true },
+  ],
+  // Correlation / post-HF methods run on top of a reference.
+  correlation: [
+    { id: 'mp2',          label: 'MP2 (DF)',          macro: '@dfmp2', arg: null,           groups: ['cc'] },
+    { id: 'ccsd',         label: 'CCSD',              macro: '@cc',    arg: 'ccsd',          groups: ['cc'] },
+    { id: 'ccsd(t)',      label: 'CCSD(T)',           macro: '@cc',    arg: 'ccsd(t)',       groups: ['cc'] },
+    { id: 'dcsd',         label: 'DCSD',              macro: '@cc',    arg: 'dcsd',          groups: ['cc'] },
+    { id: 'ccsdt',        label: 'CCSDT',             macro: '@cc',    arg: 'ccsdt',         groups: ['cc'] },
+    { id: 'dc-ccsdt',     label: 'DC-CCSDT',          macro: '@cc',    arg: 'dc-ccsdt',      groups: ['cc'] },
+    { id: 'svd-dcsd',     label: 'SVD-DCSD (DF)',     macro: '@dfcc',  arg: 'svd-dcsd',      groups: ['cc'] },
+    { id: 'svd-dc-ccsdt', label: 'SVD-DC-CCSDT (DF)', macro: '@dfcc',  arg: 'svd-dc-ccsdt',  groups: ['cc'] },
+    { id: 'fci',          label: 'FCI',               macro: '@fci',   arg: null,            groups: ['fci', 'davidson'] },
+    { id: 'ciphi',        label: 'CIPHI / SCI',       macro: '@ciphi', arg: null,            groups: ['ciphi'] },
+  ],
+};
+
+// Option groups shown on the global "System & basis" card (apply to the whole
+// run, emitted as top-level @set). charge/ms2 have dedicated inputs, so they are
+// excluded from the wf group here to avoid duplication.
+const ELEMCO_GLOBAL_GROUPS = ['wf', 'int', 'print'];
+const ELEMCO_GLOBAL_EXCLUDE = { wf: ['charge', 'ms2'] };
+
+function elemcoMethodDef(category, id) {
+  const list = ELEMCO_METHODS[category];
+  if (!list) return null;
+  return list.find((m) => m.id === id) || null;
+}
+
+if (typeof window !== 'undefined') {
+  window.ELEMCO_METHODS = ELEMCO_METHODS;
+  window.ELEMCO_GLOBAL_GROUPS = ELEMCO_GLOBAL_GROUPS;
+  window.ELEMCO_GLOBAL_EXCLUDE = ELEMCO_GLOBAL_EXCLUDE;
+}

--- a/js/elemco-options-ui.js
+++ b/js/elemco-options-ui.js
@@ -180,7 +180,10 @@ function renderOptionsBrowserInto(mount, primaryGroups, bag, afterChange, opts) 
         groupsWrap.appendChild(sec);
     };
 
-    primary.forEach((g) => addGroup(g, true));
+    // Everything starts collapsed — some groups (e.g. cc has 45 options) are long,
+    // so a compact list of group headers is friendlier. The filter box and the
+    // group headers expand what the user actually wants.
+    primary.forEach((g) => addGroup(g, false));
     if (rest.length) {
         groupsWrap.appendChild(elcEl('div', { class: 'elemco-opt-divider' }, 'All option groups'));
         rest.forEach((g) => addGroup(g, false));

--- a/js/elemco-options-ui.js
+++ b/js/elemco-options-ui.js
@@ -1,0 +1,214 @@
+// ElemCo.jl options browser — renders a searchable, grouped, typed editor for
+// ElemCo.jl calculation options into a mount element. It reads the generated
+// metadata (window.ELEMCO_OPTIONS) for names/types/defaults/descriptions and
+// writes changed-from-default values into an option "bag" ({group:{name:value}})
+// owned by the caller (a step, or the global settings). Helpers such as
+// elcEl / optionMeta / setBagOption / formatJuliaValue live in js/elemco.js.
+
+// Unique across every widget so multiple simultaneously-open browsers (e.g. two
+// open step cards) never collide on a DOM id / label association.
+var elcWidgetSeq = 0;
+
+// Build the widget for a single option. Returns { el, id, reset }.
+function elcBuildWidget(group, meta, bag, onChange) {
+    const id = `elc-${group}-${meta.name}-${elcWidgetSeq++}`;
+    const eff = () => optionEffectiveValue(bag, group, meta.name);
+    const commit = (val) => { setBagOption(bag, group, meta.name, val); onChange(); };
+    let el, reset;
+
+    switch (meta.widget) {
+        case 'bool': {
+            el = elcEl('input', { type: 'checkbox', id });
+            el.checked = !!eff();
+            el.addEventListener('change', () => commit(el.checked));
+            reset = () => { el.checked = !!meta.default; };
+            break;
+        }
+        case 'int':
+        case 'float': {
+            el = elcEl('input', { type: 'number', id, class: 'elemco-opt-input' });
+            if (meta.widget === 'float') el.step = 'any';
+            el.value = eff();
+            el.addEventListener('input', () => {
+                const raw = el.value.trim();
+                if (raw === '') { commit(undefined); return; }
+                const num = meta.widget === 'int' ? parseInt(raw, 10) : parseFloat(raw);
+                if (!isNaN(num)) commit(num);
+            });
+            reset = () => { el.value = meta.default; };
+            break;
+        }
+        case 'symbol': {
+            if (meta.choices && meta.choices.length >= 2) {
+                el = elcEl('select', { id, class: 'elemco-opt-input' });
+                meta.choices.forEach((c) => el.appendChild(elcEl('option', { value: c }, c)));
+                el.value = eff();
+                el.addEventListener('change', () => commit(el.value));
+                reset = () => { el.value = meta.default; };
+            } else {
+                el = elcEl('input', { type: 'text', id, class: 'elemco-opt-input' });
+                el.value = eff() != null ? eff() : '';
+                el.addEventListener('input', () => { const v = el.value.trim(); commit(v === '' ? undefined : v); });
+                reset = () => { el.value = meta.default != null ? meta.default : ''; };
+            }
+            break;
+        }
+        case 'vector-int':
+        case 'vector-float': {
+            el = elcEl('input', { type: 'text', id, class: 'elemco-opt-input', placeholder: 'comma-separated' });
+            el.value = (eff() || []).join(', ');
+            el.addEventListener('input', () => {
+                const raw = el.value.trim();
+                if (raw === '') { commit([]); return; }
+                const parts = raw.split(',').map((s) => s.trim()).filter((s) => s !== '');
+                const nums = parts.map((p) => meta.widget === 'vector-int' ? parseInt(p, 10) : parseFloat(p));
+                if (!nums.some(isNaN)) commit(nums);
+            });
+            reset = () => { el.value = (meta.default || []).join(', '); };
+            break;
+        }
+        case 'string':
+        default: {
+            el = elcEl('input', { type: 'text', id, class: 'elemco-opt-input' });
+            el.value = eff() != null ? eff() : '';
+            el.addEventListener('input', () => { commit(el.value); });
+            reset = () => { el.value = meta.default != null ? meta.default : ''; };
+            break;
+        }
+    }
+    return { el, id, reset };
+}
+
+function elcOptionTooltip(meta) {
+    const def = meta.defaultDoc != null ? meta.defaultDoc : meta.defaultLiteral;
+    let t = meta.desc || '';
+    t += `\n\n(type ${meta.type}, default ${def})`;
+    return t.trim();
+}
+
+// One option row: name (hover = description), typed widget, default hint, reset.
+function elcBuildOptionRow(group, meta, bag, afterChange) {
+    const row = elcEl('div', { class: 'elemco-opt-row' });
+    row.dataset.hay = (meta.name + ' ' + (meta.desc || '')).toLowerCase();
+    const tip = elcOptionTooltip(meta);
+
+    const nameEl = elcEl('label', { class: 'elemco-opt-name', title: tip }, meta.name);
+    const widgetWrap = elcEl('span', { class: 'elemco-opt-widget' });
+    const defHint = elcEl('span', { class: 'elemco-opt-default', title: tip }, 'def: ' + (meta.defaultDoc != null ? meta.defaultDoc : meta.defaultLiteral));
+    const resetBtn = elcEl('button', { type: 'button', class: 'elemco-opt-reset', title: 'Reset to default' }, '×');
+
+    const syncModified = () => {
+        const mod = bagHasOption(bag, group, meta.name);
+        row.classList.toggle('elemco-opt-modified', mod);
+        resetBtn.style.display = mod ? '' : 'none';
+    };
+    const widget = elcBuildWidget(group, meta, bag, () => { syncModified(); afterChange(); });
+    widgetWrap.appendChild(widget.el);
+    nameEl.htmlFor = widget.id;
+    resetBtn.addEventListener('click', () => {
+        setBagOption(bag, group, meta.name, undefined);
+        widget.reset();
+        syncModified();
+        afterChange();
+    });
+
+    row.appendChild(nameEl);
+    row.appendChild(widgetWrap);
+    row.appendChild(defHint);
+    row.appendChild(resetBtn);
+    syncModified();
+    return row;
+}
+
+// Render the full browser: a filter box plus one collapsible section per option
+// group. Primary groups (relevant to the method) are expanded; the remaining
+// groups follow, collapsed, so every one of ElemCo.jl's options stays reachable.
+function renderOptionsBrowserInto(mount, primaryGroups, bag, afterChange, opts) {
+    opts = opts || {};
+    mount.innerHTML = '';
+    const data = (typeof window !== 'undefined' && window.ELEMCO_OPTIONS) || null;
+    if (!data) {
+        mount.appendChild(elcEl('div', { class: 'preview-note' }, 'ElemCo.jl options metadata not loaded.'));
+        return;
+    }
+    const exclude = opts.exclude || {};
+
+    const search = elcEl('input', { type: 'text', class: 'elemco-opt-search', placeholder: 'Filter options by name or description…' });
+    mount.appendChild(search);
+
+    const groupsWrap = elcEl('div', { class: 'elemco-opt-groups' });
+    mount.appendChild(groupsWrap);
+
+    const primary = (primaryGroups || []).filter((g) => data.groups[g]);
+    const rest = data.groupOrder.filter((g) => !primary.includes(g));
+
+    const addGroup = (group, expanded) => {
+        const gmeta = data.groups[group];
+        if (!gmeta) return;
+        const skip = exclude[group] || [];
+        const names = Object.keys(gmeta.fields).filter((n) => skip.indexOf(n) < 0);
+        if (names.length === 0) return;
+
+        const sec = elcEl('div', { class: 'elemco-opt-group' });
+        const body = elcEl('div', { class: 'elemco-opt-group-body' });
+        body.style.display = expanded ? 'block' : 'none';
+
+        const caret = elcEl('span', { class: 'elemco-caret' }, expanded ? '▾' : '▸');
+        const countBadge = elcEl('span', { class: 'elemco-opt-group-count' }, '');
+        const header = elcEl('button', { type: 'button', class: 'elemco-opt-group-head' }, [
+            caret,
+            elcEl('span', { class: 'elemco-opt-group-title', title: gmeta.summary || '' }, `${gmeta.label} (${group})`),
+            countBadge,
+        ]);
+        const updateCount = () => {
+            const c = names.filter((n) => bagHasOption(bag, group, n)).length;
+            countBadge.textContent = c ? `${c} set` : '';
+        };
+        header.addEventListener('click', () => {
+            const open = body.style.display === 'none';
+            body.style.display = open ? 'block' : 'none';
+            caret.textContent = open ? '▾' : '▸';
+        });
+
+        names.forEach((name) => {
+            body.appendChild(elcBuildOptionRow(group, gmeta.fields[name], bag, () => { updateCount(); afterChange(); }));
+        });
+        updateCount();
+
+        sec.appendChild(header);
+        sec.appendChild(body);
+        groupsWrap.appendChild(sec);
+    };
+
+    primary.forEach((g) => addGroup(g, true));
+    if (rest.length) {
+        groupsWrap.appendChild(elcEl('div', { class: 'elemco-opt-divider' }, 'All option groups'));
+        rest.forEach((g) => addGroup(g, false));
+    }
+
+    // Filtering: show only rows matching the query and auto-expand their groups.
+    search.addEventListener('input', () => {
+        const q = search.value.trim().toLowerCase();
+        groupsWrap.querySelectorAll('.elemco-opt-group').forEach((sec) => {
+            let anyVisible = false;
+            sec.querySelectorAll('.elemco-opt-row').forEach((row) => {
+                const vis = !q || row.dataset.hay.indexOf(q) >= 0;
+                row.style.display = vis ? '' : 'none';
+                if (vis) anyVisible = true;
+            });
+            const body = sec.querySelector('.elemco-opt-group-body');
+            const caret = sec.querySelector('.elemco-caret');
+            if (q) {
+                body.style.display = anyVisible ? 'block' : 'none';
+                if (caret) caret.textContent = anyVisible ? '▾' : '▸';
+                sec.style.display = anyVisible ? '' : 'none';
+            } else {
+                sec.style.display = '';
+            }
+        });
+    });
+}
+
+if (typeof window !== 'undefined') {
+    window.renderOptionsBrowserInto = renderOptionsBrowserInto;
+}

--- a/js/elemco-options.js
+++ b/js/elemco-options.js
@@ -1,0 +1,1594 @@
+// AUTO-GENERATED — do not edit by hand.
+// Source: ElemCo.jl src/infos/options.jl @ main
+// Regenerate: node scripts/parse-elemco-options.js [--ref <tag>]
+window.ELEMCO_OPTIONS = {
+  "sourceRepo": "fkfest/ElemCo.jl",
+  "sourceRef": "main",
+  "sourceUrl": "https://raw.githubusercontent.com/fkfest/ElemCo.jl/main/src/infos/options.jl",
+  "generated": "2026-07-18",
+  "groupOrder": [
+    "wf",
+    "scf",
+    "int",
+    "cc",
+    "eom",
+    "fci",
+    "ciphi",
+    "dmrg",
+    "cholesky",
+    "laplace",
+    "diis",
+    "davidson",
+    "print"
+  ],
+  "groups": {
+    "wf": {
+      "key": "wf",
+      "struct": "WfOptions",
+      "label": "Wavefunction/orbitals",
+      "summary": "Wavefunction options (WfOptions).",
+      "fields": {
+        "ms2": {
+          "name": "ms2",
+          "type": "Int",
+          "widget": "int",
+          "default": -1,
+          "defaultLiteral": "-1",
+          "defaultDoc": "-1",
+          "desc": "spin magnetic quantum number times two (2×mₛ) of the system."
+        },
+        "nelec": {
+          "name": "nelec",
+          "type": "Int",
+          "widget": "int",
+          "default": -1,
+          "defaultLiteral": "-1",
+          "defaultDoc": "-1",
+          "desc": "number of electrons. If < 0, the number of electrons is read from the FCIDump file or guessed for the neutral system."
+        },
+        "charge": {
+          "name": "charge",
+          "type": "Int",
+          "widget": "int",
+          "default": 0,
+          "defaultLiteral": "0",
+          "defaultDoc": "0",
+          "desc": "charge of the system (relative to nelec/FCIDump/neutral system!)."
+        },
+        "dump": {
+          "name": "dump",
+          "type": "String",
+          "widget": "string",
+          "default": "wf.h5",
+          "defaultLiteral": "\"wf.h5\"",
+          "defaultDoc": "\"wf.h5\"",
+          "desc": "filename for wavefunction dump (stored in TREXIO format)."
+        },
+        "store": {
+          "name": "store",
+          "type": "String",
+          "widget": "string",
+          "default": "",
+          "defaultLiteral": "\"\"",
+          "defaultDoc": "\"\"",
+          "desc": "filename to store the output wavefunction dump (stored in TREXIO format). If empty, dump will be used."
+        },
+        "start": {
+          "name": "start",
+          "type": "String",
+          "widget": "string",
+          "default": "",
+          "defaultLiteral": "\"\"",
+          "defaultDoc": "\"\"",
+          "desc": "filename to read starting amplitudes from (TREXIO format). If empty, amplitudes are read from dump. If provided, amplitudes (and MOs/basis) are read from this file and projected to the current MO basis."
+        },
+        "npositron": {
+          "name": "npositron",
+          "type": "Int",
+          "widget": "int",
+          "default": 0,
+          "defaultLiteral": "0",
+          "defaultDoc": "0",
+          "desc": "Number of positrons."
+        },
+        "core": {
+          "name": "core",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "large",
+          "defaultLiteral": ":large",
+          "defaultDoc": ":large",
+          "desc": "core type for frozen-core approximation: - :none no frozen-core approximation, - :small semi-core orbitals correlated, - :large semi-core orbitals frozen.",
+          "choices": [
+            "large",
+            "none",
+            "small"
+          ]
+        },
+        "freeze_nocc": {
+          "name": "freeze_nocc",
+          "type": "Int",
+          "widget": "int",
+          "default": -1,
+          "defaultLiteral": "-1",
+          "defaultDoc": "-1",
+          "desc": "number of occupied (core) orbitals to freeze (overwrites core)."
+        },
+        "freeze_nvirt": {
+          "name": "freeze_nvirt",
+          "type": "Int",
+          "widget": "int",
+          "default": 0,
+          "defaultLiteral": "0",
+          "defaultDoc": "0",
+          "desc": "number of virtual (highest) orbitals to freeze."
+        },
+        "occa": {
+          "name": "occa",
+          "type": "String",
+          "widget": "string",
+          "default": "-",
+          "defaultLiteral": "\"-\"",
+          "defaultDoc": "\"-\"",
+          "desc": "occupied α (or closed-shell) orbitals. The occupation strings can be given as a + separated list, e.g. occa = 1+2+3 or equivalently 1-3. Additionally, the spatial symmetry of the orbitals can be specified with the syntax orb.sym, e.g. occa = \"-5.1+-2.2+-4.3\"."
+        },
+        "occb": {
+          "name": "occb",
+          "type": "String",
+          "widget": "string",
+          "default": "-",
+          "defaultLiteral": "\"-\"",
+          "defaultDoc": "\"-\"",
+          "desc": "occupied β orbitals. If occb::String is empty, the occupied β orbitals are the same as the occupied α orbitals (closed-shell case)."
+        },
+        "active": {
+          "name": "active",
+          "type": "String",
+          "widget": "string",
+          "default": "-",
+          "defaultLiteral": "\"-\"",
+          "defaultDoc": "\"-\"",
+          "desc": "active space. The active space is defined by the occupation string (cf. occa) or in the (#elec, #orb) format."
+        },
+        "ignore_error": {
+          "name": "ignore_error",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "ignore various errors in sanity checks."
+        },
+        "print_nlargest": {
+          "name": "print_nlargest",
+          "type": "Int",
+          "widget": "int",
+          "default": 5,
+          "defaultLiteral": "5",
+          "defaultDoc": "5",
+          "desc": "number of largest orbitals to print."
+        },
+        "print_thr": {
+          "name": "print_thr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.1,
+          "defaultLiteral": "0.1",
+          "defaultDoc": "0.1",
+          "desc": "threshold for orbital coefficients to print."
+        }
+      }
+    },
+    "scf": {
+      "key": "scf",
+      "struct": "ScfOptions",
+      "label": "SCF calculation",
+      "summary": "SCF options (ScfOptions).",
+      "fields": {
+        "thr": {
+          "name": "thr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-10,
+          "defaultLiteral": "1.e-10",
+          "defaultDoc": "1.e-10",
+          "desc": "convergence threshold."
+        },
+        "thren": {
+          "name": "thren",
+          "type": "Float64",
+          "widget": "float",
+          "default": -1,
+          "defaultLiteral": "-1.0",
+          "defaultDoc": "sqrt(thr)*0.1",
+          "desc": "energy convergence threshold (used additionally to thr)."
+        },
+        "maxit": {
+          "name": "maxit",
+          "type": "Int",
+          "widget": "int",
+          "default": 50,
+          "defaultLiteral": "50",
+          "defaultDoc": "50",
+          "desc": "maximum number of iterations."
+        },
+        "imagtol": {
+          "name": "imagtol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-8,
+          "defaultLiteral": "1.e-8",
+          "defaultDoc": "1.e-8",
+          "desc": "tolerance for imaginary part of MO coefs (for biorthogonal)."
+        },
+        "direct": {
+          "name": "direct",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "direct calculation without storing integrals."
+        },
+        "guess": {
+          "name": "guess",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "SAD",
+          "defaultLiteral": ":SAD",
+          "defaultDoc": ":SAD",
+          "desc": "orbital guess: - :HCORE from core Hamiltonian - :SAD from atomic densities - :GWH not implemented yet - :ORB from previous orbitals stored in dump file WfOptions.dump",
+          "choices": [
+            "SAD",
+            "HCORE",
+            "GWH",
+            "ORB"
+          ]
+        },
+        "guess_pos": {
+          "name": "guess_pos",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "HCORE",
+          "defaultLiteral": ":HCORE",
+          "defaultDoc": ":HCORE",
+          "desc": "positron orbital guess. Only :HCORE is implemented.",
+          "choices": [
+            "HCORE"
+          ]
+        },
+        "bisecdamp": {
+          "name": "bisecdamp",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.5,
+          "defaultLiteral": "0.5",
+          "defaultDoc": "0.5",
+          "desc": "damping factor for bisection search in augmented Hessian tuning."
+        },
+        "maxit4lambda": {
+          "name": "maxit4lambda",
+          "type": "Int",
+          "widget": "int",
+          "default": 3,
+          "defaultLiteral": "3",
+          "defaultDoc": "3",
+          "desc": "maximum number of iterations for searching for lambda value to get a reasonalbe guess within trust radius for MCSCF."
+        },
+        "HessianType": {
+          "name": "HessianType",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "SO_SCI",
+          "defaultLiteral": ":SO_SCI",
+          "defaultDoc": ":SO_SCI",
+          "desc": "Hessian Type for MCSCF: - :SO Second Order Approximation - :SCI Super CI - :SO_SCI Second Order Approximation combing Super CI",
+          "choices": [
+            "SO_SCI",
+            "SO",
+            "SCI"
+          ]
+        },
+        "initVecType": {
+          "name": "initVecType",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "GRADIENT_SETPLUS",
+          "defaultLiteral": ":GRADIENT_SETPLUS",
+          "defaultDoc": ":GRADIENT_SETPLUS",
+          "desc": "Initial Vectors Type for MCSCF: - :INHERIT from last macro/micro iterations - :GRADIENT_SET b0 as [1,0,0,...], b1 as gradient - :GRADIENT_SETPLUS b0, b1 as GRADIENT_SET, b2 as zeros but 1 at the first closed-virtual rotation parameter",
+          "choices": [
+            "GRADIENT_SETPLUS",
+            "INHERIT",
+            "GRADIENT_SET"
+          ]
+        },
+        "temperature_guess": {
+          "name": "temperature_guess",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0,
+          "defaultLiteral": "0.0",
+          "defaultDoc": "0.0",
+          "desc": "Fermi-Dirac temperature for starting guess (at the moment works only for BO-HF)."
+        },
+        "gamaDavScale": {
+          "name": "gamaDavScale",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.1,
+          "defaultLiteral": "0.1",
+          "defaultDoc": "0.1",
+          "desc": "the threshold of davidson convergence residure norm scaled to norm of g the gradient, for MCSCF."
+        },
+        "SO_SCI_origin": {
+          "name": "SO_SCI_origin",
+          "type": "(bool)",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "if true then use the original SO_SCI Hessian"
+        },
+        "trustScale": {
+          "name": "trustScale",
+          "type": "(float)",
+          "widget": "float",
+          "default": 0.8,
+          "defaultLiteral": "0.8",
+          "defaultDoc": "0.8",
+          "desc": "the trust region of sqrt(sum(x.^2)) should be [trustScale,1] * trust"
+        },
+        "lambdaMax": {
+          "name": "lambdaMax",
+          "type": "(float)",
+          "widget": "float",
+          "default": 1000,
+          "defaultLiteral": "1000.0",
+          "defaultDoc": "1000.0",
+          "desc": "the maximum number of lambda when adjusting the level shift"
+        },
+        "davErrorMin": {
+          "name": "davErrorMin",
+          "type": "(float)",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1e-6",
+          "defaultDoc": "1e-6",
+          "desc": "the minmum convergence threshold for davidson algorithm"
+        },
+        "iniDavMatSize": {
+          "name": "iniDavMatSize",
+          "type": "(int)",
+          "widget": "int",
+          "default": 200,
+          "defaultLiteral": "200",
+          "defaultDoc": "200",
+          "desc": "the size of initial Davidson projected matrix"
+        },
+        "trustShrinkScale": {
+          "name": "trustShrinkScale",
+          "type": "(float)",
+          "widget": "float",
+          "default": 0.7,
+          "defaultLiteral": "0.7",
+          "defaultDoc": "0.7",
+          "desc": "the shrink scale of trust region"
+        },
+        "trustExpandScale": {
+          "name": "trustExpandScale",
+          "type": "(float)",
+          "widget": "float",
+          "default": 1.2,
+          "defaultLiteral": "1.2",
+          "defaultDoc": "1.2",
+          "desc": "the expand scale of trust region"
+        },
+        "enerQuotientLowerBound": {
+          "name": "enerQuotientLowerBound",
+          "type": "(float)",
+          "widget": "float",
+          "default": 0.25,
+          "defaultLiteral": "0.25",
+          "defaultDoc": "0.25",
+          "desc": "when energy quotient is lower than this value, the trust value should be smaller"
+        },
+        "enerQuotientUpperBound": {
+          "name": "enerQuotientUpperBound",
+          "type": "(float)",
+          "widget": "float",
+          "default": 0.75,
+          "defaultLiteral": "0.75",
+          "defaultDoc": "0.75",
+          "desc": "when energy quotient is higher than this value, the trust value should be larger"
+        },
+        "pseudo": {
+          "name": "pseudo",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "Generate pseudo-canonical basis instead of solving the SCF problem, i.e., build and block-diagonalize the Fock matrix without changing the Fermi level. At the moment, it works only for BO-HF."
+        }
+      }
+    },
+    "int": {
+      "key": "int",
+      "struct": "IntOptions",
+      "label": "Integral calculation",
+      "summary": "Integral options (IntOptions).",
+      "fields": {
+        "df": {
+          "name": "df",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "use density-fitted integrals."
+        },
+        "fcidump": {
+          "name": "fcidump",
+          "type": "String",
+          "widget": "string",
+          "default": "",
+          "defaultLiteral": "\"\"",
+          "defaultDoc": "\"\"",
+          "desc": "store integrals in FCIDump format."
+        },
+        "cartesian": {
+          "name": "cartesian",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "use Cartesian subshells instead of Spherical."
+        },
+        "target_batch_length": {
+          "name": "target_batch_length",
+          "type": "Int",
+          "widget": "int",
+          "default": 1000,
+          "defaultLiteral": "1000",
+          "defaultDoc": "1000",
+          "desc": "target batch length for the integral transformation."
+        },
+        "use_fallback_basis": {
+          "name": "use_fallback_basis",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "use fallback basis sets (in case of missing basis sets)."
+        },
+        "check_fit_basis": {
+          "name": "check_fit_basis",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "sanity check of the fit basis (i.e., that it's not an AO basis)"
+        },
+        "split_ashells": {
+          "name": "split_ashells",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "split independent angular shells (important for efficiency)."
+        }
+      }
+    },
+    "cc": {
+      "key": "cc",
+      "struct": "CcOptions",
+      "label": "Coupled-Cluster calculation",
+      "summary": "Coupled-Cluster options (CcOptions).",
+      "fields": {
+        "thr": {
+          "name": "thr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-10,
+          "defaultLiteral": "1.e-10",
+          "defaultDoc": "1.e-10",
+          "desc": "convergence threshold."
+        },
+        "conven": {
+          "name": "conven",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.1,
+          "defaultLiteral": "0.1",
+          "defaultDoc": "0.1",
+          "desc": "energy convergence factor. The energy convergence threshold is sqrt(thr) * conven."
+        },
+        "maxit": {
+          "name": "maxit",
+          "type": "Int",
+          "widget": "int",
+          "default": 50,
+          "defaultLiteral": "50",
+          "defaultDoc": "50",
+          "desc": "maximum number of iterations."
+        },
+        "shifts": {
+          "name": "shifts",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.15,
+          "defaultLiteral": "0.15",
+          "defaultDoc": "0.15",
+          "desc": "level shift for singles."
+        },
+        "shiftp": {
+          "name": "shiftp",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.2,
+          "defaultLiteral": "0.2",
+          "defaultDoc": "0.2",
+          "desc": "level shift for doubles."
+        },
+        "shiftt": {
+          "name": "shiftt",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.2,
+          "defaultLiteral": "0.2",
+          "defaultDoc": "0.2",
+          "desc": "level shift for triples."
+        },
+        "properties": {
+          "name": "properties",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculate properties."
+        },
+        "ampsvdtol": {
+          "name": "ampsvdtol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.00001,
+          "defaultLiteral": "1.e-5",
+          "defaultDoc": "1.e-5",
+          "desc": "amplitude decomposition threshold."
+        },
+        "ampsvdfac": {
+          "name": "ampsvdfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.01,
+          "defaultLiteral": "1.e-2",
+          "defaultDoc": "1.e-2",
+          "desc": "tightening amplitude decomposition factor (for the two-step decomposition)."
+        },
+        "use_kext": {
+          "name": "use_kext",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "use kext for doubles residual."
+        },
+        "calc_d_vvvv": {
+          "name": "calc_d_vvvv",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculate dressed <vv|vv>."
+        },
+        "calc_d_vvvo": {
+          "name": "calc_d_vvvo",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculate dressed <vv|vo>."
+        },
+        "calc_d_vovv": {
+          "name": "calc_d_vovv",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculate dressed <vo|vv>."
+        },
+        "calc_d_vvoo": {
+          "name": "calc_d_vvoo",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculate dressed <vv|oo>."
+        },
+        "fock_diag_thr": {
+          "name": "fock_diag_thr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1.e-6",
+          "defaultDoc": "1.e-6",
+          "desc": "threshold for checking Fock matrix diagonality in (T). If negative, no check is performed."
+        },
+        "usedf": {
+          "name": "usedf",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "use density fitting in SVD-DC-CCSDT instead of the integral decomposition."
+        },
+        "usecholesky": {
+          "name": "usecholesky",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "use Cholesky decomposition in SVD-DC-CCSDT instead of SVD in the integral decomposition."
+        },
+        "calc_t3_for_decomposition": {
+          "name": "calc_t3_for_decomposition",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculate (T) for decomposition."
+        },
+        "skip_pert_t": {
+          "name": "skip_pert_t",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "skip (T) calculation in SVD-DC-CCSDT."
+        },
+        "project_t3iii": {
+          "name": "project_t3iii",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "project out the T^iii contribution from the density matrix in decomposition in SVD-DC-CCSDT."
+        },
+        "project_voXL": {
+          "name": "project_voXL",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "calculated V_{aX}^{iL} in SVD-DC-CCSDT using a projection to the X space as V_{XZ}^{L} U^{iZ}_{a}. This is an additional approximation, which reduces the scaling of the most expensive steps and is useful for large systems."
+        },
+        "space4voXL": {
+          "name": "space4voXL",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "combined",
+          "defaultLiteral": ":combined",
+          "defaultDoc": ":combined",
+          "desc": "type of space for project_voXL. Possible values are :combined, :symcombined, :triples, :full.",
+          "choices": [
+            "combined",
+            "symcombined",
+            "triples",
+            "full"
+          ]
+        },
+        "deco_ishiftp": {
+          "name": "deco_ishiftp",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0,
+          "defaultLiteral": "0.0",
+          "defaultDoc": "0.0",
+          "desc": "imaginary shift for denominator in doubles decomposition."
+        },
+        "deco_ishiftt": {
+          "name": "deco_ishiftt",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0,
+          "defaultLiteral": "0.0",
+          "defaultDoc": "0.0",
+          "desc": "imaginary shift for denominator in triples decomposition."
+        },
+        "use_projx": {
+          "name": "use_projx",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "use a projected exchange for contravariant doubles amplitudes in SVD-DCSD, \\\\tilde T_{XY} = U^{†a}_{iX} U^{†b}_{jY} \\\\tilde T^{ij}_{ab}."
+        },
+        "use_full_t2": {
+          "name": "use_full_t2",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "use full doubles amplitudes in SVD-DCSD. The decomposition is used only for N^6 scaling terms."
+        },
+        "project_vovo_t2": {
+          "name": "project_vovo_t2",
+          "type": "Int",
+          "widget": "int",
+          "default": 2,
+          "defaultLiteral": "2",
+          "defaultDoc": "2",
+          "desc": "what to project in v_{ak}^{ci} T^{kj}_{cb} in SVD-DCSD: 0: both, 1: amplitudes, 2: residual, 3: robust fit."
+        },
+        "decompose_full_doubles": {
+          "name": "decompose_full_doubles",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "decompose full doubles amplitudes in SVD-DCSD (slow)."
+        },
+        "start": {
+          "name": "start",
+          "type": "String",
+          "widget": "string",
+          "default": "cc_amplitudes",
+          "defaultLiteral": "\"cc_amplitudes\"",
+          "defaultDoc": "\"cc_amplitudes\"",
+          "desc": "main part of filename for start amplitudes. For example, the singles amplitudes are read from start*\"_1\"."
+        },
+        "save": {
+          "name": "save",
+          "type": "String",
+          "widget": "string",
+          "default": "cc_amplitudes",
+          "defaultLiteral": "\"cc_amplitudes\"",
+          "defaultDoc": "\"cc_amplitudes\"",
+          "desc": "main part of filename to save amplitudes. For example, the singles amplitudes are saved to save*\"_1\"."
+        },
+        "start_lm": {
+          "name": "start_lm",
+          "type": "String",
+          "widget": "string",
+          "default": "cc_multipliers",
+          "defaultLiteral": "\"cc_multipliers\"",
+          "defaultDoc": "\"cc_multipliers\"",
+          "desc": "main part of filename for start Lagrange multipliers. For example, the singles Lagrange multipliers are read from start_lm*\"_1\"."
+        },
+        "save_lm": {
+          "name": "save_lm",
+          "type": "String",
+          "widget": "string",
+          "default": "cc_multipliers",
+          "defaultLiteral": "\"cc_multipliers\"",
+          "defaultDoc": "\"cc_multipliers\"",
+          "desc": "main part of filename to save Lagrange multipliers. For example, the singles Lagrange multipliers are saved to save_lm*\"_1\"."
+        },
+        "nomp2": {
+          "name": "nomp2",
+          "type": "Int",
+          "widget": "int",
+          "default": 0,
+          "defaultLiteral": "0",
+          "defaultDoc": "0",
+          "desc": "Don't use MP2 amplitudes as starting guess for the CC amplitudes."
+        },
+        "mp2_ssfac": {
+          "name": "mp2_ssfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.33,
+          "defaultLiteral": "0.33",
+          "defaultDoc": "0.33",
+          "desc": "Factor for same-spin component in SCS-MP2."
+        },
+        "mp2_osfac": {
+          "name": "mp2_osfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1.2,
+          "defaultLiteral": "1.2",
+          "defaultDoc": "1.2",
+          "desc": "Factor for opposite-spin component in SCS-MP2."
+        },
+        "mp2_ofac": {
+          "name": "mp2_ofac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0,
+          "defaultLiteral": "0.0",
+          "defaultDoc": "0.0",
+          "desc": "Factor for open-shell component in SCS-MP2."
+        },
+        "mp2_sosfac": {
+          "name": "mp2_sosfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1.3,
+          "defaultLiteral": "1.3",
+          "defaultDoc": "1.3",
+          "desc": "Factor for opposite-spin component in SOS-MP2."
+        },
+        "ccsd_ssfac": {
+          "name": "ccsd_ssfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1.13,
+          "defaultLiteral": "1.13",
+          "defaultDoc": "1.13",
+          "desc": "Factor for same-spin component in SCS-CCSD."
+        },
+        "ccsd_osfac": {
+          "name": "ccsd_osfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1.27,
+          "defaultLiteral": "1.27",
+          "defaultDoc": "1.27",
+          "desc": "Factor for opposite-spin component in SCS-CCSD."
+        },
+        "ccsd_ofac": {
+          "name": "ccsd_ofac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0,
+          "defaultLiteral": "0.0",
+          "defaultDoc": "0.0",
+          "desc": "Factor for open-shell component in SCS-CCSD."
+        },
+        "dcsd_ssfac": {
+          "name": "dcsd_ssfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1.15,
+          "defaultLiteral": "1.15",
+          "defaultDoc": "1.15",
+          "desc": "Factor for same-spin component in SCS-DCSD."
+        },
+        "dcsd_osfac": {
+          "name": "dcsd_osfac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1.05,
+          "defaultLiteral": "1.05",
+          "defaultDoc": "1.05",
+          "desc": "Factor for opposite-spin component in SCS-DCSD."
+        },
+        "dcsd_ofac": {
+          "name": "dcsd_ofac",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.15,
+          "defaultLiteral": "0.15",
+          "defaultDoc": "0.15",
+          "desc": "Factor for open-shell component in SCS-DCSD."
+        },
+        "ignore_error": {
+          "name": "ignore_error",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "ignore various errors in sanity checks."
+        },
+        "keepOQVorbitals": {
+          "name": "keepOQVorbitals",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "keep the orbitals after rotations over iterations of orbital optimizations in the OQV-CCD/DCD."
+        }
+      }
+    },
+    "eom": {
+      "key": "eom",
+      "struct": "EomOptions",
+      "label": "Excited states calculation",
+      "summary": "EOM options (EomOptions).",
+      "fields": {
+        "thr": {
+          "name": "thr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1.e-6",
+          "defaultDoc": "1.e-6",
+          "desc": "convergence threshold."
+        },
+        "nstates": {
+          "name": "nstates",
+          "type": "Int",
+          "widget": "int",
+          "default": 1,
+          "defaultLiteral": "1",
+          "defaultDoc": "1",
+          "desc": "number of states to calculate."
+        },
+        "maxit": {
+          "name": "maxit",
+          "type": "Int",
+          "widget": "int",
+          "default": 50,
+          "defaultLiteral": "50",
+          "defaultDoc": "50",
+          "desc": "maximum number of iterations."
+        },
+        "shift": {
+          "name": "shift",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0,
+          "defaultLiteral": "0.0",
+          "defaultDoc": "0.0",
+          "desc": "level shift for the Davidson algorithm."
+        },
+        "start": {
+          "name": "start",
+          "type": "String",
+          "widget": "string",
+          "default": "eigenvectors",
+          "defaultLiteral": "\"eigenvectors\"",
+          "defaultDoc": "\"eigenvectors\"",
+          "desc": "main part of filename for start eigenvectors. For example, the singles eigenvectors for state 2 are read from start*\"_1^2\"."
+        },
+        "save": {
+          "name": "save",
+          "type": "String",
+          "widget": "string",
+          "default": "eigenvectors",
+          "defaultLiteral": "\"eigenvectors\"",
+          "defaultDoc": "\"eigenvectors\"",
+          "desc": "main part of filename to save eigenvectors. For example, the singles eigenvectors for state 2 are saved to save*\"_1^2\"."
+        },
+        "ampsvdtol": {
+          "name": "ampsvdtol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.00001,
+          "defaultLiteral": "1.e-5",
+          "defaultDoc": "1.e-5",
+          "desc": "amplitude decomposition threshold."
+        },
+        "svd_space_option": {
+          "name": "svd_space_option",
+          "type": "Int",
+          "widget": "int",
+          "default": 6,
+          "defaultLiteral": "6",
+          "defaultDoc": "6",
+          "desc": "Choice how excited state SVD basis is generated. Default is decomposition of full U2."
+        }
+      }
+    },
+    "fci": {
+      "key": "fci",
+      "struct": "FCIOptions",
+      "label": "FCI calculations",
+      "summary": "FCI options (FCIOptions).",
+      "fields": {
+        "max_iter": {
+          "name": "max_iter",
+          "type": "Int",
+          "widget": "int",
+          "default": 50,
+          "defaultLiteral": "50",
+          "defaultDoc": "50",
+          "desc": "Maximum number of iterations"
+        },
+        "shift": {
+          "name": "shift",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.1,
+          "defaultLiteral": "0.1",
+          "defaultDoc": "0.1",
+          "desc": "Level shift to improve convergence"
+        },
+        "conv_tol": {
+          "name": "conv_tol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-8,
+          "defaultLiteral": "1e-8",
+          "defaultDoc": "1e-8",
+          "desc": "Convergence tolerance for energy"
+        },
+        "res_tol": {
+          "name": "res_tol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1e-6",
+          "defaultDoc": "1e-6",
+          "desc": "Convergence tolerance for residual norm"
+        },
+        "nstates": {
+          "name": "nstates",
+          "type": "Int",
+          "widget": "int",
+          "default": 1,
+          "defaultLiteral": "1",
+          "defaultDoc": "1",
+          "desc": "Number of states to compute"
+        },
+        "n_guess": {
+          "name": "n_guess",
+          "type": "Int",
+          "widget": "int",
+          "default": 2,
+          "defaultLiteral": "2",
+          "defaultDoc": "2",
+          "desc": "Number of guess vectors to use"
+        },
+        "subspace_size": {
+          "name": "subspace_size",
+          "type": "Int",
+          "widget": "int",
+          "default": 10,
+          "defaultLiteral": "10",
+          "defaultDoc": "10",
+          "desc": "Maximum subspace size for Davidson diagonalization"
+        },
+        "compute_rdms": {
+          "name": "compute_rdms",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "Compute 1-RDMs after convergence"
+        },
+        "compute_2rdm": {
+          "name": "compute_2rdm",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "Compute 2-RDM after convergence"
+        },
+        "jacobi_davidson": {
+          "name": "jacobi_davidson",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "Use projected Jacobi-Davidson correction (prevents linear dependency)"
+        },
+        "max_pspace_size": {
+          "name": "max_pspace_size",
+          "type": "Int",
+          "widget": "int",
+          "default": 1000,
+          "defaultLiteral": "1000",
+          "defaultDoc": "1000",
+          "desc": "Maximum P-space size (typically 100-1000)"
+        },
+        "pspace_selection_method": {
+          "name": "pspace_selection_method",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "hybrid",
+          "defaultLiteral": ":hybrid",
+          "defaultDoc": ":hybrid",
+          "desc": "Selection method for P-space generation (:hybrid, :excitation, :energy, :ciphi)",
+          "choices": [
+            "hybrid",
+            "excitation",
+            "energy",
+            "ciphi"
+          ]
+        },
+        "max_pspace_excitation": {
+          "name": "max_pspace_excitation",
+          "type": "Int",
+          "widget": "int",
+          "default": 4,
+          "defaultLiteral": "4",
+          "defaultDoc": "4",
+          "desc": "Maximum excitation level from HF reference (0=HF, 1=S, 2=SD, etc.)"
+        },
+        "pspace_energy_threshold": {
+          "name": "pspace_energy_threshold",
+          "type": "Float64",
+          "widget": "float",
+          "default": 5,
+          "defaultLiteral": "5.0",
+          "defaultDoc": "5.0",
+          "desc": "Energy cutoff for determinant inclusion"
+        },
+        "pspace_ciphi_epsilon": {
+          "name": "pspace_ciphi_epsilon",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.001,
+          "defaultLiteral": "1e-3",
+          "defaultDoc": "1e-3",
+          "desc": "CIPHI selection threshold (epsilon_h) for P-space generation"
+        },
+        "print_level": {
+          "name": "print_level",
+          "type": "Int",
+          "widget": "int",
+          "default": 1,
+          "defaultLiteral": "1",
+          "defaultDoc": "1",
+          "desc": "Level of printed output (0=none, 1=some, 2=detailed)"
+        },
+        "thr_negligible": {
+          "name": "thr_negligible",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-12,
+          "defaultLiteral": "1e-12",
+          "defaultDoc": "1e-12",
+          "desc": "Threshold for neglecting small Hamiltonian (etc) elements"
+        }
+      }
+    },
+    "ciphi": {
+      "key": "ciphi",
+      "struct": "CIPHIOptions",
+      "label": "CIΦ (CIPHI) calculations - Selected CI via Perturbation, Heat-Bath and Iterations",
+      "summary": "CIPHI options (CIPHIOptions).",
+      "fields": {
+        "target_selection": {
+          "name": "target_selection",
+          "type": "Int",
+          "widget": "int",
+          "default": 1000000,
+          "defaultLiteral": "1_000_000",
+          "defaultDoc": "1_000_000",
+          "desc": "Target (i.e., maximum) number of determinants to select"
+        },
+        "epsilon": {
+          "name": "epsilon",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.0003,
+          "defaultLiteral": "3e-4",
+          "defaultDoc": "3e-4",
+          "desc": "Selection threshold"
+        },
+        "epsilon_h": {
+          "name": "epsilon_h",
+          "type": "Float64",
+          "widget": "float",
+          "default": -1,
+          "defaultLiteral": "-1.0",
+          "defaultDoc": "epsilon/10",
+          "desc": "CIPHI selection threshold. Note that a smaller value improves also the quality of the PT2 correction."
+        },
+        "epsilon_c": {
+          "name": "epsilon_c",
+          "type": "Float64",
+          "widget": "float",
+          "default": -1,
+          "defaultLiteral": "-1.0",
+          "defaultDoc": "epsilon_h",
+          "desc": "instantaneous PT selection threshold."
+        },
+        "epsilon_p": {
+          "name": "epsilon_p",
+          "type": "Float64",
+          "widget": "float",
+          "default": -1,
+          "defaultLiteral": "-1.0",
+          "defaultDoc": "epsilon",
+          "desc": "CIPSI selection threshold"
+        },
+        "tol": {
+          "name": "tol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1e-6",
+          "defaultDoc": "1e-6",
+          "desc": "Energy convergence threshold"
+        },
+        "res_tol": {
+          "name": "res_tol",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1e-6",
+          "defaultDoc": "1e-6",
+          "desc": "Convergence tolerance for residual norm"
+        },
+        "max_iter": {
+          "name": "max_iter",
+          "type": "Int",
+          "widget": "int",
+          "default": 50,
+          "defaultLiteral": "50",
+          "defaultDoc": "50",
+          "desc": "Maximum CIPHI iterations"
+        },
+        "shift": {
+          "name": "shift",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.1,
+          "defaultLiteral": "0.1",
+          "defaultDoc": "0.1",
+          "desc": "Level shift to improve convergence"
+        },
+        "verbose": {
+          "name": "verbose",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "Print iteration details"
+        },
+        "compute_pt2": {
+          "name": "compute_pt2",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "Compute PT2 perturbative correction"
+        },
+        "epsilon_pt2": {
+          "name": "epsilon_pt2",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1e-6",
+          "defaultDoc": "1e-6",
+          "desc": "Threshold for PT2 contributions"
+        },
+        "epsilon_pt2_c": {
+          "name": "epsilon_pt2_c",
+          "type": "Float64",
+          "widget": "float",
+          "default": -1,
+          "defaultLiteral": "-1.0",
+          "defaultDoc": "epsilon_pt2/2",
+          "desc": "Threshold for instantaneous PT2 contributions"
+        },
+        "sort4pt2": {
+          "name": "sort4pt2",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "Sort determinants by absolute value of coefficients before computing PT2 correction"
+        },
+        "pt2_shift": {
+          "name": "pt2_shift",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-10,
+          "defaultLiteral": "1e-10",
+          "defaultDoc": "1e-10",
+          "desc": "Small value added to denominators in PT2 to avoid divergences"
+        },
+        "use_mp2": {
+          "name": "use_mp2",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "Use uncontracted MP2 instead of EN2"
+        },
+        "renorm_pt2": {
+          "name": "renorm_pt2",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "Use renormalized PT2 correction: E_PT2 → E_PT2 / (1 + T2^2) with T2 being the PT2 amplitudes."
+        },
+        "nstates": {
+          "name": "nstates",
+          "type": "Int",
+          "widget": "int",
+          "default": 1,
+          "defaultLiteral": "1",
+          "defaultDoc": "1",
+          "desc": "Number of states to compute (default: 1 = ground state only)"
+        },
+        "nsteps": {
+          "name": "nsteps",
+          "type": "Int",
+          "widget": "int",
+          "default": 2,
+          "defaultLiteral": "2",
+          "defaultDoc": "2",
+          "desc": "Number of steps in the iterative CIPHI selection (if > 1, the selection process is repeated after convergence)"
+        },
+        "use_small_space_guess": {
+          "name": "use_small_space_guess",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "Use small-space Hamiltonian for initial guess"
+        },
+        "small_space_size": {
+          "name": "small_space_size",
+          "type": "Int",
+          "widget": "int",
+          "default": 0,
+          "defaultLiteral": "0",
+          "defaultDoc": "0",
+          "desc": "Size of small space (0 = auto: max(100, target÷10, 5*n_roots))"
+        },
+        "small_space_method": {
+          "name": "small_space_method",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "hybrid",
+          "defaultLiteral": ":hybrid",
+          "defaultDoc": ":hybrid",
+          "desc": "Selection method: :hybrid (energy + excitation)",
+          "choices": [
+            "hybrid"
+          ]
+        },
+        "print_level": {
+          "name": "print_level",
+          "type": "Int",
+          "widget": "int",
+          "default": 1,
+          "defaultLiteral": "1",
+          "defaultDoc": "1",
+          "desc": "Level of printed output (0=none, 1=some, 2=detailed)"
+        },
+        "pt2_only": {
+          "name": "pt2_only",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "Skip variational CIPHI iterations and only compute PT2 correction (use with restart)"
+        },
+        "thr_negligible": {
+          "name": "thr_negligible",
+          "type": "Float64",
+          "widget": "float",
+          "default": 1e-10,
+          "defaultLiteral": "1e-10",
+          "defaultDoc": "1e-10",
+          "desc": "Threshold for neglecting small Hamiltonian (etc) elements"
+        }
+      }
+    },
+    "dmrg": {
+      "key": "dmrg",
+      "struct": "DmrgOptions",
+      "label": "DMRG calculation",
+      "summary": "DMRG options (DmrgOptions).",
+      "fields": {
+        "nsweeps": {
+          "name": "nsweeps",
+          "type": "Int",
+          "widget": "int",
+          "default": 10,
+          "defaultLiteral": "10",
+          "defaultDoc": "10",
+          "desc": "number of sweeps."
+        },
+        "maxdim": {
+          "name": "maxdim",
+          "type": "Vector{Int}",
+          "widget": "vector-int",
+          "default": [
+            100,
+            200
+          ],
+          "defaultLiteral": "[100, 200]",
+          "defaultDoc": "[100, 200]",
+          "desc": "maximum size for the bond dimension."
+        },
+        "cutoff": {
+          "name": "cutoff",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1e-6",
+          "defaultDoc": "1e-6",
+          "desc": "cutoff for the singular value decomposition."
+        },
+        "noise": {
+          "name": "noise",
+          "type": "Vector{Float64}",
+          "widget": "vector-float",
+          "default": [
+            0.000001,
+            1e-7,
+            1e-8,
+            0
+          ],
+          "defaultLiteral": "[1e-6, 1e-7, 1e-8, 0.0]",
+          "defaultDoc": "[1e-6, 1e-7, 1e-8, 0.0]",
+          "desc": "strength of the noise term used to aid convergence."
+        }
+      }
+    },
+    "cholesky": {
+      "key": "cholesky",
+      "struct": "CholeskyOptions",
+      "label": "Cholesky decomposition",
+      "summary": "Cholesky options (CholeskyOptions).",
+      "fields": {
+        "thred": {
+          "name": "thred",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.000001,
+          "defaultLiteral": "1.e-6",
+          "defaultDoc": "1.e-6",
+          "desc": "threshold for elimination of redundancies in the auxiliary basis."
+        },
+        "thr": {
+          "name": "thr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 0.0001,
+          "defaultLiteral": "1.e-4",
+          "defaultDoc": "1.e-4",
+          "desc": "threshold for integral decomposition."
+        }
+      }
+    },
+    "laplace": {
+      "key": "laplace",
+      "struct": "LaplaceOptions",
+      "label": "Laplace quadrature",
+      "summary": "Laplace options (LaplaceOptions).",
+      "fields": {
+        "npoints": {
+          "name": "npoints",
+          "type": "Int",
+          "widget": "int",
+          "default": 8,
+          "defaultLiteral": "8",
+          "defaultDoc": "8",
+          "desc": "number of Laplace quadrature points."
+        },
+        "algo": {
+          "name": "algo",
+          "type": "Symbol",
+          "widget": "symbol",
+          "default": "minimax",
+          "defaultLiteral": ":minimax",
+          "defaultDoc": ":minimax",
+          "desc": "algorithm for Laplace quadrature points. (:minimax or :simplex)",
+          "choices": [
+            "minimax",
+            "simplex"
+          ]
+        }
+      }
+    },
+    "diis": {
+      "key": "diis",
+      "struct": "DiisOptions",
+      "label": "DIIS",
+      "summary": "DIIS options (DiisOptions).",
+      "fields": {
+        "maxdiis": {
+          "name": "maxdiis",
+          "type": "Int",
+          "widget": "int",
+          "default": 6,
+          "defaultLiteral": "6",
+          "defaultDoc": "6",
+          "desc": "maximum number of DIIS vectors."
+        },
+        "resthr": {
+          "name": "resthr",
+          "type": "Float64",
+          "widget": "float",
+          "default": 10,
+          "defaultLiteral": "10.0",
+          "defaultDoc": "10.0",
+          "desc": "DIIS residual threshold."
+        },
+        "crop": {
+          "name": "crop",
+          "type": "Bool",
+          "widget": "bool",
+          "default": false,
+          "defaultLiteral": "false",
+          "defaultDoc": "false",
+          "desc": "CROP-DIIS (see JCTC 11, 1518 (2015)). Usually the DIIS dimension maxcrop=3 is sufficient."
+        },
+        "maxcrop": {
+          "name": "maxcrop",
+          "type": "Int",
+          "widget": "int",
+          "default": 3,
+          "defaultLiteral": "3",
+          "defaultDoc": "3",
+          "desc": "DIIS dimension for CROP-DIIS."
+        }
+      }
+    },
+    "davidson": {
+      "key": "davidson",
+      "struct": "DavidsonOptions",
+      "label": "Davidson",
+      "summary": "Davidson options (DavidsonOptions).",
+      "fields": {
+        "maxdav": {
+          "name": "maxdav",
+          "type": "Int",
+          "widget": "int",
+          "default": 10,
+          "defaultLiteral": "10",
+          "defaultDoc": "10",
+          "desc": "maximum number of Davidson vectors per state."
+        },
+        "use_overlap": {
+          "name": "use_overlap",
+          "type": "Bool",
+          "widget": "bool",
+          "default": true,
+          "defaultLiteral": "true",
+          "defaultDoc": "true",
+          "desc": "use overlap in hermitian Davidson."
+        }
+      }
+    },
+    "print": {
+      "key": "print",
+      "struct": "PrintOptions",
+      "label": "Printing",
+      "summary": "Print options (PrintOptions).",
+      "fields": {
+        "time": {
+          "name": "time",
+          "type": "Int",
+          "widget": "int",
+          "default": 2,
+          "defaultLiteral": "2",
+          "defaultDoc": "2",
+          "desc": "verbosity level for printing timings."
+        },
+        "memory": {
+          "name": "memory",
+          "type": "Int",
+          "widget": "int",
+          "default": 2,
+          "defaultLiteral": "2",
+          "defaultDoc": "2",
+          "desc": "verbosity level for printing memory usage."
+        }
+      }
+    }
+  }
+};

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -172,6 +172,10 @@ function initializeElemCoListeners() {
         elemcoState.ms2 = parseInt(document.getElementById('elemco-multiplicity').value) || 0;
         updateElemCoInput();
     });
+    bind('elemco-fcidump', 'input', () => {
+        elemcoState.fcidump = document.getElementById('elemco-fcidump').value.trim() || 'FCIDUMP';
+        updateElemCoInput();
+    });
     setupElemcoFocusTracking();
 }
 
@@ -317,7 +321,31 @@ function initElemCoState() {
     const steps = [makeMethodStep('reference', 'dfhf')];
     const corr = elcMapDefaultMethod(prefs.defaultMethod);
     if (corr) steps.push(makeMethodStep('correlation', corr));
-    elemcoState = { _init: true, basis: { ao, jkfit: 'auto', mpfit: 'auto' }, charge: 0, ms2: 0, global: {}, steps };
+    elemcoState = { _init: true, mode: 'molecule', modeUserSet: false, fcidump: 'FCIDUMP', basis: { ao, jkfit: 'auto', mpfit: 'auto' }, charge: 0, ms2: 0, global: {}, steps };
+}
+
+// Show the basis-set fields (molecule mode) or the FCIDUMP field, and update the
+// mode selector + card title to match elemcoState.mode.
+function applyElemCoModeUI() {
+    const fci = elemcoState.mode === 'fcidump';
+    const molFields = document.getElementById('elemco-molecule-fields');
+    const fciFields = document.getElementById('elemco-fcidump-fields');
+    const modeSel = document.getElementById('elemco-mode');
+    const title = document.getElementById('elemco-global-titletext');
+    if (molFields) molFields.style.display = fci ? 'none' : '';
+    if (fciFields) fciFields.style.display = fci ? '' : 'none';
+    if (modeSel) modeSel.value = elemcoState.mode;
+    if (title) title.textContent = fci ? 'System & FCIDUMP' : 'System & basis';
+}
+
+// User picked a mode explicitly (so stop auto-switching from molecule presence).
+function setElemCoMode(mode) {
+    initElemCoState();
+    elemcoState.mode = mode === 'fcidump' ? 'fcidump' : 'molecule';
+    elemcoState.modeUserSet = true;
+    applyElemCoModeUI();
+    renderElemCoSteps();
+    updateElemCoInput();
 }
 function resetElemCoBuilder() {
     elemcoState = { _init: false };
@@ -339,6 +367,8 @@ function syncElemCoControlsFromState() {
     set('elemco-mpfit', elemcoState.basis.mpfit);
     set('elemco-charge', elemcoState.charge);
     set('elemco-multiplicity', elemcoState.ms2);
+    set('elemco-fcidump', elemcoState.fcidump);
+    applyElemCoModeUI();
     const note = document.getElementById('elemco-source-note');
     const d = elcOptionsData();
     if (note && d) note.textContent = `Options from ElemCo.jl @ ${d.sourceRef} (${d.groupOrder.length} groups, generated ${d.generated})`;
@@ -418,8 +448,9 @@ function renderElemCoSteps() {
     elemcoState.steps.forEach((step) => host.appendChild(renderStepCard(step)));
 
     // Nudge the user to add a reference (SCF) step — correlation methods need one.
+    // Skipped in FCIDUMP mode, where the reference/integrals come from the file.
     const hasReference = elemcoState.steps.some((s) => s.kind === 'method' && s.category === 'reference');
-    if (!hasReference) {
+    if (elemcoState.mode !== 'fcidump' && !hasReference) {
         const warn = elcEl('div', { class: 'elemco-suggest' });
         warn.appendChild(elcEl('span', {}, '⚠ No reference (SCF) step — correlation methods need one to run. '));
         const b = elcEl('button', { type: 'button' }, 'Add reference');
@@ -832,68 +863,38 @@ function getXYZDataWithNumberedAtoms() {
     }
 }
 
+// Is the molecular XYZ from JSmol usable? Returns the trimmed data or null.
+function elcValidMoleculeXYZ() {
+    const xyzData = getXYZDataWithNumberedAtoms();
+    if (!xyzData || xyzData.trim().length === 0) return null;
+    const lines = xyzData.trim().split('\n');
+    if (lines.length < 3) return null;
+    const atomCount = parseInt(lines[0]);
+    if (isNaN(atomCount) || atomCount <= 0) return null;
+    const dataLines = lines.slice(2);
+    if (dataLines.length < atomCount) return null;
+    let valid = 0;
+    for (let i = 0; i < Math.min(dataLines.length, atomCount); i++) {
+        const p = dataLines[i].trim().split(/\s+/);
+        if (p.length >= 4 && !isNaN(parseFloat(p[1])) && !isNaN(parseFloat(p[2])) && !isNaN(parseFloat(p[3]))) valid++;
+    }
+    return valid >= atomCount ? xyzData.trim() : null;
+}
+
 function updateElemCoInput() {
     debugLog('ElemCo', 'Starting input generation');
-    
     initElemCoState();
+    const inputArea = document.getElementById('elemco-input');
+    if (!inputArea) return;
 
-    // Get current molecular structure from JSmol (with numbered atoms if available)
-    debugLog('ElemCo', 'Calling getXYZDataWithNumberedAtoms');
-    const xyzData = getXYZDataWithNumberedAtoms();
-    
-    if (!xyzData || xyzData.trim().length === 0) {
-        debugLog('ElemCo', 'No XYZ data received', 'warning');
-        document.getElementById('elemco-input').value = '# Please load a molecule first';
-        return;
+    const xyz = elcValidMoleculeXYZ();
+
+    // Auto-select the calculation mode from molecule presence, unless the user
+    // has explicitly chosen one (no molecule loaded -> FCIDUMP mode).
+    if (!elemcoState.modeUserSet) {
+        const auto = xyz ? 'molecule' : 'fcidump';
+        if (auto !== elemcoState.mode) { elemcoState.mode = auto; applyElemCoModeUI(); renderElemCoSteps(); }
     }
-    
-    debugLog('ElemCo', `Received XYZ data, length: ${xyzData.length}`);
-    
-    // Double-check that we have valid XYZ data
-    const lines = xyzData.trim().split('\n');
-    if (lines.length < 3) {
-        console.warn('updateElemCoInput: XYZ data has insufficient lines:', lines.length);
-        document.getElementById('elemco-input').value = '# Invalid molecular structure - please reload molecule';
-        return;
-    }
-    
-    // Check if first line contains atom count
-    const atomCount = parseInt(lines[0]);
-    if (isNaN(atomCount) || atomCount <= 0) {
-        console.warn('updateElemCoInput: Invalid atom count in first line:', lines[0]);
-        document.getElementById('elemco-input').value = '# Invalid molecular structure - please reload molecule';
-        return;
-    }
-    
-    // Verify we have enough data lines for all atoms
-    const dataLines = lines.slice(2); // Skip atom count and comment lines
-    if (dataLines.length < atomCount) {
-        console.warn('updateElemCoInput: Insufficient atom data lines. Expected:', atomCount, 'Found:', dataLines.length);
-        document.getElementById('elemco-input').value = '# Incomplete molecular structure - please reload molecule';
-        return;
-    }
-    
-    // Validate that atom data lines have proper format
-    let validAtomLines = 0;
-    for (let i = 0; i < Math.min(dataLines.length, atomCount); i++) {
-        const parts = dataLines[i].trim().split(/\s+/);
-        if (parts.length >= 4) {
-            const x = parseFloat(parts[1]);
-            const y = parseFloat(parts[2]);
-            const z = parseFloat(parts[3]);
-            if (!isNaN(x) && !isNaN(y) && !isNaN(z)) {
-                validAtomLines++;
-            }
-        }
-    }
-    
-    if (validAtomLines < atomCount) {
-        console.warn('updateElemCoInput: Not all atom lines are valid. Valid:', validAtomLines, 'Expected:', atomCount);
-        document.getElementById('elemco-input').value = '# Malformed molecular structure - please reload molecule';
-        return;
-    }
-    
-    debugLog('ElemCo', `XYZ data validation passed. Atoms: ${atomCount}, Valid lines: ${validAtomLines}`);
 
     // Emit a single calculation step (building block) as its ElemCo.jl macro,
     // with any changed options as a local `begin ... end` @set block.
@@ -917,18 +918,30 @@ function updateElemCoInput() {
         return head + ' begin\n' + lines.map((l) => '  ' + l).join('\n') + '\nend';
     }
 
-    // Assemble the full script from the builder state.
-    const b = elemcoState.basis;
-    const parts = ['using ElemCo', '', 'function main()', '# Molecular geometry', 'geometry = """', xyzData.trim(), '"""', '', '# Basis set'];
-    if (b.jkfit === 'auto' && b.mpfit === 'auto') {
-        parts.push(`basis = "${b.ao}"`);
+    const parts = ['using ElemCo', '', 'function main()'];
+
+    if (elemcoState.mode === 'fcidump') {
+        // FCIDUMP mode: read integrals from a file, no geometry/basis.
+        parts.push('# Integrals from FCIDUMP', `fcidump = ${elcJuliaStringLiteral(elemcoState.fcidump || 'FCIDUMP')}`);
     } else {
-        let d = `basis = Dict(\n    "ao" => "${b.ao}"`;
-        if (b.jkfit !== 'auto') d += `,\n    "jkfit" => "${b.jkfit}"`;
-        if (b.mpfit !== 'auto') d += `,\n    "mpfit" => "${b.mpfit}"`;
-        d += '\n)';
-        parts.push(d);
+        // Molecule mode: geometry from the viewer + basis set.
+        if (!xyz) {
+            inputArea.value = '# Please load a molecule first (or switch to FCIDUMP mode in System & basis)';
+            return;
+        }
+        const b = elemcoState.basis;
+        parts.push('# Molecular geometry', 'geometry = """', xyz, '"""', '', '# Basis set');
+        if (b.jkfit === 'auto' && b.mpfit === 'auto') {
+            parts.push(`basis = "${b.ao}"`);
+        } else {
+            let d = `basis = Dict(\n    "ao" => "${b.ao}"`;
+            if (b.jkfit !== 'auto') d += `,\n    "jkfit" => "${b.jkfit}"`;
+            if (b.mpfit !== 'auto') d += `,\n    "mpfit" => "${b.mpfit}"`;
+            d += '\n)';
+            parts.push(d);
+        }
     }
+
     const gl = globalSetLines();
     if (gl.length) { parts.push('', '# Global settings'); gl.forEach((l) => parts.push(l)); }
     (elemcoState.steps || []).forEach((step) => {
@@ -938,16 +951,9 @@ function updateElemCoInput() {
         parts.push(elcStepEmit(step));
     });
     parts.push('', 'end', 'main()', '');
-    let elemcoInput = parts.join('\n');
 
-    // Set the input text
-    const inputArea = document.getElementById('elemco-input');
-    if (inputArea) {
-        inputArea.value = elemcoInput;
-        debugLog('ElemCo', 'Successfully generated input');
-    } else {
-        console.error('updateElemCoInput: Could not find elemco-input textarea');
-    }
+    inputArea.value = parts.join('\n');
+    debugLog('ElemCo', 'Successfully generated input');
 }
 
 // Function to run Julia calculation

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -618,6 +618,15 @@ function buildStepDetail(step) {
         return d;
     }
     if (step.kind === 'custom') {
+        if (typeof elcMakeJuliaEditor === 'function') {
+            const ed = elcMakeJuliaEditor('elemco-step-code');
+            ed.textarea.title = 'Raw Julia inserted verbatim';
+            ed.textarea.placeholder = '# your Julia here';
+            ed.textarea.value = step.code || '';
+            ed.textarea.addEventListener('input', () => { step.code = ed.textarea.value; updateElemCoInput(); });
+            if (ed.textarea._elcHighlight) ed.textarea._elcHighlight();
+            return ed.wrap;
+        }
         const ta = elcEl('textarea', { class: 'elemco-step-code', title: 'Raw Julia inserted verbatim', placeholder: '# your Julia here' });
         ta.value = step.code || '';
         ta.addEventListener('input', () => { step.code = ta.value; updateElemCoInput(); });
@@ -1045,6 +1054,7 @@ function updateElemCoInput() {
         // Molecule mode: geometry from the viewer + basis set.
         if (!xyz) {
             inputArea.value = '# Please load a molecule first (or switch to FCIDUMP mode in System & basis)';
+            if (inputArea._elcHighlight) inputArea._elcHighlight();
             return;
         }
         const b = elemcoState.basis;
@@ -1071,6 +1081,7 @@ function updateElemCoInput() {
     parts.push('', 'end', 'main()', '');
 
     inputArea.value = parts.join('\n');
+    if (inputArea._elcHighlight) inputArea._elcHighlight();
     debugLog('ElemCo', 'Successfully generated input');
 }
 

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -313,7 +313,7 @@ function elcMapDefaultMethod(m) {
 }
 function makeMethodStep(category, methodId) {
     const step = { id: 's' + (elcStepSeq++), kind: 'method', category, method: methodId, options: {}, _optsOpen: false };
-    if (category === 'correlation') { step.spin = ''; step.custom = ''; }
+    if (category === 'correlation') { step.spin = ''; step.custom = ''; step.customDf = false; }
     return step;
 }
 function initElemCoState() {
@@ -396,7 +396,7 @@ function addElemCoStep(type) {
     if (type === 'reference') step = makeMethodStep('reference', 'dfhf');
     else if (type === 'correlation') step = makeMethodStep('correlation', 'dcsd');
     else if (type === 'export') step = { id: 's' + (elcStepSeq++), kind: 'export', filename: 'orbitals.molden' };
-    else if (type === 'custom') step = { id: 's' + (elcStepSeq++), kind: 'custom', label: '', code: '', _codeOpen: true };
+    else if (type === 'custom') step = { id: 's' + (elcStepSeq++), kind: 'custom', label: '', code: '' };
     else return;
     elemcoState.steps.push(step);
     renderElemCoSteps();
@@ -499,7 +499,15 @@ function renderStepCard(step) {
     });
     head.appendChild(grip);
 
-    head.appendChild(elcEl('span', { class: 'elemco-badge' }, elcStepBadge(step)));
+    // Clickable badge: folds/unfolds the step's detail region (readout / spin / code).
+    const badgeCaret = elcEl('span', { class: 'elemco-caret' }, step._detailOpen !== false ? '▾' : '▸');
+    const badgeToggle = elcEl('span', { class: 'elemco-badge-toggle', title: 'Show or hide details' }, [badgeCaret, elcEl('span', { class: 'elemco-badge' }, elcStepBadge(step))]);
+    badgeToggle.addEventListener('click', () => {
+        step._detailOpen = !(step._detailOpen !== false);
+        badgeCaret.textContent = step._detailOpen ? '▾' : '▸';
+        if (step._detailEl) step._detailEl.style.display = step._detailOpen ? '' : 'none';
+    });
+    head.appendChild(badgeToggle);
 
     if (step.kind === 'method' && step.category === 'reference') {
         const sel = elcEl('select', { class: 'elemco-step-method' });
@@ -507,6 +515,7 @@ function renderStepCard(step) {
         sel.value = step.method;
         sel.addEventListener('change', () => {
             step.method = sel.value;
+            if (step._readoutEl) step._readoutEl.textContent = elemcoStepHeadString(step);
             updateElemCoInput();
             if (step._optsOpen) renderStepOptions(step);
         });
@@ -529,7 +538,11 @@ function renderStepCard(step) {
     } else if (step.kind === 'export') {
         const fn = elcEl('input', { type: 'text', class: 'elemco-step-file', title: 'Molden filename' });
         fn.value = step.filename || 'orbitals.molden';
-        fn.addEventListener('input', () => { step.filename = fn.value.trim() || 'orbitals.molden'; updateElemCoInput(); });
+        fn.addEventListener('input', () => {
+            step.filename = fn.value.trim() || 'orbitals.molden';
+            if (step._readoutEl) step._readoutEl.textContent = elcExportReadout(step);
+            updateElemCoInput();
+        });
         head.appendChild(fn);
     } else {
         const lbl = elcEl('input', { type: 'text', class: 'elemco-step-file', placeholder: 'Custom Julia (used as a comment)', title: 'Label — added as a comment line above the code' });
@@ -540,7 +553,6 @@ function renderStepCard(step) {
 
     const actions = elcEl('span', { class: 'elemco-step-actions' });
     let optsMount = null;
-    let codeMount = null;
     if (step.kind === 'method') {
         const optCaret = elcEl('span', { class: 'elemco-caret' }, step._optsOpen ? '▾' : '▸');
         const optBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Set options for this method' }, [optCaret, ' Options']);
@@ -551,15 +563,6 @@ function renderStepCard(step) {
             if (step._optsOpen) renderStepOptions(step);
         });
         actions.appendChild(optBtn);
-    } else if (step.kind === 'custom') {
-        const codeCaret = elcEl('span', { class: 'elemco-caret' }, step._codeOpen !== false ? '▾' : '▸');
-        const codeBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Show or hide the code' }, [codeCaret, ' Code']);
-        codeBtn.addEventListener('click', () => {
-            step._codeOpen = !(step._codeOpen !== false);
-            codeCaret.textContent = step._codeOpen ? '▾' : '▸';
-            if (codeMount) codeMount.style.display = step._codeOpen ? 'block' : 'none';
-        });
-        actions.appendChild(codeBtn);
     }
     const up = elcEl('button', { type: 'button', class: 'elemco-step-move', title: 'Move up' }, '▲');
     up.addEventListener('click', () => moveElemCoStep(step.id, -1));
@@ -571,8 +574,16 @@ function renderStepCard(step) {
     head.appendChild(actions);
     card.appendChild(head);
 
+    // Foldable detail region (readout / spin / code), toggled by the badge above.
+    const detail = buildStepDetail(step);
+    if (detail) {
+        detail.style.display = step._detailOpen !== false ? '' : 'none';
+        step._detailEl = detail;
+        card.appendChild(detail);
+    }
+
+    // Option chips + options browser (method steps only), below the detail.
     if (step.kind === 'method') {
-        if (step.category === 'correlation') card.appendChild(renderCorrelationDetail(step));
         const chipsEl = elcEl('div', { class: 'elemco-chips' });
         optsMount = elcEl('div', { class: 'elemco-step-options' });
         optsMount.style.display = step._optsOpen ? 'block' : 'none';
@@ -582,14 +593,37 @@ function renderStepCard(step) {
         step._optsMount = optsMount;
         renderStepChips(step);
         if (step._optsOpen) renderStepOptions(step);
-    } else if (step.kind === 'custom') {
-        codeMount = elcEl('textarea', { class: 'elemco-step-code', title: 'Raw Julia inserted verbatim', placeholder: '# your Julia here' });
-        codeMount.value = step.code || '';
-        codeMount.style.display = step._codeOpen !== false ? 'block' : 'none';
-        codeMount.addEventListener('input', () => { step.code = codeMount.value; updateElemCoInput(); });
-        card.appendChild(codeMount);
     }
     return card;
+}
+
+// The foldable content below a step's header. Reference/export show a one-line
+// readout of the emitted call; correlation shows spin + readout (or the custom
+// method field); custom shows the raw Julia code editor.
+function elcExportReadout(step) {
+    return `@export_molden ${elcJuliaStringLiteral(step.filename || 'orbitals.molden')}`;
+}
+function buildStepDetail(step) {
+    if (step.kind === 'method' && step.category === 'correlation') return renderCorrelationDetail(step);
+    if (step.kind === 'method' && step.category === 'reference') {
+        const d = elcEl('div', { class: 'elemco-method-detail' });
+        step._readoutEl = elcEl('span', { class: 'elemco-method-readout', title: 'Emitted ElemCo.jl call' }, elemcoStepHeadString(step));
+        d.appendChild(step._readoutEl);
+        return d;
+    }
+    if (step.kind === 'export') {
+        const d = elcEl('div', { class: 'elemco-method-detail' });
+        step._readoutEl = elcEl('span', { class: 'elemco-method-readout', title: 'Emitted ElemCo.jl call' }, elcExportReadout(step));
+        d.appendChild(step._readoutEl);
+        return d;
+    }
+    if (step.kind === 'custom') {
+        const ta = elcEl('textarea', { class: 'elemco-step-code', title: 'Raw Julia inserted verbatim', placeholder: '# your Julia here' });
+        ta.value = step.code || '';
+        ta.addEventListener('input', () => { step.code = ta.value; updateElemCoInput(); });
+        return ta;
+    }
+    return null;
 }
 // The ElemCo.jl call a method step emits (macro + optional method-string arg),
 // without the local-options block. Used both for generation and the live readout.
@@ -601,7 +635,7 @@ function elemcoStepHeadString(step) {
     // correlation
     let macro, methodStr;
     if (step.method === 'custom') {
-        macro = '@cc';
+        macro = step.customDf ? '@dfcc' : '@cc';
         methodStr = (step.custom || '').trim();
     } else {
         const def = elemcoCorrelationDef(step.method);
@@ -620,10 +654,20 @@ function renderCorrelationDetail(step) {
     const detail = elcEl('div', { class: 'elemco-method-detail' });
     if (step.method === 'custom') {
         detail.appendChild(elcEl('span', { class: 'elemco-detail-label' }, 'method:'));
-        const inp = elcEl('input', { type: 'text', class: 'elemco-step-file', placeholder: 'e.g. UCCSD(T)', title: 'Method string passed to @cc' });
+        const inp = elcEl('input', { type: 'text', class: 'elemco-step-file', placeholder: 'e.g. UCCSD(T)', title: 'Method string' });
         inp.value = step.custom || '';
-        inp.addEventListener('input', () => { step.custom = inp.value; updateElemCoInput(); });
+        const readout = elcEl('span', { class: 'elemco-method-readout', title: 'Emitted ElemCo.jl call' }, elemcoStepHeadString(step));
+        const refresh = () => { readout.textContent = elemcoStepHeadString(step); updateElemCoInput(); };
+        inp.addEventListener('input', () => { step.custom = inp.value; refresh(); });
         detail.appendChild(inp);
+        const dfLabel = elcEl('label', { class: 'elemco-df-toggle', title: 'Use density fitting (@dfcc instead of @cc)' });
+        const dfCb = elcEl('input', { type: 'checkbox' });
+        dfCb.checked = !!step.customDf;
+        dfCb.addEventListener('change', () => { step.customDf = dfCb.checked; refresh(); });
+        dfLabel.appendChild(dfCb);
+        dfLabel.appendChild(elcEl('span', {}, 'DF'));
+        detail.appendChild(dfLabel);
+        detail.appendChild(readout);
         return detail;
     }
     const def = elemcoCorrelationDef(step.method);

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -308,11 +308,13 @@ function elcEl(tag, props, children) {
 // --- state init / reset -----------------------------------------------------
 function elcMapDefaultMethod(m) {
     if (!m || m === 'HF') return null;
-    const map = { MP2: 'mp2', DCSD: 'dcsd', 'CCSD(T)': 'ccsd(t)', CCSD: 'ccsd' };
+    const map = { MP2: 'mp2', DCSD: 'dcsd', 'CCSD(T)': 'ccsd_t', CCSD: 'ccsd' };
     return map[m] || 'dcsd';
 }
 function makeMethodStep(category, methodId) {
-    return { id: 's' + (elcStepSeq++), kind: 'method', category, method: methodId, options: {}, _optsOpen: false };
+    const step = { id: 's' + (elcStepSeq++), kind: 'method', category, method: methodId, options: {}, _optsOpen: false };
+    if (category === 'correlation') { step.spin = ''; step.custom = ''; }
+    return step;
 }
 function initElemCoState() {
     if (elemcoState && elemcoState._init) return;
@@ -499,14 +501,29 @@ function renderStepCard(step) {
 
     head.appendChild(elcEl('span', { class: 'elemco-badge' }, elcStepBadge(step)));
 
-    if (step.kind === 'method') {
+    if (step.kind === 'method' && step.category === 'reference') {
         const sel = elcEl('select', { class: 'elemco-step-method' });
-        (ELEMCO_METHODS[step.category] || []).forEach((m) => sel.appendChild(elcEl('option', { value: m.id }, m.label)));
+        (ELEMCO_METHODS.reference || []).forEach((m) => sel.appendChild(elcEl('option', { value: m.id }, m.label)));
         sel.value = step.method;
         sel.addEventListener('change', () => {
             step.method = sel.value;
             updateElemCoInput();
             if (step._optsOpen) renderStepOptions(step);
+        });
+        head.appendChild(sel);
+    } else if (step.kind === 'method' && step.category === 'correlation') {
+        const sel = elcEl('select', { class: 'elemco-step-method' });
+        ELEMCO_CORRELATION_GROUPS.forEach((g) => {
+            const og = elcEl('optgroup', { label: g.group });
+            g.methods.forEach((m) => og.appendChild(elcEl('option', { value: m.id }, m.label)));
+            sel.appendChild(og);
+        });
+        sel.appendChild(elcEl('option', { value: 'custom' }, 'Custom…'));
+        sel.value = step.method;
+        sel.addEventListener('change', () => {
+            step.method = sel.value;
+            renderElemCoSteps(); // spin selector / readout / option groups depend on the base
+            updateElemCoInput();
         });
         head.appendChild(sel);
     } else if (step.kind === 'export') {
@@ -555,6 +572,7 @@ function renderStepCard(step) {
     card.appendChild(head);
 
     if (step.kind === 'method') {
+        if (step.category === 'correlation') card.appendChild(renderCorrelationDetail(step));
         const chipsEl = elcEl('div', { class: 'elemco-chips' });
         optsMount = elcEl('div', { class: 'elemco-step-options' });
         optsMount.style.display = step._optsOpen ? 'block' : 'none';
@@ -572,6 +590,57 @@ function renderStepCard(step) {
         card.appendChild(codeMount);
     }
     return card;
+}
+// The ElemCo.jl call a method step emits (macro + optional method-string arg),
+// without the local-options block. Used both for generation and the live readout.
+function elemcoStepHeadString(step) {
+    if (step.category === 'reference') {
+        const def = elemcoMethodDef('reference', step.method);
+        return def ? def.macro : '';
+    }
+    // correlation
+    let macro, methodStr;
+    if (step.method === 'custom') {
+        macro = '@cc';
+        methodStr = (step.custom || '').trim();
+    } else {
+        const def = elemcoCorrelationDef(step.method);
+        if (!def) return '';
+        macro = def.macro;
+        methodStr = elemcoComposeMethod(def, step.spin);
+    }
+    const takesArg = (macro === '@cc' || macro === '@dfcc');
+    return macro + (takesArg && methodStr ? ' ' + elcJuliaStringLiteral(methodStr) : '');
+}
+
+// The detail line under a correlation step's header: a spin selector (for methods
+// that support U/R) plus a live readout of the emitted call, or a free-text field
+// for the Custom… method.
+function renderCorrelationDetail(step) {
+    const detail = elcEl('div', { class: 'elemco-method-detail' });
+    if (step.method === 'custom') {
+        detail.appendChild(elcEl('span', { class: 'elemco-detail-label' }, 'method:'));
+        const inp = elcEl('input', { type: 'text', class: 'elemco-step-file', placeholder: 'e.g. UCCSD(T)', title: 'Method string passed to @cc' });
+        inp.value = step.custom || '';
+        inp.addEventListener('input', () => { step.custom = inp.value; updateElemCoInput(); });
+        detail.appendChild(inp);
+        return detail;
+    }
+    const def = elemcoCorrelationDef(step.method);
+    const readout = elcEl('span', { class: 'elemco-method-readout', title: 'Emitted ElemCo.jl call' }, elemcoStepHeadString(step));
+    if (def && def.spins) {
+        const spinSel = elcEl('select', { class: 'elemco-spin-select', title: 'Spin type (adds the U or R prefix)' });
+        (window.ELEMCO_SPINS || []).forEach((sp) => spinSel.appendChild(elcEl('option', { value: sp.id }, sp.label)));
+        spinSel.value = step.spin || '';
+        spinSel.addEventListener('change', () => {
+            step.spin = spinSel.value;
+            readout.textContent = elemcoStepHeadString(step);
+            updateElemCoInput();
+        });
+        detail.appendChild(spinSel);
+    }
+    detail.appendChild(readout);
+    return detail;
 }
 function renderStepOptions(step) {
     if (!step._optsMount || typeof renderOptionsBrowserInto !== 'function') return;
@@ -901,18 +970,23 @@ function updateElemCoInput() {
     function elcStepComment(step) {
         if (step.kind === 'export') return 'Export orbitals (Molden)';
         if (step.kind === 'custom') return (step.label || '').trim();
+        if (step.category === 'correlation') {
+            if (step.method === 'custom') return (step.custom || '').trim();
+            const def = elemcoCorrelationDef(step.method);
+            if (!def) return step.method;
+            return elemcoComposeMethod(def, step.spin) || def.label;
+        }
         const def = elemcoMethodDef(step.category, step.method);
         return def ? def.label : step.method;
     }
+    // The method name is emitted as a string literal (ElemCo.jl accepts `@cc "CCSD"`
+    // / `@dfcc "SVD-DCSD"`); bare forms like ccsd(t) or svd-dcsd would parse as a
+    // call / subtraction in Julia. Composition happens in elemcoStepHeadString.
     function elcStepEmit(step) {
         if (step.kind === 'export') return `@export_molden ${elcJuliaStringLiteral(step.filename || 'orbitals.molden')}`;
         if (step.kind === 'custom') return (step.code || '').replace(/\s+$/, '');
-        const def = elemcoMethodDef(step.category, step.method);
-        if (!def) return `# unknown method: ${step.method}`;
-        // Pass the method name as a string literal (ElemCo.jl accepts `@cc "CCSD"`
-        // / `@dfcc "SVD-DCSD"`). Bare forms like ccsd(t) or svd-dcsd would parse as
-        // a call / subtraction in Julia, so quoting is the unambiguous choice.
-        const head = def.macro + (def.arg ? ' "' + def.arg + '"' : '');
+        const head = elemcoStepHeadString(step);
+        if (!head) return `# unknown method: ${step.method}`;
         const lines = bagSetLines(step.options || {});
         if (lines.length === 0) return head;
         return head + ' begin\n' + lines.map((l) => '  ' + l).join('\n') + '\nend';

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -364,7 +364,7 @@ function addElemCoStep(type) {
     if (type === 'reference') step = makeMethodStep('reference', 'dfhf');
     else if (type === 'correlation') step = makeMethodStep('correlation', 'dcsd');
     else if (type === 'export') step = { id: 's' + (elcStepSeq++), kind: 'export', filename: 'orbitals.molden' };
-    else if (type === 'custom') step = { id: 's' + (elcStepSeq++), kind: 'custom', code: '# custom Julia code\n' };
+    else if (type === 'custom') step = { id: 's' + (elcStepSeq++), kind: 'custom', label: '', code: '', _codeOpen: true };
     else return;
     elemcoState.steps.push(step);
     renderElemCoSteps();
@@ -416,6 +416,22 @@ function renderElemCoSteps() {
         return;
     }
     elemcoState.steps.forEach((step) => host.appendChild(renderStepCard(step)));
+
+    // Nudge the user to add a reference (SCF) step — correlation methods need one.
+    const hasReference = elemcoState.steps.some((s) => s.kind === 'method' && s.category === 'reference');
+    if (!hasReference) {
+        const warn = elcEl('div', { class: 'elemco-suggest' });
+        warn.appendChild(elcEl('span', {}, '⚠ No reference (SCF) step — correlation methods need one to run. '));
+        const b = elcEl('button', { type: 'button' }, 'Add reference');
+        b.addEventListener('click', () => {
+            initElemCoState();
+            elemcoState.steps.unshift(makeMethodStep('reference', 'dfhf'));
+            renderElemCoSteps();
+            updateElemCoInput();
+        });
+        warn.appendChild(b);
+        host.appendChild(warn);
+    }
 }
 var elcDraggingStepId = null;
 function renderStepCard(step) {
@@ -468,20 +484,34 @@ function renderStepCard(step) {
         fn.addEventListener('input', () => { step.filename = fn.value.trim() || 'orbitals.molden'; updateElemCoInput(); });
         head.appendChild(fn);
     } else {
-        head.appendChild(elcEl('span', { class: 'elemco-step-custom-label' }, 'Custom Julia'));
+        const lbl = elcEl('input', { type: 'text', class: 'elemco-step-file', placeholder: 'Custom Julia (used as a comment)', title: 'Label — added as a comment line above the code' });
+        lbl.value = step.label || '';
+        lbl.addEventListener('input', () => { step.label = lbl.value; updateElemCoInput(); });
+        head.appendChild(lbl);
     }
 
     const actions = elcEl('span', { class: 'elemco-step-actions' });
     let optsMount = null;
+    let codeMount = null;
     if (step.kind === 'method') {
-        const optBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Set options for this method' }, step._optsOpen ? 'Options ▾' : 'Options ▸');
+        const optCaret = elcEl('span', { class: 'elemco-caret' }, step._optsOpen ? '▾' : '▸');
+        const optBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Set options for this method' }, [optCaret, ' Options']);
         optBtn.addEventListener('click', () => {
             step._optsOpen = !step._optsOpen;
-            optBtn.textContent = step._optsOpen ? 'Options ▾' : 'Options ▸';
+            optCaret.textContent = step._optsOpen ? '▾' : '▸';
             if (optsMount) optsMount.style.display = step._optsOpen ? 'block' : 'none';
             if (step._optsOpen) renderStepOptions(step);
         });
         actions.appendChild(optBtn);
+    } else if (step.kind === 'custom') {
+        const codeCaret = elcEl('span', { class: 'elemco-caret' }, step._codeOpen !== false ? '▾' : '▸');
+        const codeBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Show or hide the code' }, [codeCaret, ' Code']);
+        codeBtn.addEventListener('click', () => {
+            step._codeOpen = !(step._codeOpen !== false);
+            codeCaret.textContent = step._codeOpen ? '▾' : '▸';
+            if (codeMount) codeMount.style.display = step._codeOpen ? 'block' : 'none';
+        });
+        actions.appendChild(codeBtn);
     }
     const up = elcEl('button', { type: 'button', class: 'elemco-step-move', title: 'Move up' }, '▲');
     up.addEventListener('click', () => moveElemCoStep(step.id, -1));
@@ -504,10 +534,11 @@ function renderStepCard(step) {
         renderStepChips(step);
         if (step._optsOpen) renderStepOptions(step);
     } else if (step.kind === 'custom') {
-        const ta = elcEl('textarea', { class: 'elemco-step-code', title: 'Raw Julia inserted verbatim' });
-        ta.value = step.code || '';
-        ta.addEventListener('input', () => { step.code = ta.value; updateElemCoInput(); });
-        card.appendChild(ta);
+        codeMount = elcEl('textarea', { class: 'elemco-step-code', title: 'Raw Julia inserted verbatim', placeholder: '# your Julia here' });
+        codeMount.value = step.code || '';
+        codeMount.style.display = step._codeOpen !== false ? 'block' : 'none';
+        codeMount.addEventListener('input', () => { step.code = codeMount.value; updateElemCoInput(); });
+        card.appendChild(codeMount);
     }
     return card;
 }
@@ -554,9 +585,9 @@ function renderStepChips(step) {
 // --- rendering: global options card ----------------------------------------
 function toggleGlobalOptions() {
     const mount = document.getElementById('elemco-global-options');
-    const btn = document.getElementById('elemco-global-optbtn');
+    const caret = document.getElementById('elemco-global-optcaret');
     elemcoGlobalOptsOpen = !elemcoGlobalOptsOpen;
-    if (btn) btn.textContent = elemcoGlobalOptsOpen ? 'Global options ▾' : 'Global options ▸';
+    if (caret) caret.textContent = elemcoGlobalOptsOpen ? '▾' : '▸';
     if (mount) {
         mount.style.display = elemcoGlobalOptsOpen ? 'block' : 'none';
         if (elemcoGlobalOptsOpen) renderGlobalOptions();
@@ -868,7 +899,7 @@ function updateElemCoInput() {
     // with any changed options as a local `begin ... end` @set block.
     function elcStepComment(step) {
         if (step.kind === 'export') return 'Export orbitals (Molden)';
-        if (step.kind === 'custom') return 'Custom Julia';
+        if (step.kind === 'custom') return (step.label || '').trim();
         const def = elemcoMethodDef(step.category, step.method);
         return def ? def.label : step.method;
     }
@@ -901,7 +932,10 @@ function updateElemCoInput() {
     const gl = globalSetLines();
     if (gl.length) { parts.push('', '# Global settings'); gl.forEach((l) => parts.push(l)); }
     (elemcoState.steps || []).forEach((step) => {
-        parts.push('', '# ' + elcStepComment(step), elcStepEmit(step));
+        const comment = elcStepComment(step);
+        parts.push('');
+        if (comment) parts.push('# ' + comment);
+        parts.push(elcStepEmit(step));
     });
     parts.push('', 'end', 'main()', '');
     let elemcoInput = parts.join('\n');

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -63,7 +63,7 @@ function hideElemCoPanel() {
 }
 
 function generateElemCoInput() {
-    updateElemCoInput();
+    resetElemCoBuilder();
     document.getElementById('status').innerHTML = 'ElemCo.jl input reset to default';
 }
 
@@ -119,76 +119,393 @@ function fallbackCopyToClipboard(textArea) {
     }
 }
 
-// Remove previous event listeners and add new ones
+// Wire the fixed "System & basis" controls (basis sets, charge, ms2) to the
+// state model. Per-method and per-option controls are wired as they are
+// rendered (see renderElemCoSteps and the options browser), not here.
 function initializeElemCoListeners() {
-    const method = document.getElementById('elemco-method');
-    const aoBasis = document.getElementById('elemco-basis');
-    const jkfitBasis = document.getElementById('elemco-jkfit');
-    const mpfitBasis = document.getElementById('elemco-mpfit');
-    const charge = document.getElementById('elemco-charge');
-    const multiplicity = document.getElementById('elemco-multiplicity');
-    const moldenCheckbox = document.getElementById('elemco-molden');
-    const moldenFile = document.getElementById('elemco-molden-file');
-
-    // Store references to listeners for proper cleanup
-    const elements = [
-        { element: method, event: 'change', handler: updateElemCoInput },
-        { element: aoBasis, event: 'change', handler: updateElemCoInput },
-        { element: jkfitBasis, event: 'change', handler: updateElemCoInput },
-        { element: mpfitBasis, event: 'change', handler: updateElemCoInput },
-        { element: charge, event: 'input', handler: updateElemCoInput },
-        { element: multiplicity, event: 'input', handler: updateElemCoInput },
-        { element: moldenCheckbox, event: 'change', handler: updateElemCoInput },
-        { element: moldenFile, event: 'input', handler: updateElemCoInput }
-    ];
-
-    // Remove old listeners if they exist
-    elements.forEach(({ element, event, handler }) => {
-        if (element && element._elemcoHandler) {
-            element.removeEventListener(event, element._elemcoHandler);
-        }
+    const bind = (id, event, handler) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        if (el._elemcoHandler) el.removeEventListener(event, el._elemcoHandler);
+        el._elemcoHandler = handler;
+        el.addEventListener(event, handler);
+    };
+    bind('elemco-basis', 'change', () => {
+        elemcoState.basis.ao = document.getElementById('elemco-basis').value;
+        updateElemCoInput();
     });
-
-    // Add new listeners and store references
-    elements.forEach(({ element, event, handler }) => {
-        if (element) {
-            element._elemcoHandler = handler;
-            element.addEventListener(event, handler);
-        }
+    bind('elemco-jkfit', 'change', () => {
+        elemcoState.basis.jkfit = document.getElementById('elemco-jkfit').value;
+        updateElemCoInput();
+    });
+    bind('elemco-mpfit', 'change', () => {
+        elemcoState.basis.mpfit = document.getElementById('elemco-mpfit').value;
+        updateElemCoInput();
+    });
+    bind('elemco-charge', 'input', () => {
+        elemcoState.charge = parseInt(document.getElementById('elemco-charge').value) || 0;
+        updateElemCoInput();
+    });
+    bind('elemco-multiplicity', 'input', () => {
+        elemcoState.ms2 = parseInt(document.getElementById('elemco-multiplicity').value) || 0;
+        updateElemCoInput();
     });
 }
 
-// Function to update method options based on DF toggle
+// ===========================================================================
+// ElemCo.jl input builder — state model
+// ===========================================================================
+// A calculation is a global "System & basis" section plus an ordered list of
+// steps (building blocks). Each method step maps to an ElemCo.jl macro and
+// carries only the options the user changed from their ElemCo.jl defaults; those
+// are emitted as a local `@set` block (`@cc dcsd begin ... end`). Global options
+// (wf/int/print) are emitted as top-level `@set` lines. See js/elemco-methods.js
+// for the method→macro registry and js/elemco-options.js for option metadata.
+
+var elemcoState = { _init: false };
+var elcStepSeq = 0;
+var elemcoGlobalOptsOpen = false;
+
+// Back-compat shim: some callers (and older code paths) still invoke this.
 function updateMethodOptions() {
-    const dfEnabled = document.getElementById('elemco-df').checked;
-    const methodSelect = document.getElementById('elemco-method');
-    const selectedMethod = methodSelect.value;
-    
-    // Store all available methods
-    const allMethods = {
-        standard: ['HF', 'MP2', 'DCSD', 'CCSD(T)', 'CCSDT', 'DC-CCSDT', 'SVD-DC-CCSDT'],
-        df: ['HF', 'MP2', 'SVD-DCSD']
-    };
+    if (typeof renderElemCoSteps === 'function') renderElemCoSteps();
+    updateElemCoInput();
+}
 
-    // Clear existing options
-    methodSelect.innerHTML = '';
+// --- option metadata lookup -------------------------------------------------
+function elcOptionsData() { return (typeof window !== 'undefined' && window.ELEMCO_OPTIONS) || null; }
+function optionMeta(group, name) {
+    const d = elcOptionsData();
+    return (d && d.groups[group] && d.groups[group].fields[name]) || null;
+}
+function elcGroupOrder() {
+    const d = elcOptionsData();
+    return (d && d.groupOrder) || [];
+}
 
-    // Add appropriate methods based on DF toggle
-    const methods = dfEnabled ? allMethods.df : allMethods.standard;
-    methods.forEach(method => {
-        const option = document.createElement('option');
-        option.value = method;
-        option.text = method;
-        methodSelect.appendChild(option);
+// --- option value helpers (a "bag" is { group: { name: value } } of non-defaults)
+function bagHasOption(bag, group, name) {
+    return !!(bag && bag[group] && Object.prototype.hasOwnProperty.call(bag[group], name));
+}
+function optionEffectiveValue(bag, group, name) {
+    if (bagHasOption(bag, group, name)) return bag[group][name];
+    const meta = optionMeta(group, name);
+    return meta ? meta.default : undefined;
+}
+// Store a value only when it differs from the ElemCo.jl default; otherwise drop
+// it so the generated input stays minimal.
+function setBagOption(bag, group, name, val) {
+    const meta = optionMeta(group, name);
+    const isDefault = meta && JSON.stringify(val) === JSON.stringify(meta.default);
+    if (val === undefined || val === null || isDefault) {
+        if (bag[group]) {
+            delete bag[group][name];
+            if (Object.keys(bag[group]).length === 0) delete bag[group];
+        }
+    } else {
+        if (!bag[group]) bag[group] = {};
+        bag[group][name] = val;
+    }
+}
+
+// --- JS value -> Julia source literal --------------------------------------
+function elcFormatFloat(v) {
+    if (typeof v !== 'number' || !isFinite(v)) return String(v);
+    if (Number.isInteger(v)) return v.toFixed(1); // keep it a Float literal, e.g. 100.0
+    return String(v);
+}
+// Wrap a JS string as a Julia double-quoted literal. Julia requires escaping the
+// backslash, the double-quote, and '$' (string interpolation); backslash first.
+function elcJuliaStringLiteral(val) {
+    return '"' + String(val).replace(/\\/g, '\\\\').replace(/\$/g, '\\$').replace(/"/g, '\\"') + '"';
+}
+function formatJuliaValue(meta, val) {
+    const w = meta ? meta.widget : 'unknown';
+    switch (w) {
+        case 'bool': return val ? 'true' : 'false';
+        case 'int': return String(val);
+        case 'float': return elcFormatFloat(val);
+        case 'symbol': return ':' + val;
+        case 'string': return elcJuliaStringLiteral(val);
+        case 'vector-int': return '[' + (val || []).join(', ') + ']';
+        case 'vector-float': return '[' + (val || []).map(elcFormatFloat).join(', ') + ']';
+        default: return String(val);
+    }
+}
+
+// --- @set line generation ---------------------------------------------------
+function bagSetLines(bag) {
+    const lines = [];
+    const order = elcGroupOrder();
+    const groups = order.length ? order : Object.keys(bag);
+    groups.forEach((group) => {
+        const dict = bag[group];
+        if (!dict) return;
+        const parts = Object.keys(dict).map((name) => `${name}=${formatJuliaValue(optionMeta(group, name), dict[name])}`);
+        if (parts.length) lines.push(`@set ${group} ${parts.join(' ')}`);
     });
+    return lines;
+}
 
-    // Try to maintain selected method if it's still available
-    if (methods.includes(selectedMethod)) {
-        methodSelect.value = selectedMethod;
+// Top-level @set lines: global option groups, with charge/ms2 (dedicated inputs)
+// folded into the wf group. Charge/ms2 preserve the legacy rule of emitting both
+// whenever either is non-zero.
+function globalSetLines() {
+    const bag = {};
+    for (const g in elemcoState.global) bag[g] = Object.assign({}, elemcoState.global[g]);
+    if (elemcoState.charge !== 0 || elemcoState.ms2 !== 0) {
+        bag.wf = Object.assign({ charge: elemcoState.charge, ms2: elemcoState.ms2 }, bag.wf || {});
+    }
+    return bagSetLines(bag);
+}
+
+// --- DOM helper -------------------------------------------------------------
+function elcEl(tag, props, children) {
+    const e = document.createElement(tag);
+    if (props) {
+        for (const k in props) {
+            const v = props[k];
+            if (k === 'class') e.className = v;
+            else if (k === 'html') e.innerHTML = v;
+            else if (k in e) { try { e[k] = v; } catch (_) { e.setAttribute(k, v); } }
+            else e.setAttribute(k, v);
+        }
+    }
+    if (children != null) {
+        const kids = Array.isArray(children) ? children : [children];
+        kids.forEach((c) => { if (c != null) e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c); });
+    }
+    return e;
+}
+
+// --- state init / reset -----------------------------------------------------
+function elcMapDefaultMethod(m) {
+    if (!m || m === 'HF') return null;
+    const map = { MP2: 'mp2', DCSD: 'dcsd', 'CCSD(T)': 'ccsd(t)', CCSD: 'ccsd' };
+    return map[m] || 'dcsd';
+}
+function makeMethodStep(category, methodId) {
+    return { id: 's' + (elcStepSeq++), kind: 'method', category, method: methodId, options: {}, _optsOpen: false };
+}
+function initElemCoState() {
+    if (elemcoState && elemcoState._init) return;
+    const prefs = (typeof getPreferences === 'function') ? getPreferences() : {};
+    const ao = prefs.defaultBasisSet || 'cc-pVDZ';
+    const steps = [makeMethodStep('reference', 'dfhf')];
+    const corr = elcMapDefaultMethod(prefs.defaultMethod);
+    if (corr) steps.push(makeMethodStep('correlation', corr));
+    elemcoState = { _init: true, basis: { ao, jkfit: 'auto', mpfit: 'auto' }, charge: 0, ms2: 0, global: {}, steps };
+}
+function resetElemCoBuilder() {
+    elemcoState = { _init: false };
+    elemcoGlobalOptsOpen = false;
+    initElemCoState();
+    syncElemCoControlsFromState();
+    renderElemCoSteps();
+    const gm = document.getElementById('elemco-global-options');
+    if (gm) { gm.style.display = 'none'; gm.innerHTML = ''; }
+    const gb = document.getElementById('elemco-global-optbtn');
+    if (gb) gb.textContent = 'Global options ▸';
+    renderGlobalChips();
+    updateElemCoInput();
+}
+function syncElemCoControlsFromState() {
+    const set = (id, val) => { const e = document.getElementById(id); if (e) e.value = val; };
+    set('elemco-basis', elemcoState.basis.ao);
+    set('elemco-jkfit', elemcoState.basis.jkfit);
+    set('elemco-mpfit', elemcoState.basis.mpfit);
+    set('elemco-charge', elemcoState.charge);
+    set('elemco-multiplicity', elemcoState.ms2);
+    const note = document.getElementById('elemco-source-note');
+    const d = elcOptionsData();
+    if (note && d) note.textContent = `Options from ElemCo.jl @ ${d.sourceRef} (${d.groupOrder.length} groups, generated ${d.generated})`;
+}
+
+// Apply relevant preferences to the live state (basis default). Called on load
+// and after saving preferences; must not clobber user-built steps.
+function syncElemCoBasisFromPrefs() {
+    const prefs = (typeof getPreferences === 'function') ? getPreferences() : {};
+    if (!elemcoState || !elemcoState._init) return;
+    if (prefs.defaultBasisSet) {
+        elemcoState.basis.ao = prefs.defaultBasisSet;
+        const sel = document.getElementById('elemco-basis');
+        if (sel) sel.value = prefs.defaultBasisSet;
+    }
+    updateElemCoInput();
+}
+
+// --- step CRUD --------------------------------------------------------------
+function addElemCoStep(type) {
+    initElemCoState();
+    let step;
+    if (type === 'reference') step = makeMethodStep('reference', 'dfhf');
+    else if (type === 'correlation') step = makeMethodStep('correlation', 'dcsd');
+    else if (type === 'export') step = { id: 's' + (elcStepSeq++), kind: 'export', filename: 'orbitals.molden' };
+    else if (type === 'custom') step = { id: 's' + (elcStepSeq++), kind: 'custom', code: '# custom Julia code\n' };
+    else return;
+    elemcoState.steps.push(step);
+    renderElemCoSteps();
+    updateElemCoInput();
+}
+function removeElemCoStep(id) {
+    elemcoState.steps = elemcoState.steps.filter((s) => s.id !== id);
+    renderElemCoSteps();
+    updateElemCoInput();
+}
+function moveElemCoStep(id, dir) {
+    const s = elemcoState.steps;
+    const i = s.findIndex((x) => x.id === id);
+    if (i < 0) return;
+    const j = i + dir;
+    if (j < 0 || j >= s.length) return;
+    [s[i], s[j]] = [s[j], s[i]];
+    renderElemCoSteps();
+    updateElemCoInput();
+}
+
+// --- rendering: step list ---------------------------------------------------
+function elcStepBadge(step) {
+    if (step.kind === 'export') return 'Export';
+    if (step.kind === 'custom') return 'Custom';
+    return step.category === 'reference' ? 'Reference' : 'Method';
+}
+function renderElemCoSteps() {
+    const host = document.getElementById('elemco-steps');
+    if (!host) return;
+    host.innerHTML = '';
+    if (!elemcoState.steps || elemcoState.steps.length === 0) {
+        host.appendChild(elcEl('div', { class: 'preview-note' }, 'No steps yet — add a reference and a method below.'));
+        return;
+    }
+    elemcoState.steps.forEach((step) => host.appendChild(renderStepCard(step)));
+}
+function renderStepCard(step) {
+    const card = elcEl('div', { class: 'elemco-step-card' });
+    const head = elcEl('div', { class: 'elemco-step-head' });
+    head.appendChild(elcEl('span', { class: 'elemco-badge' }, elcStepBadge(step)));
+
+    if (step.kind === 'method') {
+        const sel = elcEl('select', { class: 'elemco-step-method' });
+        (ELEMCO_METHODS[step.category] || []).forEach((m) => sel.appendChild(elcEl('option', { value: m.id }, m.label)));
+        sel.value = step.method;
+        sel.addEventListener('change', () => {
+            step.method = sel.value;
+            updateElemCoInput();
+            if (step._optsOpen) renderStepOptions(step);
+        });
+        head.appendChild(sel);
+    } else if (step.kind === 'export') {
+        const fn = elcEl('input', { type: 'text', class: 'elemco-step-file', title: 'Molden filename' });
+        fn.value = step.filename || 'orbitals.molden';
+        fn.addEventListener('input', () => { step.filename = fn.value.trim() || 'orbitals.molden'; updateElemCoInput(); });
+        head.appendChild(fn);
+    } else {
+        head.appendChild(elcEl('span', { class: 'elemco-step-custom-label' }, 'Custom Julia'));
     }
 
-    // Update the input text
-    updateElemCoInput();
+    const actions = elcEl('span', { class: 'elemco-step-actions' });
+    let optsMount = null;
+    if (step.kind === 'method') {
+        const optBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Set options for this method' }, step._optsOpen ? 'Options ▾' : 'Options ▸');
+        optBtn.addEventListener('click', () => {
+            step._optsOpen = !step._optsOpen;
+            optBtn.textContent = step._optsOpen ? 'Options ▾' : 'Options ▸';
+            if (optsMount) optsMount.style.display = step._optsOpen ? 'block' : 'none';
+            if (step._optsOpen) renderStepOptions(step);
+        });
+        actions.appendChild(optBtn);
+    }
+    const up = elcEl('button', { type: 'button', class: 'elemco-step-move', title: 'Move up' }, '▲');
+    up.addEventListener('click', () => moveElemCoStep(step.id, -1));
+    const down = elcEl('button', { type: 'button', class: 'elemco-step-move', title: 'Move down' }, '▼');
+    down.addEventListener('click', () => moveElemCoStep(step.id, 1));
+    const del = elcEl('button', { type: 'button', class: 'elemco-step-del', title: 'Remove step' }, '✕');
+    del.addEventListener('click', () => removeElemCoStep(step.id));
+    actions.appendChild(up); actions.appendChild(down); actions.appendChild(del);
+    head.appendChild(actions);
+    card.appendChild(head);
+
+    if (step.kind === 'method') {
+        const chipsEl = elcEl('div', { class: 'elemco-chips' });
+        optsMount = elcEl('div', { class: 'elemco-step-options' });
+        optsMount.style.display = step._optsOpen ? 'block' : 'none';
+        card.appendChild(chipsEl);
+        card.appendChild(optsMount);
+        step._chipsEl = chipsEl;
+        step._optsMount = optsMount;
+        renderStepChips(step);
+        if (step._optsOpen) renderStepOptions(step);
+    } else if (step.kind === 'custom') {
+        const ta = elcEl('textarea', { class: 'elemco-step-code', title: 'Raw Julia inserted verbatim' });
+        ta.value = step.code || '';
+        ta.addEventListener('input', () => { step.code = ta.value; updateElemCoInput(); });
+        card.appendChild(ta);
+    }
+    return card;
+}
+function renderStepOptions(step) {
+    if (!step._optsMount || typeof renderOptionsBrowserInto !== 'function') return;
+    const def = elemcoMethodDef(step.category, step.method);
+    const groups = def ? def.groups : ['cc'];
+    renderOptionsBrowserInto(step._optsMount, groups, step.options, () => {
+        renderStepChips(step);
+        updateElemCoInput();
+    }, {});
+}
+
+// --- rendering: option chips ------------------------------------------------
+function renderBagChips(bag, chipsEl, afterRemove) {
+    if (!chipsEl) return;
+    chipsEl.innerHTML = '';
+    let any = false;
+    elcGroupOrder().forEach((group) => {
+        const dict = bag[group];
+        if (!dict) return;
+        Object.keys(dict).forEach((name) => {
+            any = true;
+            const meta = optionMeta(group, name);
+            const chip = elcEl('span', { class: 'elemco-chip', title: `${group}.${name}${meta ? ' — ' + meta.desc : ''}` });
+            chip.appendChild(elcEl('span', { class: 'elemco-chip-text' }, `${group}.${name}=${formatJuliaValue(meta, dict[name])}`));
+            const x = elcEl('button', { type: 'button', class: 'elemco-chip-x', title: 'Remove (reset to default)' }, '×');
+            x.addEventListener('click', () => {
+                setBagOption(bag, group, name, undefined);
+                renderBagChips(bag, chipsEl, afterRemove);
+                updateElemCoInput();
+                if (afterRemove) afterRemove();
+            });
+            chip.appendChild(x);
+            chipsEl.appendChild(chip);
+        });
+    });
+    chipsEl.style.display = any ? 'flex' : 'none';
+}
+function renderStepChips(step) {
+    renderBagChips(step.options, step._chipsEl, () => { if (step._optsOpen) renderStepOptions(step); });
+}
+
+// --- rendering: global options card ----------------------------------------
+function toggleGlobalOptions() {
+    const mount = document.getElementById('elemco-global-options');
+    const btn = document.getElementById('elemco-global-optbtn');
+    elemcoGlobalOptsOpen = !elemcoGlobalOptsOpen;
+    if (btn) btn.textContent = elemcoGlobalOptsOpen ? 'Global options ▾' : 'Global options ▸';
+    if (mount) {
+        mount.style.display = elemcoGlobalOptsOpen ? 'block' : 'none';
+        if (elemcoGlobalOptsOpen) renderGlobalOptions();
+    }
+}
+function renderGlobalOptions() {
+    const mount = document.getElementById('elemco-global-options');
+    if (!mount || typeof renderOptionsBrowserInto !== 'function') return;
+    renderOptionsBrowserInto(mount, window.ELEMCO_GLOBAL_GROUPS || ['wf', 'int', 'print'], elemcoState.global, () => {
+        renderGlobalChips();
+        updateElemCoInput();
+    }, { exclude: window.ELEMCO_GLOBAL_EXCLUDE || {} });
+}
+function renderGlobalChips() {
+    const el = document.getElementById('elemco-global-chips');
+    if (!el) return;
+    renderBagChips(elemcoState.global, el, () => { if (elemcoGlobalOptsOpen) renderGlobalOptions(); });
 }
 
 // Function to generate meaningful comment line for XYZ files
@@ -410,15 +727,7 @@ function getXYZDataWithNumberedAtoms() {
 function updateElemCoInput() {
     debugLog('ElemCo', 'Starting input generation');
     
-    const dfEnabled = document.getElementById('elemco-df').checked;
-    const method = document.getElementById('elemco-method').value;
-    const aoBasis = document.getElementById('elemco-basis').value;
-    const jkfitBasis = document.getElementById('elemco-jkfit').value;
-    const mpfitBasis = document.getElementById('elemco-mpfit').value;
-    const charge = parseInt(document.getElementById('elemco-charge').value) || 0;
-    const multiplicity = parseInt(document.getElementById('elemco-multiplicity').value) || 0;
-    const moldenEnabled = document.getElementById('elemco-molden').checked;
-    const moldenFile = document.getElementById('elemco-molden-file').value.trim() || 'orbitals.molden';
+    initElemCoState();
 
     // Get current molecular structure from JSmol (with numbered atoms if available)
     debugLog('ElemCo', 'Calling getXYZDataWithNumberedAtoms');
@@ -478,56 +787,47 @@ function updateElemCoInput() {
     
     debugLog('ElemCo', `XYZ data validation passed. Atoms: ${atomCount}, Valid lines: ${validAtomLines}`);
 
-    // Format ElemCo.jl input with complete XYZ specification
-    let elemcoInput = `using ElemCo
+    // Emit a single calculation step (building block) as its ElemCo.jl macro,
+    // with any changed options as a local `begin ... end` @set block.
+    function elcStepComment(step) {
+        if (step.kind === 'export') return 'Export orbitals (Molden)';
+        if (step.kind === 'custom') return 'Custom Julia';
+        const def = elemcoMethodDef(step.category, step.method);
+        return def ? def.label : step.method;
+    }
+    function elcStepEmit(step) {
+        if (step.kind === 'export') return `@export_molden ${elcJuliaStringLiteral(step.filename || 'orbitals.molden')}`;
+        if (step.kind === 'custom') return (step.code || '').replace(/\s+$/, '');
+        const def = elemcoMethodDef(step.category, step.method);
+        if (!def) return `# unknown method: ${step.method}`;
+        // Pass the method name as a string literal (ElemCo.jl accepts `@cc "CCSD"`
+        // / `@dfcc "SVD-DCSD"`). Bare forms like ccsd(t) or svd-dcsd would parse as
+        // a call / subtraction in Julia, so quoting is the unambiguous choice.
+        const head = def.macro + (def.arg ? ' "' + def.arg + '"' : '');
+        const lines = bagSetLines(step.options || {});
+        if (lines.length === 0) return head;
+        return head + ' begin\n' + lines.map((l) => '  ' + l).join('\n') + '\nend';
+    }
 
-function main()        
-# Molecule specification
-geometry = """
-${xyzData.trim()}
-"""
-        
-# Set basis set`;
-
-    // Handle basis set configuration based on selected options
-    if (jkfitBasis === 'auto' && mpfitBasis === 'auto') {
-        // Use simple basis set specification if no auxiliary basis sets are selected
-        elemcoInput += `\nbasis = "${aoBasis}"\n`;
+    // Assemble the full script from the builder state.
+    const b = elemcoState.basis;
+    const parts = ['using ElemCo', '', 'function main()', '# Molecular geometry', 'geometry = """', xyzData.trim(), '"""', '', '# Basis set'];
+    if (b.jkfit === 'auto' && b.mpfit === 'auto') {
+        parts.push(`basis = "${b.ao}"`);
     } else {
-        // Build the basis dictionary with selected auxiliary basis sets
-        elemcoInput += `\nbasis = Dict(\n    "ao" => "${aoBasis}"`;
-
-        if (jkfitBasis !== 'auto') {
-            elemcoInput += `,\n    "jkfit" => "${jkfitBasis}"`;
-        }
-
-        if (mpfitBasis !== 'auto') {
-            elemcoInput += `,\n    "mpfit" => "${mpfitBasis}"`;
-        }
-
-        elemcoInput += "\n)\n";
+        let d = `basis = Dict(\n    "ao" => "${b.ao}"`;
+        if (b.jkfit !== 'auto') d += `,\n    "jkfit" => "${b.jkfit}"`;
+        if (b.mpfit !== 'auto') d += `,\n    "mpfit" => "${b.mpfit}"`;
+        d += '\n)';
+        parts.push(d);
     }
-
-    // Add charge and multiplicity settings only if they are non-zero
-    if (charge !== 0 || multiplicity !== 0) {
-        elemcoInput += `\n# Set charge and multiplicity\n@set wf charge=${charge} ms2=${multiplicity}\n`;
-    }
-
-    // Add calculation commands
-    elemcoInput += `\n# Run HF calculation first\n${dfEnabled ? '@dfhf' : '@dfhf'}\n`;
-
-    // Add coupled cluster calculation if method is not HF
-    if (method !== 'HF') {
-        const ccCommand = dfEnabled ? '@dfcc' : '@cc';
-        elemcoInput += `\n# Run ${method} calculation\n${ccCommand} ${method.toLowerCase()}\n`;
-    }
-
-    // Add molden export if enabled
-    if (moldenEnabled) {
-        elemcoInput += `\n# Export orbitals to Molden file\n@export_molden "${moldenFile}"\n`;
-    }
-
-    elemcoInput += `\nend\nmain()\n`;
+    const gl = globalSetLines();
+    if (gl.length) { parts.push('', '# Global settings'); gl.forEach((l) => parts.push(l)); }
+    (elemcoState.steps || []).forEach((step) => {
+        parts.push('', '# ' + elcStepComment(step), elcStepEmit(step));
+    });
+    parts.push('', 'end', 'main()', '');
+    let elemcoInput = parts.join('\n');
 
     // Set the input text
     const inputArea = document.getElementById('elemco-input');

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -67,9 +67,27 @@ function generateElemCoInput() {
     document.getElementById('status').innerHTML = 'ElemCo.jl input reset to default';
 }
 
+// Remember the last editable field the user focused inside the ElemCo panel (an
+// option text field, the custom-step editor, or the main input editor) so that
+// "Insert Selected Atoms" targets wherever they were typing. Clicking the button
+// itself moves focus to the button, which is not editable, so this value sticks.
+var elemcoLastFocusedField = null;
+function setupElemcoFocusTracking() {
+    const panel = document.getElementById('elemcoPanel');
+    if (!panel || panel._focusTrackWired) return;
+    panel._focusTrackWired = true;
+    panel.addEventListener('focusin', (e) => {
+        const t = e.target;
+        if (!t) return;
+        const editable = t.tagName === 'TEXTAREA' ||
+            (t.tagName === 'INPUT' && /^(text|search)$/i.test(t.type || 'text'));
+        if (editable) elemcoLastFocusedField = t;
+    });
+}
+
 // Insert the list of currently selected atoms (sorted, 1-based indices) at the
-// cursor position in the ElemCo input editor, e.g. for dummy atoms or active
-// regions. Falls back to appending at the end if no cursor position is known.
+// cursor of whichever field the user last edited, falling back to the main input
+// editor. Useful for dummy atoms, active regions, or option fields.
 function insertSelectedAtomsIntoElemCo() {
     const nums = getSelectedAtomNumbers();
     if (nums.length === 0) {
@@ -77,15 +95,19 @@ function insertSelectedAtomsIntoElemCo() {
             'No atoms selected — click atoms in the structure or XYZ viewer first';
         return;
     }
-    const textarea = document.getElementById('elemco-input');
+    let field = elemcoLastFocusedField;
+    if (!field || !document.contains(field)) field = document.getElementById('elemco-input');
+    if (!field) return;
     const listText = '[' + nums.join(', ') + ']';
-    const hasCursor = typeof textarea.selectionStart === 'number';
-    const start = hasCursor ? textarea.selectionStart : textarea.value.length;
-    const end = hasCursor ? textarea.selectionEnd : textarea.value.length;
-    textarea.value = textarea.value.slice(0, start) + listText + textarea.value.slice(end);
+    const hasCursor = typeof field.selectionStart === 'number';
+    const start = hasCursor ? field.selectionStart : field.value.length;
+    const end = hasCursor ? field.selectionEnd : field.value.length;
+    field.value = field.value.slice(0, start) + listText + field.value.slice(end);
     const pos = start + listText.length;
-    textarea.selectionStart = textarea.selectionEnd = pos;
-    textarea.focus();
+    try { field.selectionStart = field.selectionEnd = pos; } catch (_) { /* some inputs disallow selection */ }
+    field.focus();
+    // Let any state-backed field (option inputs, custom step) react to the edit.
+    field.dispatchEvent(new Event('input', { bubbles: true }));
     document.getElementById('status').innerHTML =
         `Inserted ${nums.length} selected atom${nums.length === 1 ? '' : 's'}: ${listText}`;
 }
@@ -150,6 +172,7 @@ function initializeElemCoListeners() {
         elemcoState.ms2 = parseInt(document.getElementById('elemco-multiplicity').value) || 0;
         updateElemCoInput();
     });
+    setupElemcoFocusTracking();
 }
 
 // ===========================================================================
@@ -362,6 +385,21 @@ function moveElemCoStep(id, dir) {
     renderElemCoSteps();
     updateElemCoInput();
 }
+// Move the dragged step next to the target step (before it, or after when the
+// pointer was dropped on the target's lower half).
+function reorderElemCoStep(draggedId, targetId, after) {
+    if (draggedId === targetId) return;
+    const s = elemcoState.steps;
+    const from = s.findIndex((x) => x.id === draggedId);
+    if (from < 0) return;
+    const [moved] = s.splice(from, 1);
+    let to = s.findIndex((x) => x.id === targetId);
+    if (to < 0) { s.splice(from, 0, moved); return; }
+    if (after) to += 1;
+    s.splice(to, 0, moved);
+    renderElemCoSteps();
+    updateElemCoInput();
+}
 
 // --- rendering: step list ---------------------------------------------------
 function elcStepBadge(step) {
@@ -379,9 +417,39 @@ function renderElemCoSteps() {
     }
     elemcoState.steps.forEach((step) => host.appendChild(renderStepCard(step)));
 }
+var elcDraggingStepId = null;
 function renderStepCard(step) {
     const card = elcEl('div', { class: 'elemco-step-card' });
+    card.dataset.stepId = step.id;
     const head = elcEl('div', { class: 'elemco-step-head' });
+
+    // Drag-to-reorder: only the grip starts a drag (so the select/inputs stay
+    // usable); the whole card is a drop target.
+    const grip = elcEl('span', { class: 'elemco-step-grip', title: 'Drag to reorder', draggable: 'true' }, '⠿');
+    grip.addEventListener('dragstart', (e) => {
+        elcDraggingStepId = step.id;
+        if (e.dataTransfer) { e.dataTransfer.setData('text/plain', step.id); e.dataTransfer.effectAllowed = 'move'; }
+        card.classList.add('elemco-dragging');
+    });
+    grip.addEventListener('dragend', () => { elcDraggingStepId = null; card.classList.remove('elemco-dragging'); });
+    card.addEventListener('dragover', (e) => {
+        if (!elcDraggingStepId || elcDraggingStepId === step.id) return;
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        card.classList.add('elemco-drag-over');
+    });
+    card.addEventListener('dragleave', () => card.classList.remove('elemco-drag-over'));
+    card.addEventListener('drop', (e) => {
+        card.classList.remove('elemco-drag-over');
+        const draggedId = (e.dataTransfer && e.dataTransfer.getData('text/plain')) || elcDraggingStepId;
+        if (!draggedId) return;
+        e.preventDefault();
+        const rect = card.getBoundingClientRect();
+        const after = (e.clientY - rect.top) > rect.height / 2;
+        reorderElemCoStep(draggedId, step.id, after);
+    });
+    head.appendChild(grip);
+
     head.appendChild(elcEl('span', { class: 'elemco-badge' }, elcStepBadge(step)));
 
     if (step.kind === 'method') {
@@ -506,6 +574,15 @@ function renderGlobalChips() {
     const el = document.getElementById('elemco-global-chips');
     if (!el) return;
     renderBagChips(elemcoState.global, el, () => { if (elemcoGlobalOptsOpen) renderGlobalOptions(); });
+}
+// Fold/unfold the whole System & basis card.
+function toggleElemCoGlobalCard() {
+    const body = document.getElementById('elemco-global-body');
+    const caret = document.getElementById('elemco-global-caret');
+    if (!body) return;
+    const open = body.style.display === 'none';
+    body.style.display = open ? 'block' : 'none';
+    if (caret) caret.textContent = open ? '▾' : '▸';
 }
 
 // Function to generate meaningful comment line for XYZ files

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -396,6 +396,7 @@ function addElemCoStep(type) {
     if (type === 'reference') step = makeMethodStep('reference', 'dfhf');
     else if (type === 'correlation') step = makeMethodStep('correlation', 'dcsd');
     else if (type === 'export') step = { id: 's' + (elcStepSeq++), kind: 'export', filename: 'orbitals.molden' };
+    else if (type === 'macro') step = { id: 's' + (elcStepSeq++), kind: 'macro', macro: 'export_molden', args: '', options: {}, _optsOpen: false };
     else if (type === 'custom') step = { id: 's' + (elcStepSeq++), kind: 'custom', label: '', code: '' };
     else return;
     elemcoState.steps.push(step);
@@ -436,8 +437,28 @@ function reorderElemCoStep(draggedId, targetId, after) {
 // --- rendering: step list ---------------------------------------------------
 function elcStepBadge(step) {
     if (step.kind === 'export') return 'Export';
+    if (step.kind === 'macro') return 'Macro';
     if (step.kind === 'custom') return 'Custom';
     return step.category === 'reference' ? 'Reference' : 'Method';
+}
+// Metadata for a parsed ElemCo.jl macro (js/elemco-macros.js), and whether a step
+// exposes an options browser (methods always; macros only if they take a block).
+function elemcoMacroDef(name) {
+    const M = window.ELEMCO_MACROS && window.ELEMCO_MACROS.macros;
+    return M ? (M.find((m) => m.name === name) || null) : null;
+}
+function stepAcceptsOptions(step) {
+    if (step.kind === 'method') return true;
+    if (step.kind === 'macro') { const d = elemcoMacroDef(step.macro); return !!(d && d.acceptsOptions); }
+    return false;
+}
+// The argument hint shown in a macro step's args field (signature minus opts_block).
+function elcMacroArgsPlaceholder(def) {
+    if (!def) return 'arguments';
+    const m = def.signature.match(/\(([^)]*)\)/);
+    if (!m) return 'arguments';
+    const a = m[1].replace(/,?\s*opts_block=nothing/, '').trim();
+    return a || 'no arguments';
 }
 function renderElemCoSteps() {
     const host = document.getElementById('elemco-steps');
@@ -544,6 +565,20 @@ function renderStepCard(step) {
             updateElemCoInput();
         });
         head.appendChild(fn);
+    } else if (step.kind === 'macro') {
+        const sel = elcEl('select', { class: 'elemco-step-method' });
+        ((window.ELEMCO_MACROS && window.ELEMCO_MACROS.macros) || []).forEach((m) => {
+            sel.appendChild(elcEl('option', { value: m.name, title: m.doc || '' }, '@' + m.name));
+        });
+        sel.value = step.macro;
+        const mdef = elemcoMacroDef(step.macro);
+        if (mdef) sel.title = mdef.doc || '';
+        sel.addEventListener('change', () => {
+            step.macro = sel.value;
+            renderElemCoSteps(); // options button / args hint / readout depend on the macro
+            updateElemCoInput();
+        });
+        head.appendChild(sel);
     } else {
         const lbl = elcEl('input', { type: 'text', class: 'elemco-step-file', placeholder: 'Custom Julia (used as a comment)', title: 'Label — added as a comment line above the code' });
         lbl.value = step.label || '';
@@ -553,7 +588,7 @@ function renderStepCard(step) {
 
     const actions = elcEl('span', { class: 'elemco-step-actions' });
     let optsMount = null;
-    if (step.kind === 'method') {
+    if (stepAcceptsOptions(step)) {
         const optCaret = elcEl('span', { class: 'elemco-caret' }, step._optsOpen ? '▾' : '▸');
         const optBtn = elcEl('button', { type: 'button', class: 'elemco-step-optbtn', title: 'Set options for this method' }, [optCaret, ' Options']);
         optBtn.addEventListener('click', () => {
@@ -582,8 +617,8 @@ function renderStepCard(step) {
         card.appendChild(detail);
     }
 
-    // Option chips + options browser (method steps only), below the detail.
-    if (step.kind === 'method') {
+    // Option chips + options browser (steps that accept a local @set block).
+    if (stepAcceptsOptions(step)) {
         const chipsEl = elcEl('div', { class: 'elemco-chips' });
         optsMount = elcEl('div', { class: 'elemco-step-options' });
         optsMount.style.display = step._optsOpen ? 'block' : 'none';
@@ -617,6 +652,18 @@ function buildStepDetail(step) {
         d.appendChild(step._readoutEl);
         return d;
     }
+    if (step.kind === 'macro') {
+        const def = elemcoMacroDef(step.macro);
+        const d = elcEl('div', { class: 'elemco-method-detail' });
+        d.appendChild(elcEl('span', { class: 'elemco-detail-label' }, 'args:'));
+        const inp = elcEl('input', { type: 'text', class: 'elemco-step-file', title: def ? def.signature : '', placeholder: elcMacroArgsPlaceholder(def) });
+        inp.value = step.args || '';
+        step._readoutEl = elcEl('span', { class: 'elemco-method-readout', title: 'Emitted ElemCo.jl call' }, elemcoStepHeadString(step));
+        inp.addEventListener('input', () => { step.args = inp.value; step._readoutEl.textContent = elemcoStepHeadString(step); updateElemCoInput(); });
+        d.appendChild(inp);
+        d.appendChild(step._readoutEl);
+        return d;
+    }
     if (step.kind === 'custom') {
         if (typeof elcMakeJuliaEditor === 'function') {
             const ed = elcMakeJuliaEditor('elemco-step-code');
@@ -637,6 +684,10 @@ function buildStepDetail(step) {
 // The ElemCo.jl call a method step emits (macro + optional method-string arg),
 // without the local-options block. Used both for generation and the live readout.
 function elemcoStepHeadString(step) {
+    if (step.kind === 'macro') {
+        const args = (step.args || '').trim();
+        return '@' + step.macro + (args ? ' ' + args : '');
+    }
     if (step.category === 'reference') {
         const def = elemcoMethodDef('reference', step.method);
         return def ? def.macro : '';
@@ -697,8 +748,9 @@ function renderCorrelationDetail(step) {
 }
 function renderStepOptions(step) {
     if (!step._optsMount || typeof renderOptionsBrowserInto !== 'function') return;
-    const def = elemcoMethodDef(step.category, step.method);
-    const groups = def ? def.groups : ['cc'];
+    let groups;
+    if (step.kind === 'macro') groups = []; // any macro: show all option groups
+    else { const def = elemcoMethodDef(step.category, step.method); groups = def ? def.groups : ['cc']; }
     renderOptionsBrowserInto(step._optsMount, groups, step.options, () => {
         renderStepChips(step);
         updateElemCoInput();
@@ -1022,6 +1074,7 @@ function updateElemCoInput() {
     // with any changed options as a local `begin ... end` @set block.
     function elcStepComment(step) {
         if (step.kind === 'export') return 'Export orbitals (Molden)';
+        if (step.kind === 'macro') return '';
         if (step.kind === 'custom') return (step.label || '').trim();
         if (step.category === 'correlation') {
             if (step.method === 'custom') return (step.custom || '').trim();
@@ -1038,6 +1091,12 @@ function updateElemCoInput() {
     function elcStepEmit(step) {
         if (step.kind === 'export') return `@export_molden ${elcJuliaStringLiteral(step.filename || 'orbitals.molden')}`;
         if (step.kind === 'custom') return (step.code || '').replace(/\s+$/, '');
+        if (step.kind === 'macro') {
+            const head = elemcoStepHeadString(step);
+            const lines = stepAcceptsOptions(step) ? bagSetLines(step.options || {}) : [];
+            if (lines.length === 0) return head;
+            return head + ' begin\n' + lines.map((l) => '  ' + l).join('\n') + '\nend';
+        }
         const head = elemcoStepHeadString(step);
         if (!head) return `# unknown method: ${step.method}`;
         const lines = bagSetLines(step.options || {});

--- a/js/elemco.js
+++ b/js/elemco.js
@@ -306,24 +306,47 @@ function elcEl(tag, props, children) {
 }
 
 // --- state init / reset -----------------------------------------------------
-function elcMapDefaultMethod(m) {
-    if (!m || m === 'HF') return null;
-    const map = { MP2: 'mp2', DCSD: 'dcsd', 'CCSD(T)': 'ccsd_t', CCSD: 'ccsd' };
-    return map[m] || 'dcsd';
-}
 function makeMethodStep(category, methodId) {
     const step = { id: 's' + (elcStepSeq++), kind: 'method', category, method: methodId, options: {}, _optsOpen: false };
     if (category === 'correlation') { step.spin = ''; step.custom = ''; step.customDf = false; }
     return step;
 }
+// Default step list for a mode, from preferences. Molecule mode always starts
+// with a DF-HF reference; FCIDUMP mode adds no reference when a correlated method
+// is chosen. A method value of 'HF' means reference-only (no correlation step).
+function elcBuildDefaultSteps(mode) {
+    const prefs = (typeof getPreferences === 'function') ? getPreferences() : {};
+    if (mode === 'fcidump') {
+        const m = prefs.defaultMethodFcidump || 'lambda_ccsd_t';
+        if (!m || m === 'HF') return [makeMethodStep('reference', 'bohf')];
+        return [makeMethodStep('correlation', m)];
+    }
+    const m = prefs.defaultMethodMolecule || 'ccsd_t';
+    const steps = [makeMethodStep('reference', 'dfhf')];
+    if (m && m !== 'HF') steps.push(makeMethodStep('correlation', m));
+    return steps;
+}
+// Are the current steps still the untouched defaults for `mode`? (structural
+// comparison, ignoring ids). Used to decide whether a mode change may rebuild.
+function elcStepsMatchDefault(mode) {
+    const def = elcBuildDefaultSteps(mode);
+    const cur = (elemcoState && elemcoState.steps) || [];
+    if (cur.length !== def.length) return false;
+    return cur.every((a, i) => {
+        const b = def[i];
+        if (a.kind !== 'method' || b.kind !== 'method') return false;
+        if (a.category !== b.category || a.method !== b.method) return false;
+        if ((a.spin || '') !== (b.spin || '')) return false;
+        if (a.options && Object.keys(a.options).length) return false;
+        return true;
+    });
+}
 function initElemCoState() {
     if (elemcoState && elemcoState._init) return;
     const prefs = (typeof getPreferences === 'function') ? getPreferences() : {};
     const ao = prefs.defaultBasisSet || 'cc-pVDZ';
-    const steps = [makeMethodStep('reference', 'dfhf')];
-    const corr = elcMapDefaultMethod(prefs.defaultMethod);
-    if (corr) steps.push(makeMethodStep('correlation', corr));
-    elemcoState = { _init: true, mode: 'molecule', modeUserSet: false, fcidump: 'FCIDUMP', basis: { ao, jkfit: 'auto', mpfit: 'auto' }, charge: 0, ms2: 0, global: {}, steps };
+    const mode = (typeof elcValidMoleculeXYZ === 'function' && elcValidMoleculeXYZ()) ? 'molecule' : 'fcidump';
+    elemcoState = { _init: true, mode, modeUserSet: false, fcidump: 'FCIDUMP', basis: { ao, jkfit: 'auto', mpfit: 'auto' }, charge: 0, ms2: 0, global: {}, steps: elcBuildDefaultSteps(mode) };
 }
 
 // Show the basis-set fields (molecule mode) or the FCIDUMP field, and update the
@@ -343,7 +366,11 @@ function applyElemCoModeUI() {
 // User picked a mode explicitly (so stop auto-switching from molecule presence).
 function setElemCoMode(mode) {
     initElemCoState();
-    elemcoState.mode = mode === 'fcidump' ? 'fcidump' : 'molecule';
+    const newMode = mode === 'fcidump' ? 'fcidump' : 'molecule';
+    if (newMode !== elemcoState.mode && elcStepsMatchDefault(elemcoState.mode)) {
+        elemcoState.steps = elcBuildDefaultSteps(newMode);
+    }
+    elemcoState.mode = newMode;
     elemcoState.modeUserSet = true;
     applyElemCoModeUI();
     renderElemCoSteps();
@@ -1067,7 +1094,13 @@ function updateElemCoInput() {
     // has explicitly chosen one (no molecule loaded -> FCIDUMP mode).
     if (!elemcoState.modeUserSet) {
         const auto = xyz ? 'molecule' : 'fcidump';
-        if (auto !== elemcoState.mode) { elemcoState.mode = auto; applyElemCoModeUI(); renderElemCoSteps(); }
+        if (auto !== elemcoState.mode) {
+            const wasDefault = elcStepsMatchDefault(elemcoState.mode);
+            elemcoState.mode = auto;
+            if (wasDefault) elemcoState.steps = elcBuildDefaultSteps(auto);
+            applyElemCoModeUI();
+            renderElemCoSteps();
+        }
     }
 
     // Emit a single calculation step (building block) as its ElemCo.jl macro,

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -543,6 +543,28 @@ function initPreferences() {
     console.log('User preferences initialized');
 }
 
+// Convert the always-visible per-option descriptions into hover help (an ⓘ icon
+// next to the label, description as its tooltip) so preference rows stay compact.
+// Standalone notes and dynamic result messages (no label) are left visible. Once.
+function elcCompactPreferenceDescriptions() {
+    const panel = document.getElementById('preferencesPanel');
+    if (!panel || panel._descsCompacted) return;
+    panel._descsCompacted = true;
+    panel.querySelectorAll('.preference-item').forEach((item) => {
+        const desc = item.querySelector('.preference-description');
+        const label = item.querySelector('.preference-label, .preference-checkbox-label');
+        if (!desc || !label) return;
+        const text = desc.textContent.trim();
+        if (!text) return;
+        const info = document.createElement('span');
+        info.className = 'preference-help';
+        info.textContent = 'ⓘ';
+        info.title = text;
+        label.appendChild(info);
+        desc.style.display = 'none';
+    });
+}
+
 // Show preferences panel
 function showPreferencesPanel() {
     const panel = document.getElementById('preferencesPanel');
@@ -551,6 +573,7 @@ function showPreferencesPanel() {
         // Reset transform to avoid it appearing in a strange location if previously dragged
         panel.style.transform = 'translate(0px, 0px)';
         loadPreferencesIntoUI();
+        elcCompactPreferenceDescriptions();
     }
 }
 

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -342,29 +342,12 @@ function applyPreferences() {
         }
     }
     
-    // Apply default basis set to ElemCo panel
+    // Apply the default basis set to the ElemCo builder state. The default
+    // method only seeds the initial steps (in initElemCoState), so it is not
+    // re-applied here — that would clobber steps the user has built.
     try {
-        const basisSelect = document.getElementById('elemco-basis');
-        if (basisSelect && prefs.defaultBasisSet) {
-            basisSelect.value = prefs.defaultBasisSet;
-        }
-        
-        // Apply default method to ElemCo panel
-        const methodSelect = document.getElementById('elemco-method');
-        if (methodSelect && prefs.defaultMethod) {
-            methodSelect.value = prefs.defaultMethod;
-        }
-        
-        // Apply DF preference
-        const dfCheckbox = document.getElementById('elemco-df');
-        if (dfCheckbox && prefs.useDF !== undefined) {
-            dfCheckbox.checked = prefs.useDF;
-            updateMethodOptions(); // Update available methods based on DF setting
-        }
-        
-        // Update ElemCo input with these preferences
-        if ((basisSelect || methodSelect) && typeof updateElemCoInput === 'function') {
-            updateElemCoInput();
+        if (typeof syncElemCoBasisFromPrefs === 'function') {
+            syncElemCoBasisFromPrefs();
         }
     } catch (e) {
         console.warn('Could not apply ElemCo preferences:', e);

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -27,7 +27,8 @@ const DEFAULT_PREFERENCES = {
     
     // ElemCo.jl settings
     defaultBasisSet: 'cc-pVDZ',
-    defaultMethod: 'HF',
+    defaultMethodMolecule: 'ccsd_t',
+    defaultMethodFcidump: 'lambda_ccsd_t',
     juliaCommand: 'julia',
     calcTimeout: 5,
     useDF: false,
@@ -37,6 +38,28 @@ const DEFAULT_PREFERENCES = {
     // xtb (g-xTB) settings
     xtbCommand: 'xtb'
 };
+
+// Fill a default-method <select> with a leading "reference only" (HF) option and
+// the grouped correlation methods from the ElemCo method registry.
+function elcPopulateMethodPrefSelect(sel, refOnlyLabel) {
+    if (!sel) return;
+    sel.innerHTML = '';
+    const none = document.createElement('option');
+    none.value = 'HF';
+    none.textContent = refOnlyLabel;
+    sel.appendChild(none);
+    ((typeof window !== 'undefined' && window.ELEMCO_CORRELATION_GROUPS) || []).forEach((g) => {
+        const og = document.createElement('optgroup');
+        og.label = g.group;
+        g.methods.forEach((m) => {
+            const o = document.createElement('option');
+            o.value = m.id;
+            o.textContent = m.label;
+            og.appendChild(o);
+        });
+        sel.appendChild(og);
+    });
+}
 
 // Switch between preference tabs
 function switchPreferencesTab(tabName) {
@@ -190,8 +213,12 @@ function loadPreferencesIntoUI() {
     const basisSetSelect = document.getElementById('pref-basis-set');
     if (basisSetSelect) basisSetSelect.value = prefs.defaultBasisSet || 'cc-pVDZ';
     
-    const methodSelect = document.getElementById('pref-method');
-    if (methodSelect) methodSelect.value = prefs.defaultMethod || 'HF';
+    const molMethodSelect = document.getElementById('pref-method-molecule');
+    const fciMethodSelect = document.getElementById('pref-method-fcidump');
+    elcPopulateMethodPrefSelect(molMethodSelect, 'HF (reference only)');
+    elcPopulateMethodPrefSelect(fciMethodSelect, 'BO-HF (reference only)');
+    if (molMethodSelect) molMethodSelect.value = prefs.defaultMethodMolecule || 'ccsd_t';
+    if (fciMethodSelect) fciMethodSelect.value = prefs.defaultMethodFcidump || 'lambda_ccsd_t';
     
     const juliaCommandInput = document.getElementById('pref-julia-command');
     if (juliaCommandInput) juliaCommandInput.value = prefs.juliaCommand || 'julia';
@@ -281,8 +308,10 @@ function savePreferencesFromUI() {
     const basisSetSelect = document.getElementById('pref-basis-set');
     if (basisSetSelect) prefs.defaultBasisSet = basisSetSelect.value;
     
-    const methodSelect = document.getElementById('pref-method');
-    if (methodSelect) prefs.defaultMethod = methodSelect.value;
+    const molMethodSelect = document.getElementById('pref-method-molecule');
+    if (molMethodSelect) prefs.defaultMethodMolecule = molMethodSelect.value;
+    const fciMethodSelect = document.getElementById('pref-method-fcidump');
+    if (fciMethodSelect) prefs.defaultMethodFcidump = fciMethodSelect.value;
     
     const juliaCommandInput = document.getElementById('pref-julia-command');
     if (juliaCommandInput) prefs.juliaCommand = juliaCommandInput.value.trim() || 'julia';

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -388,7 +388,16 @@ function loadPreferences() {
     try {
         const saved = localStorage.getItem('jlmol-preferences');
         if (saved) {
-            return { ...DEFAULT_PREFERENCES, ...JSON.parse(saved) };
+            const parsed = JSON.parse(saved);
+            const prefs = { ...DEFAULT_PREFERENCES, ...parsed };
+            // Migrate the legacy single default method (a UI label such as
+            // "CCSD(T)") to the per-mode molecule default (a method id like
+            // "ccsd_t"), so upgrading users keep their preferred method.
+            if (parsed.defaultMethod && parsed.defaultMethodMolecule === undefined) {
+                const map = { HF: 'HF', MP2: 'mp2', DCSD: 'dcsd', CCSD: 'ccsd', 'CCSD(T)': 'ccsd_t' };
+                if (map[parsed.defaultMethod]) prefs.defaultMethodMolecule = map[parsed.defaultMethod];
+            }
+            return prefs;
         }
     } catch (error) {
         console.warn('Error loading preferences:', error);

--- a/js/ui.js
+++ b/js/ui.js
@@ -8,8 +8,17 @@ function initDraggable() {
     // Every panel we've wired up, so window resizes can re-clamp them all.
     const draggables = [];
 
+    // Bumped each time a panel is clicked or shown so it comes to the front. The
+    // base (10000) stays above the main window, so panels are always on top of it.
+    let panelTopZ = 10000;
+
     function makeDraggable(panel, header) {
         if (!panel || !header) return;
+
+        // Clicking (or opening) a panel raises it above the other panels.
+        function bringToFront() { panel.style.zIndex = ++panelTopZ; }
+        panel.addEventListener('mousedown', bringToFront);
+        panel.addEventListener('touchstart', bringToFront, { passive: true });
 
         let isDragging = false;
         let currentX;
@@ -45,7 +54,7 @@ function initDraggable() {
             const display = panel.style.display;
             if (display !== lastDisplay) {
                 lastDisplay = display;
-                if (display !== 'none') applySizeLimit();
+                if (display !== 'none') { applySizeLimit(); bringToFront(); }
             }
         }).observe(panel, { attributes: true, attributeFilter: ['style'] });
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:mac": "electron-builder --mac",
     "build:linux": "electron-builder --linux",
     "check-version": "node build-version.js",
-    "update-elemco-options": "node scripts/parse-elemco-options.js"
+    "update-elemco-options": "node scripts/parse-elemco-options.js",
+    "update-elemco-macros": "node scripts/parse-elemco-macros.js"
   },
   "build": {
     "appId": "com.jlmol.viewer",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:windows": "electron-builder --win",
     "build:mac": "electron-builder --mac",
     "build:linux": "electron-builder --linux",
-    "check-version": "node build-version.js"
+    "check-version": "node build-version.js",
+    "update-elemco-options": "node scripts/parse-elemco-options.js"
   },
   "build": {
     "appId": "com.jlmol.viewer",

--- a/renderer.js
+++ b/renderer.js
@@ -2,7 +2,7 @@
 (function checkVersion(retryCount) {
     retryCount = retryCount || 0;
     const maxRetries = 50; // Max 5 seconds (50 * 100ms)
-    
+
     const versionElement = document.getElementById('version-number');
     if (versionElement && window.appVersion) {
         versionElement.textContent = window.appVersion;
@@ -23,33 +23,11 @@
 // are defined as globals in the js/ feature scripts (js/elemco.js, js/xtb.js), which
 // load after this file. We do NOT redefine them here — earlier definitions would just
 // be overridden, and the feature-script versions are authoritative.
-
-// Add event listeners for input changes when the DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
-    const method = document.getElementById('elemco-method');
-    const aoBasis = document.getElementById('elemco-basis');
-    const jkfitBasis = document.getElementById('elemco-jkfit');
-    const mpfitBasis = document.getElementById('elemco-mpfit');
-    const charge = document.getElementById('elemco-charge');
-    const multiplicity = document.getElementById('elemco-multiplicity');
-    const dfToggle = document.getElementById('elemco-df');
-    const moldenCheckbox = document.getElementById('elemco-molden');
-    const moldenFile = document.getElementById('elemco-molden-file');
-
-    // Add event listeners
-    method?.addEventListener('change', updateElemCoInput);
-    aoBasis?.addEventListener('change', updateElemCoInput);
-    jkfitBasis?.addEventListener('change', updateElemCoInput);
-    mpfitBasis?.addEventListener('change', updateElemCoInput);
-    charge?.addEventListener('input', updateElemCoInput);
-    multiplicity?.addEventListener('input', updateElemCoInput);
-    moldenCheckbox?.addEventListener('change', updateElemCoInput);
-    moldenFile?.addEventListener('input', updateElemCoInput);
-    dfToggle?.addEventListener('change', () => {
-        updateMethodOptions();
-        updateElemCoInput();
-    });
-});
+//
+// ElemCo panel initialization and its control listeners are owned by the builder:
+// js/app-init.js (initializeApplication, on window load) and js/elemco.js
+// (showElemCoPanel -> initElemCoPanel each time the panel opens). renderer.js no
+// longer wires ElemCo controls, to avoid duplicate handlers and redundant re-inits.
 
 // Wait for the window to load completely
 window.addEventListener('load', () => {
@@ -62,42 +40,5 @@ window.addEventListener('load', () => {
     // Ensure JSME is properly initialized in Electron context
     if (window.jsmeOnLoad) {
         window.jsmeOnLoad();
-    }
-
-    // Initialize ElemCo panel after a delay to ensure DOM is ready
-    setTimeout(() => {
-        if (typeof initElemCoPanel === 'function') {
-            try {
-                initElemCoPanel();
-                initializeElemCoListeners();
-            } catch (e) {
-                console.error('Error initializing ElemCo panel:', e);
-            }
-        }
-    }, 1000);
-
-    // Re-initialize on visibility changes (but only once per change)
-    let isHidden = false;
-    document.addEventListener('visibilitychange', () => {
-        if (!document.hidden && isHidden && typeof initElemCoPanel === 'function') {
-            try {
-                initElemCoPanel();
-                initializeElemCoListeners();
-            } catch (e) {
-                console.error('Error re-initializing ElemCo panel:', e);
-            }
-        }
-        isHidden = document.hidden;
-    });
-});
-
-// Handle window resize events
-window.addEventListener('resize', () => {
-    // Reinitialize panels if they're visible
-    const elemcoPanel = document.getElementById('elemcoPanel');
-    if (elemcoPanel && elemcoPanel.style.display !== 'none') {
-        if (typeof initElemCoPanel === 'function') {
-            initElemCoPanel();
-        }
     }
 });

--- a/scripts/parse-elemco-macros.js
+++ b/scripts/parse-elemco-macros.js
@@ -116,7 +116,10 @@ function parseMacros(text) {
     }
     const al = line.match(/^\s*var"@([A-Za-z_][\w!ϕΛ]*)"\s*=\s*var"@([A-Za-z_][\w!ϕΛ]*)"/);
     if (al) { aliases.push({ name: al[1], target: al[2] }); pendingDoc = null; continue; }
-    if (line.trim() !== '') pendingDoc = pendingDoc; // keep doc across blanks only
+    // A docstring attaches only to an immediately-following macro/alias (blank
+    // lines allowed). Any intervening code ends the association so a docstring
+    // can't leak onto a later definition.
+    if (line.trim() !== '') pendingDoc = null;
   }
 
   // 3) acceptsOptions: does the macro body use an options block?

--- a/scripts/parse-elemco-macros.js
+++ b/scripts/parse-elemco-macros.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * Parse ElemCo.jl's exported macros and emit js/elemco-macros.js.
+ *
+ * ElemCo.jl's public macros are declared in src/ElemCo.jl as `export @name, …`
+ * lines followed by `"""docstring""" macro name(sig) … end` definitions. This
+ * script collects the exported macros with their signature, a cleaned docstring
+ * (for hover help), and whether they accept a local `begin…end` options block, so
+ * the renderer can offer a "Macro" building block.
+ *
+ * Usage:
+ *   node scripts/parse-elemco-macros.js                 # fetch main from GitHub
+ *   node scripts/parse-elemco-macros.js --ref v0.14.0   # fetch a tag/branch/sha
+ *   node scripts/parse-elemco-macros.js --file path.jl  # parse a local file
+ *   node scripts/parse-elemco-macros.js --stdout        # print, don't write
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = 'fkfest/ElemCo.jl';
+const SRC_PATH = 'src/ElemCo.jl';
+const OUT_PATH = path.join(__dirname, '..', 'js', 'elemco-macros.js');
+
+// Internal setup/util macros that aren't useful as user-facing building blocks.
+const SKIP = new Set(['ECinit', 'tryECinit', 'setupEC', 'var2string', 'mainname', 'print_input']);
+
+function parseArgs(argv) {
+  const args = { ref: 'main', file: null, stdout: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--ref') args.ref = argv[++i];
+    else if (a === '--file') args.file = argv[++i];
+    else if (a === '--stdout') args.stdout = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+async function getSource(args) {
+  if (args.file) return { text: fs.readFileSync(args.file, 'utf8'), ref: `file:${args.file}`, url: args.file };
+  const url = `https://raw.githubusercontent.com/${REPO}/${args.ref}/${SRC_PATH}`;
+  if (typeof fetch !== 'function') throw new Error('global fetch() unavailable; use Node >=18 or pass --file');
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+  return { text: await res.text(), ref: args.ref, url };
+}
+
+// Turn a docstring into concise hover text: drop the leading signature line and
+// everything from the first section header / code fence, then strip markdown.
+function cleanDoc(raw) {
+  const lines = raw.replace(/\r/g, '').split('\n');
+  const kept = [];
+  let started = false;
+  for (const line of lines) {
+    const t = line.trim();
+    if (!started) {
+      if (t === '') continue;           // leading blanks
+      if (t.startsWith('@')) { started = true; continue; } // signature line
+      started = true;                    // no signature line; description starts
+    }
+    if (t.startsWith('```') || t.startsWith('# ')) break; // stop at examples/sections
+    kept.push(line);
+  }
+  let s = kept.join('\n');
+  s = s.replace(/\[`?([^`\]]+?)`?\]\(@ref[^)]*\)/g, '$1'); // cross-refs -> text
+  s = s.replace(/\[([^\]]+?)\]\([^)]*\)/g, '$1');
+  s = s.replace(/`/g, '');
+  s = s.replace(/[ \t]+/g, ' ');
+  s = s.replace(/\n{3,}/g, '\n\n').trim();
+  return s;
+}
+
+function parseMacros(text) {
+  const lines = text.split('\n');
+
+  // 1) exported macro names.
+  const exported = new Set();
+  for (const line of lines) {
+    const m = line.match(/^\s*export\s+(.+)$/);
+    if (!m) continue;
+    const names = m[1].match(/@[A-Za-z_][\w!ϕΛ]*/g) || [];
+    names.forEach((n) => exported.add(n.slice(1)));
+  }
+
+  // 2) walk with a triple-quote state machine, capturing each macro def's doc.
+  const defs = []; // { name, sig, doc, line }
+  const aliases = []; // { name, target }
+  let inDoc = false;
+  let docBuf = [];
+  let pendingDoc = null;
+
+  const finishDoc = () => { pendingDoc = docBuf.join('\n'); docBuf = []; };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const quotes = (line.match(/"""/g) || []).length;
+
+    if (inDoc) {
+      if (quotes % 2 === 1) { docBuf.push(line.slice(0, line.indexOf('"""'))); inDoc = false; finishDoc(); }
+      else docBuf.push(line);
+      continue;
+    }
+    if (quotes >= 2) { docBuf.push(line.slice(line.indexOf('"""') + 3, line.lastIndexOf('"""'))); finishDoc(); continue; }
+    if (quotes === 1) { docBuf.push(line.slice(line.indexOf('"""') + 3)); inDoc = true; continue; }
+
+    const md = line.match(/^\s*macro\s+([A-Za-z_][\w!ϕΛ]*)\s*\(([^)]*)\)/);
+    if (md) {
+      defs.push({ name: md[1], sig: md[2].trim(), doc: cleanDoc(pendingDoc || ''), line: i });
+      pendingDoc = null;
+      continue;
+    }
+    const al = line.match(/^\s*var"@([A-Za-z_][\w!ϕΛ]*)"\s*=\s*var"@([A-Za-z_][\w!ϕΛ]*)"/);
+    if (al) { aliases.push({ name: al[1], target: al[2] }); pendingDoc = null; continue; }
+    if (line.trim() !== '') pendingDoc = pendingDoc; // keep doc across blanks only
+  }
+
+  // 3) acceptsOptions: does the macro body use an options block?
+  const OPT_RE = /opts_block|is_options_block|with_local_options/;
+  const byName = {};
+  defs.forEach((d, idx) => {
+    const end = idx + 1 < defs.length ? defs[idx + 1].line : Math.min(lines.length, d.line + 80);
+    const body = lines.slice(d.line, end).join('\n');
+    d.acceptsOptions = OPT_RE.test(body);
+    byName[d.name] = d;
+  });
+
+  // 4) resolve aliases to their target's metadata.
+  aliases.forEach((a) => {
+    const t = byName[a.target];
+    if (t && !byName[a.name]) {
+      defs.push({ name: a.name, sig: t.sig, doc: `Alias for @${a.target}. ${t.doc}`.trim(), acceptsOptions: t.acceptsOptions, line: t.line });
+      byName[a.name] = byName[a.target];
+    }
+  });
+
+  // 5) keep exported, non-internal macros; sort by name.
+  const macros = defs
+    .filter((d) => exported.has(d.name) && !SKIP.has(d.name))
+    .map((d) => ({ name: d.name, signature: `@${d.name}(${d.sig})`, acceptsOptions: !!d.acceptsOptions, doc: d.doc }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return macros;
+}
+
+function render(macros, source) {
+  const generated = new Date().toISOString().slice(0, 10);
+  const header =
+`// AUTO-GENERATED — do not edit by hand.
+// Source: ElemCo.jl ${SRC_PATH} @ ${source.ref}
+// Regenerate: node scripts/parse-elemco-macros.js [--ref <tag>]
+`;
+  const payload = { sourceRepo: REPO, sourceRef: source.ref, sourceUrl: source.url, generated, macros };
+  return `${header}window.ELEMCO_MACROS = ${JSON.stringify(payload, null, 2)};\n`;
+}
+
+(async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) { console.log('Usage: node scripts/parse-elemco-macros.js [--ref <tag>] [--file <path>] [--stdout]'); return; }
+  const source = await getSource(args);
+  const macros = parseMacros(source.text);
+  if (macros.length < 15) throw new Error(`Sanity check failed: parsed only ${macros.length} macros — refusing to write.`);
+  const out = render(macros, source);
+  if (args.stdout) process.stdout.write(out);
+  else { fs.writeFileSync(OUT_PATH, out); console.log(`Wrote ${path.relative(path.join(__dirname, '..'), OUT_PATH)} — ${macros.length} macros (ElemCo.jl @ ${source.ref}).`); }
+})().catch((err) => { console.error(`parse-elemco-macros: ${err.message}`); process.exit(1); });

--- a/scripts/parse-elemco-options.js
+++ b/scripts/parse-elemco-options.js
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+/**
+ * Parse ElemCo.jl's option definitions and emit js/elemco-options.js.
+ *
+ * ElemCo.jl declares every calculation option in src/infos/options.jl as a set
+ * of `@kwdef mutable struct XxxOptions` blocks (one per option group: wf, scf,
+ * cc, ...), plus a master `Options` struct that maps each group key to its
+ * struct. Each field carries a triple-quoted docstring holding a `⟨default⟩`
+ * marker and a human description. This script turns that into a static metadata
+ * object the renderer consumes to build the options browser / method builder.
+ *
+ * Usage:
+ *   node scripts/parse-elemco-options.js                 # fetch main from GitHub
+ *   node scripts/parse-elemco-options.js --ref v0.14.0   # fetch a tag/branch/sha
+ *   node scripts/parse-elemco-options.js --file path.jl  # parse a local file
+ *   node scripts/parse-elemco-options.js --stdout        # print, don't write
+ *
+ * The generated js/elemco-options.js is committed so the build stays offline;
+ * re-run this whenever ElemCo.jl's options change.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO = 'fkfest/ElemCo.jl';
+const SRC_PATH = 'src/infos/options.jl';
+const OUT_PATH = path.join(__dirname, '..', 'js', 'elemco-options.js');
+
+function parseArgs(argv) {
+  const args = { ref: 'main', file: null, stdout: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--ref') args.ref = argv[++i];
+    else if (a === '--file') args.file = argv[++i];
+    else if (a === '--stdout') args.stdout = true;
+    else if (a === '--help' || a === '-h') { args.help = true; }
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+async function getSource(args) {
+  if (args.file) {
+    return { text: fs.readFileSync(args.file, 'utf8'), ref: `file:${args.file}`, url: args.file };
+  }
+  const url = `https://raw.githubusercontent.com/${REPO}/${args.ref}/${SRC_PATH}`;
+  if (typeof fetch !== 'function') {
+    throw new Error('global fetch() unavailable; use Node >=18 or pass --file');
+  }
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+  return { text: await res.text(), ref: args.ref, url };
+}
+
+// ---------------------------------------------------------------------------
+// Description cleanup: turn a Julia docstring into plain tooltip text and pull
+// out the leading `⟨default⟩` marker.
+// ---------------------------------------------------------------------------
+function cleanDescription(raw) {
+  let s = raw.replace(/\$\(TYPEDFIELDS\)/g, ' ').trim();
+  // Documenter cross-references and markdown links -> just the link text.
+  s = s.replace(/\[`?([^`\]]+?)`?\]\(@ref[^)]*\)/g, '$1');
+  s = s.replace(/\[([^\]]+?)\]\([^)]*\)/g, '$1');
+  s = s.replace(/`/g, '');              // drop inline-code backticks
+  s = s.replace(/\s+/g, ' ').trim();    // collapse whitespace/newlines
+  return s;
+}
+
+// The docstring convention is: `⟨<default>⟩` <description>. Pull the marker out
+// (⟨ = U+27E8, ⟩ = U+27E9). The marker sometimes holds an expression such as
+// `sqrt(thr)*0.1` that differs from the literal code default, so we keep it
+// separately for display but never treat it as the parsed value.
+function splitDefaultMarker(desc) {
+  const m = desc.match(/^⟨([^⟩]*)⟩\s*/);
+  if (m) return { defaultDoc: m[1].trim(), text: desc.slice(m[0].length).trim() };
+  return { defaultDoc: null, text: desc };
+}
+
+// ---------------------------------------------------------------------------
+// Julia default literal -> { value, jsType }. Returns value:undefined and
+// jsType:'unknown' for anything we can't confidently interpret (expressions,
+// function calls), so the UI falls back to a raw text field.
+// ---------------------------------------------------------------------------
+function parseLiteral(literal, declaredType) {
+  const lit = literal.trim();
+
+  if (lit === 'true' || lit === 'false') return { value: lit === 'true', jsType: 'bool' };
+
+  // Symbol, e.g. :SAD, :SO_SCI
+  let m = lit.match(/^:([A-Za-z_][A-Za-z0-9_]*)$/);
+  if (m) return { value: m[1], jsType: 'symbol' };
+
+  // String, e.g. "wf.h5", "", "-"
+  m = lit.match(/^"((?:[^"\\]|\\.)*)"$/);
+  if (m) return { value: m[1], jsType: 'string' };
+
+  // Vector, e.g. [100, 200] or [1e-6, 1e-7, 0.0]
+  if (/^\[.*\]$/.test(lit)) {
+    const inner = lit.slice(1, -1).trim();
+    if (inner === '') return { value: [], jsType: 'vector-float' };
+    const parts = inner.split(',').map((p) => p.trim());
+    const nums = parts.map(parseNumber);
+    if (nums.every((n) => n !== null)) {
+      const allInt = parts.every((p) => /^[+-]?[0-9_]+$/.test(p));
+      return { value: nums, jsType: allInt ? 'vector-int' : 'vector-float' };
+    }
+    return { value: undefined, jsType: 'unknown' };
+  }
+
+  // Numbers (respect the declared type to distinguish Int vs Float64)
+  const num = parseNumber(lit);
+  if (num !== null) {
+    const isFloat =
+      declaredType === 'Float64' ||
+      /[.eE]/.test(lit.replace(/_/g, '')) ||
+      declaredType === undefined && /[.eE]/.test(lit);
+    return { value: num, jsType: isFloat ? 'float' : 'int' };
+  }
+
+  return { value: undefined, jsType: 'unknown' };
+}
+
+// Julia numeric literal -> Number (handles 1_000_000, 1.e-10, 1e-6, .5).
+function parseNumber(s) {
+  const t = s.replace(/_/g, '');
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/.test(t)) return null;
+  const n = Number(t);
+  return Number.isNaN(n) ? null : n;
+}
+
+// Map a Julia declared type (or, if absent, the inferred jsType) to a widget hint.
+function widgetType(declaredType, inferred) {
+  switch (declaredType) {
+    case 'Bool': return 'bool';
+    case 'Int': return 'int';
+    case 'Float64': return 'float';
+    case 'String': return 'string';
+    case 'Symbol': return 'symbol';
+    case 'Vector{Int}': return 'vector-int';
+    case 'Vector{Float64}': return 'vector-float';
+    default: return inferred; // no annotation: trust the literal
+  }
+}
+
+// Collect `:Choice` tokens mentioned in a docstring (backticked or not). Best
+// effort: Symbol options list their allowed values in prose. Always include the
+// default so the resulting set is never empty for a real choice.
+function extractChoices(desc, defaultValue) {
+  const found = [];
+  const re = /:([A-Za-z_][A-Za-z0-9_]*)/g;
+  let m;
+  while ((m = re.exec(desc)) !== null) {
+    if (!found.includes(m[1])) found.push(m[1]);
+  }
+  if (defaultValue != null && !found.includes(defaultValue)) found.unshift(defaultValue);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Core parser: line state machine over options.jl.
+// ---------------------------------------------------------------------------
+function parseOptions(text) {
+  const lines = text.split('\n');
+
+  const structDocs = {};   // StructName -> cleaned struct docstring
+  const structFields = {}; // StructName -> { field -> meta }
+  const structOrder = [];  // struct declaration order
+  let masterGroups = null; // from the `Options` struct: [{ key, struct, doc }]
+
+  let inDoc = false;
+  let docBuf = [];
+  let pendingDoc = null;   // last completed docstring, awaiting a struct/field
+  let currentStruct = null;
+
+  const STRUCT_RE = /^\s*@kwdef\s+mutable\s+struct\s+([A-Za-z_][A-Za-z0-9_]*)/;
+  const FIELD_RE = /^\s*([A-Za-z_][A-Za-z0-9_!]*)\s*(?:::\s*([^=]+?))?\s*=\s*(.+?)\s*$/;
+
+  const finishDoc = () => {
+    pendingDoc = docBuf.join('\n').trim();
+    docBuf = [];
+  };
+
+  for (const line of lines) {
+    const quoteCount = (line.match(/"""/g) || []).length;
+
+    if (inDoc) {
+      if (quoteCount % 2 === 1) {
+        docBuf.push(line.slice(0, line.indexOf('"""')));
+        inDoc = false;
+        finishDoc();
+      } else {
+        docBuf.push(line);
+      }
+      continue;
+    }
+
+    if (quoteCount >= 2) {
+      // Opens and closes on one line.
+      const first = line.indexOf('"""');
+      const last = line.lastIndexOf('"""');
+      docBuf.push(line.slice(first + 3, last));
+      finishDoc();
+      continue;
+    }
+    if (quoteCount === 1) {
+      docBuf.push(line.slice(line.indexOf('"""') + 3));
+      inDoc = true;
+      continue;
+    }
+
+    // --- plain code line ---
+    const structM = line.match(STRUCT_RE);
+    if (structM) {
+      const name = structM[1];
+      structDocs[name] = cleanDescription(pendingDoc || '');
+      structFields[name] = {};
+      structOrder.push(name);
+      currentStruct = name;
+      pendingDoc = null;
+      continue;
+    }
+
+    if (/^\s*end\b/.test(line)) {
+      currentStruct = null;
+      pendingDoc = null;
+      continue;
+    }
+
+    if (currentStruct) {
+      const fieldM = line.match(FIELD_RE);
+      if (fieldM) {
+        const [, fname, rawType, rawDefault] = fieldM;
+        const declaredType = rawType ? rawType.trim() : undefined;
+
+        if (currentStruct === 'Options') {
+          // Master struct: `wf::WfOptions = WfOptions()` etc.
+          if (!masterGroups) masterGroups = [];
+          masterGroups.push({
+            key: fname,
+            struct: declaredType,
+            doc: cleanDescription(pendingDoc || ''),
+          });
+          pendingDoc = null;
+          continue;
+        }
+
+        const descRaw = cleanDescription(pendingDoc || '');
+        const { defaultDoc, text: descText } = splitDefaultMarker(descRaw);
+        const { value, jsType: inferred } = parseLiteral(rawDefault, declaredType);
+        const wtype = widgetType(declaredType, inferred);
+        const meta = {
+          name: fname,
+          type: declaredType || `(${inferred})`,
+          widget: wtype,
+          default: value,
+          defaultLiteral: rawDefault.trim(),
+          defaultDoc,
+          desc: descText,
+        };
+        if (wtype === 'symbol') meta.choices = extractChoices(descRaw, value);
+        structFields[currentStruct][fname] = meta;
+        pendingDoc = null;
+        continue;
+      }
+    }
+
+    // Anything else (blank, comment, stray code) drops any dangling doc only if
+    // it's clearly unrelated; keep pendingDoc across blank lines.
+    if (line.trim() !== '' && !/^\s*#/.test(line)) {
+      // non-field, non-doc code inside/after a struct: leave pendingDoc as-is
+    }
+  }
+
+  if (!masterGroups) throw new Error('Could not find master `Options` struct — parser out of date?');
+
+  // Assemble groups in the master struct's declared order.
+  const groups = {};
+  const groupOrder = [];
+  for (const g of masterGroups) {
+    const fields = structFields[g.struct];
+    if (!fields) throw new Error(`Master group '${g.key}' references unknown struct '${g.struct}'`);
+    const label = cleanLabel(structDocs[g.struct] || g.doc || g.key);
+    groups[g.key] = {
+      key: g.key,
+      struct: g.struct,
+      label,
+      summary: g.doc,
+      fields,
+    };
+    groupOrder.push(g.key);
+  }
+
+  return { groups, groupOrder };
+}
+
+// "Options for wavefunction/orbitals." -> "Wavefunction/orbitals"
+function cleanLabel(structDoc) {
+  let s = (structDoc || '').split(/[.\n]/)[0].trim();
+  s = s.replace(/^Options?\s+for\s+/i, '').replace(/^Option\s+for\s+/i, '');
+  if (!s) return structDoc;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function render(meta, source) {
+  const generated = new Date().toISOString().slice(0, 10);
+  const header =
+`// AUTO-GENERATED — do not edit by hand.
+// Source: ElemCo.jl ${SRC_PATH} @ ${source.ref}
+// Regenerate: node scripts/parse-elemco-options.js [--ref <tag>]
+`;
+  const payload = {
+    sourceRepo: REPO,
+    sourceRef: source.ref,
+    sourceUrl: source.url,
+    generated,
+    groupOrder: meta.groupOrder,
+    groups: meta.groups,
+  };
+  return `${header}window.ELEMCO_OPTIONS = ${JSON.stringify(payload, null, 2)};\n`;
+}
+
+(async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log('Usage: node scripts/parse-elemco-options.js [--ref <tag>] [--file <path>] [--stdout]');
+    return;
+  }
+  const source = await getSource(args);
+  const meta = parseOptions(source.text);
+
+  const numGroups = meta.groupOrder.length;
+  const numFields = meta.groupOrder.reduce((n, k) => n + Object.keys(meta.groups[k].fields).length, 0);
+  if (numGroups < 5 || numFields < 50) {
+    throw new Error(`Sanity check failed: parsed only ${numGroups} groups / ${numFields} fields — refusing to write a likely-broken metadata file.`);
+  }
+
+  const out = render(meta, source);
+  if (args.stdout) {
+    process.stdout.write(out);
+  } else {
+    fs.writeFileSync(OUT_PATH, out);
+    console.log(`Wrote ${path.relative(path.join(__dirname, '..'), OUT_PATH)} — ${numGroups} groups, ${numFields} options (ElemCo.jl @ ${source.ref}).`);
+  }
+})().catch((err) => {
+  console.error(`parse-elemco-options: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Reworks the ElemCo.jl panel from a fixed form into a method-driven, building-block input builder. Slated for **v1.5.0** (version bump + tag done at release time, after merge; changelog entries are staged under `## [Unreleased]`).

## Highlights

- **Building-block builder** — a calculation is an ordered list of steps (Reference / Method / Export / Macro / Custom) you add, remove, reorder (buttons or drag), and collapse. Each step emits its ElemCo.jl macro; only options changed from their ElemCo.jl defaults are emitted, as a local `begin … end @set` block.
- **Full options browser** — all 13 option groups (~157 options), searchable and grouped, with typed inputs, defaults pre-filled, descriptions on hover, and per-option reset. Generated from ElemCo.jl's `options.jl` (`js/elemco-options.js`, `npm run update-elemco-options`).
- **Composable methods** — grouped correlation methods + a separate spin selector (closed / `U` / `R`) that composes the ElemCo.jl method string in canonical prefix order (`UCCSD`, `ΛCCSD(T)`, `EOM-UCCSD`), with a live read-out and a "Custom…" free-text method (with a DF toggle). Adds ΛCCSD(T), CCD, DCD, QV-/OQV-CCD/DCD, EOM-CCSD/DCSD, FCI, CIPHI.
- **FCIDUMP mode** — Molecule/FCIDUMP switch; emits `fcidump = "…"` instead of geometry+basis, no reference step. Auto-selected when no molecule is loaded.
- **Generic Macro step** — any exported ElemCo.jl macro, with docstring on hover, an args field, and a local options block where supported. Parsed from source (`js/elemco-macros.js`, `npm run update-elemco-macros`).
- **Julia syntax highlighting** in the input and custom-code editors.
- Separate default methods for molecule vs FCIDUMP in Settings; per-mode default steps.

## Also
- Wider, collapsible panel with unified typography; larger fold carets.
- "Insert Selected Atoms" targets the last-focused field.
- Click/open a floating panel to bring it to the front (always above the main window).
- Preference descriptions moved to ⓘ hover help.
- Removes the global "DF" checkbox / single default-method setting (now per step).

## Notes for reviewers
- `js/elemco-options.js` and `js/elemco-macros.js` are **generated** and committed (parsers under `scripts/`); regenerate with the `npm run update-elemco-*` scripts if ElemCo.jl changes.
- No version bump in this PR; `npm run check-version` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)