### PR TITLE
Fix ElemCo input overlay clamping long option lines off-screen

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -935,9 +935,10 @@
             border: 1px solid #ccc;
             border-radius: 4px;
             box-sizing: border-box;
-            overflow-x: hidden;
-            word-wrap: break-word;
-            white-space: pre-wrap;
+            /* No overflow-x:hidden / white-space:pre-wrap / word-wrap here: this
+               textarea is wrapped by the Julia highlight overlay (.elemco-code-input),
+               which needs white-space:pre + overflow:auto to scroll horizontally.
+               Those legacy declarations wrapped/clipped the long option line. */
         }
 
         .preview-note {
@@ -1836,6 +1837,15 @@
             color: #333;
         }
         .elemco-code-highlights {
+            /* Size to the widest line (not the container) so the scrollbar
+               compensation padding added in elcWireHighlight actually extends
+               the backdrop's scroll width. As a plain block it clamped to the
+               container width and absorbed the padding, so when the textarea
+               grew a vertical scrollbar (shrinking its client width) the overlay
+               could not scroll as far right as the caret and the last options
+               were hidden. */
+            width: max-content;
+            min-width: 100%;
             min-height: 100%;
         }
         .elemco-code-highlights .j-com { color: #8c8c8c; font-style: italic; }


### PR DESCRIPTION
## Problem

In the ElemCo.jl **Generated input** field, when an option line is very long, the last options scroll off the right edge and you can't reach them — the horizontal scroll of the colored text stops short of the caret. There's also apparent vertical drift of the highlighting/cursor in that state.

## Root cause

The field is a transparent `<textarea>` layered over a colored syntax-highlight backdrop (`.elemco-code-backdrop` / `.elemco-code-highlights`), kept in sync by copying `scrollLeft`/`scrollTop`. When the input is tall enough to grow a **vertical scrollbar**, the textarea's client width shrinks by the scrollbar width (~15px on Linux/Electron classic scrollbars), so the textarea scrolls ~15px further right than the backdrop can. The caret reaches the last options but the colored overlay clamps short and hides them.

`elcWireHighlight` already tries to compensate with `paddingRight` on the highlights, but it was **inert**: `.elemco-code-highlights` was a plain block clamped to the container width, so the right padding was absorbed instead of extending the scroll width. (`paddingBottom` worked because block height is content-driven — which is why vertical scroll already matched.)

## Fix (`css/styles.css`)

- Size `.elemco-code-highlights` to the widest line (`width: max-content; min-width: 100%`) so the existing padding compensation actually extends the backdrop's horizontal scroll range to match the textarea. No JS change needed.
- Remove three inert-but-dangerous legacy declarations from `#elemco-input` (`overflow-x: hidden`, `word-wrap: break-word`, `white-space: pre-wrap`). They were overridden by the higher-specificity `.elemco-code-input` overlay rules, but described the exact broken behavior and would re-break the field on any future specificity change.

## Verification

Measured the real geometry in headless Chromium with classic scrollbars forced (as on Linux/Electron), loading the **actual edited `styles.css` + `elemco-highlight.js`**:

| case | before | after |
|------|--------|-------|
| single long line | HGAP 0 | HGAP 0 |
| long line + few lines | HGAP 0 | HGAP 0 |
| long line + many lines (vertical scrollbar) | **HGAP 15** | **HGAP 0** |

Horizontal and vertical scroll-sync gaps are 0 across all cases. A screenshot at full-right scroll confirms the last option renders in color, aligned, up to the scrollbar. Applies to the per-step Julia editors too (same class); the XYZ editor is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)