### PR TITLE
Fix highlight-overlay scroll drift and invisible H-atom halo (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-07-20
+
+### Fixed
+
+- Julia syntax highlighting in the ElemCo.jl input and custom-code editors no longer drifts out of alignment with the text when scrolled to the very bottom or right. The highlight layer now tracks the textarea with a transform (which is never clamped) instead of a scroll position that clamped short of the textarea's own range at the extremes.
+- The XYZ text editor's selected-atom highlight band had the same drift at the scroll extremes and is fixed the same way.
+- Selected atoms are now clearly highlighted regardless of element. The 3D selection halo uses an explicit, high-contrast color derived from the viewer background (a warm gold) instead of inheriting each atom's element color — previously a selected hydrogen got a white halo that was invisible on the white background. The halo re-derives its color if the background is changed.
+
 ## [1.5.0] - 2026-07-19
 
 ### Added

--- a/js/elemco-highlight.js
+++ b/js/elemco-highlight.js
@@ -28,32 +28,21 @@ function elcHighlightJulia(code) {
     return out;
 }
 
-// Native scrollbar thickness (0 on overlay-scrollbar platforms). Measured once.
-let _elcScrollbarSize = null;
-function elcScrollbarSize() {
-    if (_elcScrollbarSize != null) return _elcScrollbarSize;
-    _elcScrollbarSize = 0;
-    try {
-        const d = document.createElement('div');
-        d.style.cssText = 'position:absolute;top:-9999px;left:-9999px;width:100px;height:100px;overflow:scroll;';
-        document.body.appendChild(d);
-        _elcScrollbarSize = d.offsetWidth - d.clientWidth;
-        document.body.removeChild(d);
-    } catch (e) { _elcScrollbarSize = 0; }
-    return _elcScrollbarSize;
-}
-
 // Wire a textarea + its backdrop/highlights so the overlay tracks edits & scroll.
 // Exposes ta._elcHighlight() to refresh after programmatic value changes.
 function elcWireHighlight(ta, backdrop, highlights) {
-    // A textarea's scrollbars reserve space and shrink its client area, so it can
-    // scroll further than the (scrollbar-less) backdrop — at the very bottom/right
-    // the overlay would clamp short and the last line drifts. Pad the highlights by
-    // the scrollbar thickness so both scroll ranges match exactly.
-    const sb = elcScrollbarSize();
-    if (sb > 0) { highlights.style.paddingBottom = sb + 'px'; highlights.style.paddingRight = sb + 'px'; }
     const refresh = () => { highlights.innerHTML = elcHighlightJulia(ta.value || ''); };
-    const sync = () => { backdrop.scrollTop = ta.scrollTop; backdrop.scrollLeft = ta.scrollLeft; };
+    // Mirror the textarea's scroll onto the highlight layer with a transform rather
+    // than the backdrop's own scrollTop/scrollLeft. Setting scrollTop clamps to the
+    // element's own scroll range, and a textarea's scrollbars shrink its client area
+    // so it can scroll a hair further than the scrollbar-less backdrop: at the very
+    // bottom/right the clamped backdrop fell short, so the colored text (and the
+    // selection band drawn over it) drifted above the textarea's own text. A
+    // transform is never clamped, so the highlights track the textarea exactly at
+    // every scroll position, including the extremes.
+    const sync = () => {
+        highlights.style.transform = 'translate(' + (-ta.scrollLeft) + 'px, ' + (-ta.scrollTop) + 'px)';
+    };
     ta.addEventListener('input', () => { refresh(); sync(); });
     ta.addEventListener('scroll', sync);
     // After a programmatic value change (e.g. generating the input) the textarea's
@@ -66,6 +55,7 @@ function elcWireHighlight(ta, backdrop, highlights) {
         setTimeout(sync, 0);
     };
     refresh();
+    sync();
 }
 
 // Build a fresh highlighted Julia editor. Returns { wrap, textarea }.

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -95,9 +95,13 @@ function updateBackgroundColor(color) {
         const jsmolColor = '[x' + color.replace('#', '') + ']';
         Jmol.script(jmolApplet0, `background ${jsmolColor}`);
         console.log('Applied background color:', color, '->', jsmolColor);
-        
+
         // Update the preference
         updatePreference('bgColor', color);
+
+        // The selection halo color is derived from the background, so keep any
+        // active selection visible against the new background.
+        if (typeof reapplyHaloColor === 'function') reapplyHaloColor();
     }
 }
 

