### PR TITLE
webpage: update for v1.5.0 (ElemCo.jl input builder)

### DIFF
--- a/help/elemco.html
+++ b/help/elemco.html
@@ -105,12 +105,13 @@
             <p>JLmol offers deep integration with <strong>ElemCo.jl</strong>, a modern Julia-based quantum chemistry package. This enables users to go from structure visualization to high-level computation and back, all within a single interface. The integration is designed for both beginners and advanced users, with support for local, WSL, and remote execution.</p>
             <h3>Input Generation:</h3>
             <ul>
-                <li>Automatically generate ElemCo.jl input files from any loaded structure.</li>
-                <li>Select from a broad range of methods: HF, MP2, DCSD, CCSD(T), CCSDT, DC-CCSDT, and the SVD-based SVD-DCSD and SVD-DC-CCSDT.</li>
-                <li>Choose correlation-consistent basis sets (cc-pVDZ/TZ, aug-cc-pVDZ/TZ) and auxiliary JK- and MP2-fitting sets, and toggle density fitting for supported methods.</li>
-                <li>Set charge and multiplicity, then edit the generated input directly or copy it to the clipboard.</li>
-                <li><strong>Molden orbital export:</strong> add an option in the input editor to dump the calculated orbitals in Molden format, ready to be reopened in JLmol or other tools for <a href="orbitals.html">orbital visualization</a>.</li>
-                <li><strong>Insert Selected Atoms:</strong> insert the atoms currently <a href="editing.html#atom-selection">selected</a> in the structure as a 1-based index list (e.g. <code>[1, 3, 5]</code>) at the cursor &mdash; useful for defining dummy atoms or active regions.</li>
+                <li>Build a calculation from ordered &ldquo;building blocks&rdquo; &mdash; a reference, correlation methods, exports, custom Julia, or any ElemCo.jl macro &mdash; that you add, remove, reorder and collapse, with the generated Julia updating live.</li>
+                <li>Select methods from grouped menus with a spin selector (closed-shell / <code>U</code> / <code>R</code>): HF, MP2, the coupled-cluster and distinguishable-cluster families, ΛCCSD(T), quasi-variational (QV / OQV) methods, excited states (EOM), FCI and CIPHI &mdash; composed into the ElemCo.jl method string (e.g. <code>UCCSD</code>, <code>EOM-UCCSD</code>).</li>
+                <li>Set any ElemCo.jl option through a searchable options browser: every option is pre-filled with its default and shows its description on hover, and only the values you change are written to the input.</li>
+                <li>Choose correlation-consistent basis sets (cc-pVDZ/TZ, aug-cc-pVDZ/TZ) and auxiliary JK- and MP2-fitting sets, or switch to <strong>FCIDUMP mode</strong> to read integrals from a file instead of a geometry and basis.</li>
+                <li>Set the charge and spin, add any macro exported by ElemCo.jl as a step (with its signature and docstring shown as help), then edit the generated input directly &mdash; with Julia syntax highlighting &mdash; or copy it to the clipboard.</li>
+                <li><strong>Molden orbital export:</strong> add an export step to dump the calculated orbitals in Molden format, ready to be reopened in JLmol or other tools for <a href="orbitals.html">orbital visualization</a>.</li>
+                <li><strong>Insert Selected Atoms:</strong> insert the atoms currently <a href="editing.html#atom-selection">selected</a> in the structure as a 1-based index list (e.g. <code>[1, 3, 5]</code>) at the cursor of whichever field you're editing &mdash; useful for defining dummy atoms or active regions.</li>
             </ul>
             <h3>Calculation Runner:</h3>
             <ul>
@@ -122,7 +123,7 @@
             </ul>
             <h3>User Preferences & Technical Details:</h3>
             <ul>
-                <li>Configure Julia executable path, default methods, and basis sets in the settings panel.</li>
+                <li>Configure the Julia executable path, per-mode default methods (molecule and FCIDUMP), and the default basis set in the settings panel.</li>
                 <li>Preferences are saved between sessions for a persistent workflow.</li>
                 <li>Calculation output can be visualized directly (orbitals, energies, etc.).</li>
                 <li>Handles errors gracefully and provides detailed feedback for failed jobs.</li>

--- a/index.html
+++ b/index.html
@@ -676,6 +676,13 @@
             <p class="section-subtitle">Highlights from recent releases. See the <a href="https://github.com/fkfest/jlmol/blob/main/CHANGELOG.md" target="_blank" rel="noopener noreferrer" class="learn-more-link">full changelog</a> for every change.</p>
             <div class="news-grid">
                 <div class="news-card">
