### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-19
+
 ### Added
 
 - ElemCo.jl input builder rework: the ElemCo.jl panel is now a method-driven "building block" editor. A calculation is assembled from an ordered list of steps (Reference, Method, Export, Macro, Custom) that you can add, remove, reorder (with the up/down buttons or by dragging the grip), and collapse. Each step emits its ElemCo.jl macro, and only the options you change from their ElemCo.jl defaults are emitted, as a local `begin … end @set` block, keeping the generated script minimal.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jlmol",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "jlmol - A Molecular Viewer Desktop App",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Release PR for **v1.5.0**.

- Bumps `package.json` to `1.5.0` (`npm run check-version` passes).
- Finalizes `CHANGELOG.md`: renames the accumulated `[Unreleased]` section to `## [1.5.0] - 2026-07-19` and adds a fresh empty `[Unreleased]`.

Headline: the ElemCo.jl input panel is reworked into a method-driven "building block" builder with a full options browser, composable method selection, FCIDUMP mode, a generic Macro step, and Julia syntax highlighting (see the changelog for the complete list).

After merge: tag `main` with an annotated `v1.5.0` and push it to trigger the release build (Windows + Linux), which produces a **draft** GitHub release that must be published manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)