--- a/js/selection.js
+++ b/js/selection.js
@@ -60,11 +60,13 @@ function haloColorForBackground(bgHex) {
     // WCAG relative luminance decides whether the background is light or dark.
     const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
     const Y = 0.2126 * lin(rgb.r) + 0.7152 * lin(rgb.g) + 0.0722 * lin(rgb.b);
-    // Warm gold halo: a fixed amber hue so the selection always reads as gold,
-    // with the lightness flipped to the far end from the background so it stays
-    // clearly visible (dark amber on light backgrounds, pale gold on dark ones).
-    const HALO_HUE = 48;   // degrees — gold/amber (pure yellow is 60)
-    const HALO_SAT = 0.55;
+    // Warm gold halo, leaning toward the Solarized-light cream (#FDF6E3, hue ~44):
+    // a fixed, softly-saturated amber hue so the selection always reads as a warm
+    // gold, with the lightness flipped to the far end from the background so it
+    // stays clearly visible (a soft dark gold on light backgrounds, a pale cream
+    // on dark ones).
+    const HALO_HUE = 45;   // degrees — warm gold (pure yellow is 60; Solarized base3 ~44)
+    const HALO_SAT = 0.40;
     const l = Y > 0.5 ? 0.32 : 0.82;
     const out = elcHslToRgb(HALO_HUE, HALO_SAT, l);
     return '[x' + elcRgbToHex(out.r, out.g, out.b) + ']';

--- a/js/selection.js
+++ b/js/selection.js
@@ -25,10 +25,9 @@ function refreshEditHighlightsIfVisible() {
 // ===== Selection halo color =====
 // The 3D halo has no color of its own, so Jmol falls back to each atom's CPK
 // element color — white for hydrogen, which is invisible on the default white
-// background. Derive an explicit halo color from the current background instead:
-// keep the background's hue/saturation but flip to the opposite lightness end so
-// the halo always contrasts (a neutral grey for a white/greyscale background),
-// staying visible without clashing.
+// background. Give the halo an explicit warm-gold color instead, with its
+// lightness flipped to the far end from the background luminance so it always
+// stays visible (a dark amber on light backgrounds, pale gold on dark ones).
 function elcHexToRgb(hex) {
     const m = /^#?([0-9a-f]{6})$/i.exec((hex || '').trim());
     if (!m) return null;
@@ -39,24 +38,6 @@ function elcHexToRgb(hex) {
 function elcRgbToHex(r, g, b) {
     const h = (v) => Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, '0');
     return h(r) + h(g) + h(b);
-}
-
-function elcRgbToHsl(r, g, b) {
-    r /= 255; g /= 255; b /= 255;
-    const max = Math.max(r, g, b), min = Math.min(r, g, b);
-    const l = (max + min) / 2;
-    const d = max - min;
-    let h = 0, s = 0;
-    if (d !== 0) {
-        s = d / (1 - Math.abs(2 * l - 1));
-        switch (max) {
-            case r: h = (((g - b) / d) % 6 + 6) % 6; break;
-            case g: h = (b - r) / d + 2; break;
-            default: h = (r - g) / d + 4; break;
-        }
-        h *= 60;
-    }
-    return { h, s, l };
 }
 
 function elcHslToRgb(h, s, l) {
@@ -79,11 +60,13 @@ function haloColorForBackground(bgHex) {
     // WCAG relative luminance decides whether the background is light or dark.
     const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
     const Y = 0.2126 * lin(rgb.r) + 0.7152 * lin(rgb.g) + 0.0722 * lin(rgb.b);
-    const hsl = elcRgbToHsl(rgb.r, rgb.g, rgb.b);
-    // Flip to the far lightness end for a strong, guaranteed contrast; keep the
-    // background hue/saturation so the halo reads as a related, tasteful tone.
-    const l = Y > 0.5 ? 0.30 : 0.82;
-    const out = elcHslToRgb(hsl.h, hsl.s, l);
+    // Warm gold halo: a fixed amber hue so the selection always reads as gold,
+    // with the lightness flipped to the far end from the background so it stays
+    // clearly visible (dark amber on light backgrounds, pale gold on dark ones).
+    const HALO_HUE = 48;   // degrees — gold/amber (pure yellow is 60)
+    const HALO_SAT = 0.55;
+    const l = Y > 0.5 ? 0.32 : 0.82;
+    const out = elcHslToRgb(HALO_HUE, HALO_SAT, l);
     return '[x' + elcRgbToHex(out.r, out.g, out.b) + ']';
 }
 

--- a/js/selection.js
+++ b/js/selection.js
@@ -22,6 +22,81 @@ function refreshEditHighlightsIfVisible() {
     }
 }
 
+// ===== Selection halo color =====
+// The 3D halo has no color of its own, so Jmol falls back to each atom's CPK
+// element color — white for hydrogen, which is invisible on the default white
+// background. Derive an explicit halo color from the current background instead:
+// keep the background's hue/saturation but flip to the opposite lightness end so
+// the halo always contrasts (a neutral grey for a white/greyscale background),
+// staying visible without clashing.
+function elcHexToRgb(hex) {
+    const m = /^#?([0-9a-f]{6})$/i.exec((hex || '').trim());
+    if (!m) return null;
+    const n = parseInt(m[1], 16);
+    return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function elcRgbToHex(r, g, b) {
+    const h = (v) => Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, '0');
+    return h(r) + h(g) + h(b);
+}
+
+function elcRgbToHsl(r, g, b) {
+    r /= 255; g /= 255; b /= 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    const d = max - min;
+    let h = 0, s = 0;
+    if (d !== 0) {
+        s = d / (1 - Math.abs(2 * l - 1));
+        switch (max) {
+            case r: h = (((g - b) / d) % 6 + 6) % 6; break;
+            case g: h = (b - r) / d + 2; break;
+            default: h = (r - g) / d + 4; break;
+        }
+        h *= 60;
+    }
+    return { h, s, l };
+}
+
+function elcHslToRgb(h, s, l) {
+    const c = (1 - Math.abs(2 * l - 1)) * s;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = l - c / 2;
+    let r = 0, g = 0, b = 0;
+    if (h < 60) { r = c; g = x; }
+    else if (h < 120) { r = x; g = c; }
+    else if (h < 180) { g = c; b = x; }
+    else if (h < 240) { g = x; b = c; }
+    else if (h < 300) { r = x; b = c; }
+    else { r = c; b = x; }
+    return { r: (r + m) * 255, g: (g + m) * 255, b: (b + m) * 255 };
+}
+
+// Jmol color literal ([xRRGGBB]) for the halo, given a background hex color.
+function haloColorForBackground(bgHex) {
+    const rgb = elcHexToRgb(bgHex) || { r: 255, g: 255, b: 255 };
+    // WCAG relative luminance decides whether the background is light or dark.
+    const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
+    const Y = 0.2126 * lin(rgb.r) + 0.7152 * lin(rgb.g) + 0.0722 * lin(rgb.b);
+    const hsl = elcRgbToHsl(rgb.r, rgb.g, rgb.b);
+    // Flip to the far lightness end for a strong, guaranteed contrast; keep the
+    // background hue/saturation so the halo reads as a related, tasteful tone.
+    const l = Y > 0.5 ? 0.30 : 0.82;
+    const out = elcHslToRgb(hsl.h, hsl.s, l);
+    return '[x' + elcRgbToHex(out.r, out.g, out.b) + ']';
+}
+
+// Current halo color, derived from the user's background-color preference.
+function currentHaloColor() {
+    let bg = '#FFFFFF';
+    try {
+        const prefs = (typeof getPreferences === 'function') ? getPreferences() : null;
+        if (prefs && prefs.bgColor) bg = prefs.bgColor;
+    } catch (e) { /* fall back to white */ }
+    return haloColorForBackground(bg);
+}
+
 // Turn the 3D halo on/off for a single atom (atomIndex is 0-based).
 // Always restores the full selection afterwards: halo flags persist
 // independently of the selection set, and leaving a partial selection
@@ -29,7 +104,11 @@ function refreshEditHighlightsIfVisible() {
 // (xtb, ElemCo), which only export the currently selected atoms.
 function applyHaloForAtom(atomIndex, on) {
     try {
-        Jmol.script(jmolApplet0, `select atomno=${atomIndex + 1}; halos ${on ? 'on' : 'off'}; select all`);
+        const sel = `select atomno=${atomIndex + 1};`;
+        const cmd = on
+            ? `${sel} color halos ${currentHaloColor()}; halos on; select all`
+            : `${sel} halos off; select all`;
+        Jmol.script(jmolApplet0, cmd);
     } catch (e) {
         console.error('Error updating halo for atom', atomIndex, e);
     }
@@ -80,12 +159,25 @@ function reapplySelectionToRows() {
     if (selectedAtoms.size > 0) {
         const list = Array.from(selectedAtoms).map(i => 'atomno=' + (i + 1)).join(' or ');
         try {
-            Jmol.script(jmolApplet0, `select ${list}; halos on; select all`);
+            Jmol.script(jmolApplet0, `select ${list}; color halos ${currentHaloColor()}; halos on; select all`);
         } catch (e) {
             console.error('Error re-applying halos:', e);
         }
     }
     updateSelectionUI();
+}
+
+// Re-tint the halos of the current selection — e.g. after the viewer background
+// color changed, so the derived halo color stays visible. No-op when nothing is
+// selected.
+function reapplyHaloColor() {
+    if (selectedAtoms.size === 0) return;
+    const list = Array.from(selectedAtoms).map(i => 'atomno=' + (i + 1)).join(' or ');
+    try {
+        Jmol.script(jmolApplet0, `select ${list}; color halos ${currentHaloColor()}; select all`);
+    } catch (e) {
+        console.error('Error recoloring halos:', e);
+    }
 }
 
 // Selected atom numbers as sorted 1-based indices (for ElemCo / external use).

--- a/js/xyz-editor.js
+++ b/js/xyz-editor.js
@@ -154,6 +154,16 @@ function escapeHtmlForHighlight(s) {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+// Mirror the textarea's scroll onto the highlight layer with a transform. Setting
+// the backdrop's own scrollTop clamps to its scroll range, and a textarea's
+// scrollbars shrink its client area so it can scroll a hair further than the
+// scrollbar-less backdrop — at the very bottom/right the clamped band drifted
+// above its line. A transform is never clamped, so it tracks the textarea exactly.
+function syncXYZEditScroll(textarea, highlights) {
+    highlights.style.transform =
+        'translate(' + (-textarea.scrollLeft) + 'px, ' + (-textarea.scrollTop) + 'px)';
+}
+
 // Re-draw the edit-mode highlight overlay: tint the textarea lines that belong
 // to currently selected atoms. Atom i (0-based) lives on text line i + 2
 // (line 0 = atom count, line 1 = comment).
@@ -171,8 +181,7 @@ function renderXYZEditHighlights() {
     }).join('\n');
 
     // Keep the overlay scroll-aligned with the textarea.
-    backdrop.scrollTop = textarea.scrollTop;
-    backdrop.scrollLeft = textarea.scrollLeft;
+    syncXYZEditScroll(textarea, highlights);
 }
 
 // Attach the textarea listeners that keep the highlight overlay in sync. Runs
@@ -183,13 +192,10 @@ function initXYZEditHighlights() {
     if (!textarea || textarea.dataset.hlInit) return;
     textarea.dataset.hlInit = '1';
 
-    const backdrop = document.getElementById('xyz-edit-backdrop');
+    const highlights = document.getElementById('xyz-edit-highlights');
     textarea.addEventListener('input', renderXYZEditHighlights);
     textarea.addEventListener('scroll', function() {
-        if (backdrop) {
-            backdrop.scrollTop = textarea.scrollTop;
-            backdrop.scrollLeft = textarea.scrollLeft;
-        }
+        if (highlights) syncXYZEditScroll(textarea, highlights);
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jlmol",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "jlmol - A Molecular Viewer Desktop App",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Bugfix release **v1.5.1**. Three small rendering fixes to the editors and the 3D selection halo.

## Fixes

### Syntax-highlight overlay drift at the scroll extremes
The ElemCo.jl input/custom-code editors and the XYZ text editor overlay a transparent `<textarea>` on a highlighted backdrop, kept in sync via scroll. The backdrop was synced with `backdrop.scrollTop = ta.scrollTop`, but assigning `scrollTop` is **clamped** to the element's own scroll range. A textarea's scrollbars shrink its client area, so at the very bottom/right it can scroll a little further than the scrollbar-less backdrop — the backdrop clamped short and the colored text (and the selection band drawn over it) drifted above the caret.

Fixed by driving the highlight layer with `transform: translate(...)`, which is never clamped, so it tracks the textarea exactly at every scroll position. Removed the previous scrollbar-width padding workaround. Applied to both the ElemCo editors (`js/elemco-highlight.js`) and the XYZ editor (`js/xyz-editor.js`).

### White-on-white selection halo for hydrogen
The 3D selection halo had no explicit color, so Jmol inherited each atom's CPK element color. Hydrogen is white, so a selected H got a white halo on the (default) white background — invisible.

Fixed by giving the halo an explicit color **derived from the current background**: a warm gold whose lightness is flipped away from the background luminance so it always stays visible (a soft dark gold on light backgrounds, a pale cream near Solarized `#FDF6E3` on dark ones). The color is re-derived live when the background is changed in Preferences (`js/selection.js`, `js/preferences.js`).

## Release
- Bumped `package.json` to **1.5.1** and added the dated `[1.5.1]` section to `CHANGELOG.md`.
- `npm run check-version` passes (version is centralized; nothing hardcodes it).
- Per the release process, tagging `v1.5.1` on `main` (which triggers the draft build) is a **separate step after this merges** — not included here.

## Verification
- All changed JS files pass `node --check`.
- The scroll-clamp mechanism was reproduced and measured in headless Chromium (textarea max scroll exceeded the backdrop's by the scrollbar width → clamp gap; transform residual = 0).
- Halo colors and their WCAG contrast were verified numerically across white/black/light/dark backgrounds (white → `#726231`, ~6:1).

Not driven in the full Electron app here, so a quick manual check on the desktop app is worthwhile: scroll an ElemCo input to the very bottom and select text; and select a hydrogen atom on the white background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)