### PR TITLE
CI: bump checkout/setup-node to v7 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
     
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # Pin the minimum where require() of an ESM module is unflagged.
           # electron-builder's @noble/hashes v2 is ESM-only and is require()-d,


### PR DESCRIPTION
Silences the GitHub Actions deprecation warning seen in the v1.5.0 release build:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3, actions/setup-node@v4

- `actions/checkout@v3` → `@v7`
- `actions/setup-node@v4` → `@v7`

Verified both `v7.0.0` are stable releases whose `action.yml` uses `node24`. The build still installs **Node 22.12.0** via the unchanged `node-version` input (needed for electron-builder's `require()` of ESM `@noble/hashes` v2).

Non-blocking cleanup; takes effect for the next tag-triggered release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)