+                    <p class="news-date">July 2026 &middot; v1.5.0</p>
+                    <h3>ElemCo.jl Input Builder</h3>
+                    <p>Assemble a calculation from ordered building blocks, browse and set every ElemCo.jl option (defaults and descriptions included), compose methods with spin prefixes (UCCSD, ΛCCSD(T), EOM-UCCSD), and work from a geometry or an FCIDUMP file &mdash; with Julia syntax highlighting.</p>
+                    <a href="help/elemco.html" class="learn-more-link">Learn More &rarr;</a>
+                </div>
+
+                <div class="news-card">
                     <p class="news-date">May 2026 &middot; v1.4.0</p>
                     <h3>Semiempirical Calculations with xtb / g-xTB</h3>
                     <p>Calculate the energy or optimize the geometry of the current structure with the g-xTB method in one click. Set charge, unpaired electrons, and extra flags, and even freeze atoms to relax only a selected region.</p>
@@ -689,12 +696,6 @@
                     <a href="help/editing.html#atom-selection" class="learn-more-link">Learn More &rarr;</a>
                 </div>
 
-                <div class="news-card">
-                    <p class="news-date">February 2026 &middot; v1.3.0</p>
-                    <h3>Molden Orbital Export &amp; Redesigned Preferences</h3>
-                    <p>Dump orbitals in Molden format directly from the ElemCo.jl input editor, and enjoy a cleaner, tabbed preferences panel along with a quieter, auto-hiding interface.</p>
-                    <a href="help/elemco.html" class="learn-more-link">Learn More &rarr;</a>
-                </div>
             </div>
             <div style="text-align: center; margin-top: 3rem;">
                 <a href="news.html" class="btn btn-primary" style="background:#4F46E5;color:#fff;">View all updates &rarr;</a>

--- a/news.html
+++ b/news.html
@@ -121,6 +121,17 @@
         <p class="section-subtitle">Highlights from each JLmol release, newest first.</p>
 
         <div class="news-card">
+            <p class="news-date">July 2026 &middot; v1.5.0</p>
+            <h3>ElemCo.jl Input Builder</h3>
+            <ul>
+                <li><strong>Building-block editor:</strong> assemble a calculation from ordered steps (a reference, correlation methods, exports, custom Julia, or any ElemCo.jl macro) that you add, reorder and collapse, with the generated Julia updating live. <a href="help/elemco.html">Learn more &rarr;</a></li>
+                <li><strong>Full options browser:</strong> set any ElemCo.jl option from a searchable, grouped list &mdash; defaults pre-filled, descriptions on hover &mdash; with only your changes written to the input. The option catalogue is generated from ElemCo.jl's own source.</li>
+                <li><strong>Composable methods:</strong> grouped menus with a spin selector (closed-shell / <code>U</code> / <code>R</code>) that build the ElemCo.jl method string (e.g. <code>UCCSD</code>, <code>ΛCCSD(T)</code>, <code>EOM-UCCSD</code>); adds ΛCCSD(T), CCD/DCD, quasi-variational (QV/OQV), EOM, FCI and CIPHI.</li>
+                <li><strong>FCIDUMP mode</strong> to read integrals from a file, a generic <strong>macro</strong> step for any exported ElemCo.jl macro, and <strong>Julia syntax highlighting</strong> in the editors.</li>
+            </ul>
+        </div>
+
+        <div class="news-card">
             <p class="news-date">May 2026 &middot; v1.4.0</p>
             <h3>Semiempirical xtb / g-xTB &amp; Interactive Atom Selection</h3>
             <ul>


### PR DESCRIPTION
Updates the website for the **v1.5.0** release.

- **`help/elemco.html`** — rewrote the ElemCo.jl integration's "Input Generation" section to describe the current builder: ordered building-block steps, the searchable options browser (defaults + hover descriptions, only-changed values written), composable method selection with the spin selector and expanded method list (ΛCCSD(T), CCD/DCD, QV/OQV, EOM, FCI, CIPHI), **FCIDUMP** mode, the generic **Macro** step, and Julia syntax highlighting. Updated the settings note to per-mode default methods.
- **`news.html`** — added a v1.5.0 news card ("ElemCo.jl Input Builder") at the top; historical release entries left unchanged.
- **`index.html`** — added a v1.5.0 "What's New" card and dropped the oldest (v1.3.0) so the section keeps three current cards.

Content-only; HTML tag balance verified. Merge, then deploy the site as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)